### PR TITLE
fix: allow pnpm git dep prepare scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,11 @@
     "keeper",
     "liquidation",
     "defi"
-  ]
+  ],
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@percolator/sdk",
+      "@percolator/shared"
+    ]
+  }
 }


### PR DESCRIPTION
Fixes CI failure: ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED

pnpm 10 blocks prepare scripts for git-hosted dependencies by default. This adds `@percolator/sdk` and `@percolator/shared` to `pnpm.onlyBuiltDependencies` to allow their TypeScript compilation during install.