### PR TITLE
fix: use lastEffectivePriceE6 for Pyth-pinned markets in liquidation scanner

### DIFF
--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -152,7 +152,7 @@ describe('LiquidationService', () => {
           collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
           oracleAuthority: { toBase58: () => 'Oracle11111111111111111111111111111111' },
           indexFeedId: { toBytes: () => new Uint8Array(32) },
-          authorityPriceE6: 1_000_000n,
+          oracleAuthority: { equals: () => false } as any, authorityPriceE6: 1_000_000n, lastEffectivePriceE6: 1_000_000n,
           authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
         },
         params: {
@@ -176,7 +176,7 @@ describe('LiquidationService', () => {
         maintenanceMarginBps: 500n,
       } as any);
       vi.mocked(core.parseConfig).mockReturnValue({
-        authorityPriceE6: 1_000_000n,
+        oracleAuthority: { equals: () => false } as any, authorityPriceE6: 1_000_000n, lastEffectivePriceE6: 1_000_000n,
         authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
       } as any);
       vi.mocked(core.detectLayout).mockReturnValue({ accountsOffset: 0 } as any);
@@ -207,7 +207,7 @@ describe('LiquidationService', () => {
           collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
           oracleAuthority: { toBase58: () => 'Oracle11111111111111111111111111111111' },
           indexFeedId: { toBytes: () => new Uint8Array(32) },
-          authorityPriceE6: 1_000_000n,
+          oracleAuthority: { equals: () => false } as any, authorityPriceE6: 1_000_000n, lastEffectivePriceE6: 1_000_000n,
           authorityTimestamp: BigInt(Math.floor(Date.now() / 1000) - 120), // 2 minutes old
         },
         params: { maintenanceMarginBps: 500n },
@@ -224,7 +224,7 @@ describe('LiquidationService', () => {
         maintenanceMarginBps: 500n,
       } as any);
       vi.mocked(core.parseConfig).mockReturnValue({
-        authorityPriceE6: 1_000_000n,
+        oracleAuthority: { equals: () => false } as any, authorityPriceE6: 1_000_000n, lastEffectivePriceE6: 1_000_000n,
         authorityTimestamp: BigInt(Math.floor(Date.now() / 1000) - 120), // 2 minutes old (>60s)
       } as any);
       vi.mocked(core.detectLayout).mockReturnValue({ accountsOffset: 0 } as any);
@@ -262,7 +262,7 @@ describe('LiquidationService', () => {
       vi.mocked(core.parseEngine).mockReturnValue({} as any);
       vi.mocked(core.parseParams).mockReturnValue({ maintenanceMarginBps: 500n } as any);
       vi.mocked(core.parseConfig).mockReturnValue({
-        authorityPriceE6: 1_000_000n,
+        oracleAuthority: { equals: () => false } as any, authorityPriceE6: 1_000_000n, lastEffectivePriceE6: 1_000_000n,
         authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
       } as any);
       vi.mocked(core.parseUsedIndices).mockReturnValue([0]);
@@ -308,7 +308,7 @@ describe('LiquidationService', () => {
       vi.mocked(core.parseEngine).mockReturnValue({} as any);
       vi.mocked(core.parseParams).mockReturnValue({ maintenanceMarginBps: 500n } as any);
       vi.mocked(core.parseConfig).mockReturnValue({
-        authorityPriceE6: 1_000_000n,
+        oracleAuthority: { equals: () => false } as any, authorityPriceE6: 1_000_000n, lastEffectivePriceE6: 1_000_000n,
         authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
       } as any);
       vi.mocked(core.parseUsedIndices).mockReturnValue([0]);


### PR DESCRIPTION
## Problem

Keeper's liquidation scanner was skipping ALL Pyth-pinned markets because:
- `authorityTimestamp` is `0` for these markets (no authority push)
- Staleness check: `priceAge = now - 0 = ~1.77 billion seconds` → always stale
- **Result: zero liquidations running for Pyth-pinned markets**

## Root Cause

Pyth-pinned markets (`oracle_authority == [0;32]`) get their price via on-chain Pyth CPI, not authority push. The authority fields (`authorityPriceE6`, `authorityTimestamp`) are never written.

## Fix

- Detect Pyth-pinned markets by checking `oracleAuthority.equals(PublicKey([0;32]))`
- Use `lastEffectivePriceE6` (the on-chain resolved price) instead of `authorityPriceE6`
- Skip the off-chain staleness check for Pyth markets (staleness is enforced on-chain during Pyth CPI)

## Testing

- All 36 existing tests pass
- Updated test mocks to include `oracleAuthority` and `lastEffectivePriceE6`

## Severity

🔴 **CRITICAL** — no liquidations were running for Pyth-pinned markets