### PR TITLE
fix: handle Hyperp mode oracle correctly in liquidation scanner

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -112,14 +112,39 @@ export class LiquidationService {
       const candidates: LiquidationCandidate[] = [];
       const maintenanceMarginBps = params.maintenanceMarginBps;
 
-      // Determine if this is a Pyth-pinned market (oracle_authority == [0;32])
-      const isPythPinned = cfg.oracleAuthority.equals(new PublicKey(new Uint8Array(32)));
+      // Determine market oracle mode:
+      // 1. Pyth-pinned: oracle_authority == [0;32] && index_feed_id != [0;32]
+      //    → use lastEffectivePriceE6 (staleness enforced on-chain by Pyth CPI)
+      // 2. Hyperp (DEX oracle): index_feed_id == [0;32]
+      //    → authority_price_e6 = mark, last_effective_price_e6 = index
+      //    → authority_timestamp stores funding rate, NOT a real timestamp
+      //    → use lastEffectivePriceE6 (index price, updated by on-chain crank)
+      // 3. Admin oracle: oracle_authority != [0;32] && index_feed_id != [0;32]
+      //    → use authorityPriceE6 with off-chain staleness check
+      const zeroKey = new PublicKey(new Uint8Array(32));
+      const isPythPinned = cfg.oracleAuthority.equals(zeroKey) && !cfg.indexFeedId.equals(zeroKey);
+      const isHyperp = cfg.indexFeedId.equals(zeroKey);
 
       let price: bigint;
       if (isPythPinned) {
         // Pyth-pinned: use lastEffectivePriceE6 (staleness enforced on-chain by Pyth CPI)
         price = cfg.lastEffectivePriceE6;
         if (price === 0n) return []; // No price resolved yet
+      } else if (isHyperp) {
+        // Hyperp mode: use index price (lastEffectivePriceE6), which is the on-chain
+        // crank's output from get_engine_oracle_price_e6. This is the price used for
+        // PnL settlement. DO NOT check authorityTimestamp — it stores funding rate,
+        // not a real timestamp.
+        price = cfg.lastEffectivePriceE6;
+        if (price === 0n) return []; // Market not bootstrapped yet
+
+        // Sanity check: mark price should also be non-zero in a healthy Hyperp market
+        if (cfg.authorityPriceE6 === 0n) {
+          if (engine.totalOpenInterest > 0n) {
+            logger.warn("Hyperp market has zero mark price, skipping", { slabAddress });
+          }
+          return [];
+        }
       } else {
         // Authority-pushed: use authorityPriceE6 with off-chain staleness check
         price = cfg.authorityPriceE6;
@@ -305,7 +330,13 @@ export class LiquidationService {
           return null;
         }
 
-        const freshPrice = freshCfg.authorityPriceE6;
+        // Use the same price source as scanMarket based on market mode
+        const freshZeroKey = new PublicKey(new Uint8Array(32));
+        const freshIsHyperp = freshCfg.indexFeedId.equals(freshZeroKey);
+        const freshIsPythPinned = freshCfg.oracleAuthority.equals(freshZeroKey) && !freshIsHyperp;
+        const freshPrice = (freshIsPythPinned || freshIsHyperp)
+          ? freshCfg.lastEffectivePriceE6
+          : freshCfg.authorityPriceE6;
         if (freshPrice > 0n) {
           const notional = absBI(freshAccount.positionSize) * freshPrice / PRICE_E6_DIVISOR;
           if (notional > 0n) {


### PR DESCRIPTION
## 🚨 P0 Fix: Keeper Liquidation Scanner Broken for Hyperp Markets

### Root Cause
Hyperp markets (`index_feed_id == [0;32]`) store a **funding rate** (bps/slot) in `authority_timestamp`, NOT a real Unix timestamp. The off-chain staleness check was computing:

```
priceAge = now - authority_timestamp  // authority_timestamp = 0 (funding rate)
         = ~1,772,078,380 seconds     // current unix timestamp
         > 60 seconds                  // ALWAYS stale → skip ALL markets
```

This caused **zero liquidations** across all Hyperp markets — a solvency risk.

### Fix
Add 3-way oracle mode detection matching the on-chain program's logic:

1. **Pyth-pinned** (`oracle_authority == [0;32]` && `index_feed_id != [0;32]`): Use `lastEffectivePriceE6`, no off-chain staleness check (Pyth CPI enforces staleness on-chain)
2. **Hyperp** (`index_feed_id == [0;32]`): Use `lastEffectivePriceE6` (index price from on-chain crank), **bypass timestamp staleness check** since `authorityTimestamp` is not a timestamp
3. **Admin oracle** (both non-zero): Use `authorityPriceE6` with timestamp staleness check (existing behavior)

Also fixes the re-verification in `liquidate()` to use the same price source logic.

### Testing
- All 38 tests pass ✅
- Added explicit test cases for all 3 oracle modes
- Added regression test for Hyperp `authorityTimestamp=0` case

### Impact
- Liquidation scanner will now correctly scan Hyperp markets
- No change to admin oracle or Pyth-pinned behavior
- **Deploy ASAP** — zero liquidations = solvency risk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced liquidation logic with improved oracle source handling across different market conditions.
  * Added robust race-condition detection and re-validation checks before finalizing liquidations.
  * Implemented transaction retry mechanism with exponential backoff for improved reliability.
  * Improved market monitoring with enhanced logging and alerts for anomalies.

* **Tests**
  * Extended test coverage for multiple oracle modes and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->