### PR TITLE
fix(oracle): remove on-chain price fallback to prevent feedback loop

### DIFF
--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -273,17 +273,19 @@ export class OracleService {
     const mint = marketConfig.collateralMint.toBase58();
     let priceEntry = await this.fetchPrice(mint, slabAddress);
 
-    // Fallback for devnet test tokens with no external price source:
-    // use the last on-chain authority price, or default to 1.0
+    // No external price available — do NOT fall back to on-chain authorityPriceE6.
+    // Using the on-chain price as a fallback creates a feedback loop: if the
+    // on-chain price is corrupted (e.g. $13.3 quadrillion), the keeper would
+    // re-push the corrupted value indefinitely. Instead, skip the push and let
+    // the oracle-keeper.ts script (which fetches from Binance/CoinGecko/Jupiter)
+    // be the authoritative price source for devnet markets.
     if (!priceEntry) {
-      const onChainPrice = marketConfig.authorityPriceE6;
-      if (onChainPrice > 0n) {
-        priceEntry = { priceE6: onChainPrice, source: "on-chain", timestamp: Date.now() };
-        logger.info("Using on-chain price", { mint, onChainPrice: onChainPrice.toString() });
-      } else {
-        logger.warn("No price source available", { mint });
-        return false; // Don't push a guessed price
-      }
+      logger.warn("No price source available — skipping push (on-chain fallback disabled)", {
+        mint,
+        slabAddress,
+        onChainPrice: marketConfig.authorityPriceE6.toString(),
+      });
+      return false;
     }
 
     try {

--- a/tests/services/oracle.test.ts
+++ b/tests/services/oracle.test.ts
@@ -489,6 +489,28 @@ describe('OracleService', () => {
     });
   });
 
+  describe('on-chain fallback disabled', () => {
+    it('should NOT use on-chain authorityPriceE6 when external sources fail', async () => {
+      // Simulate all external sources returning null
+      vi.mocked(fetch).mockResolvedValue({
+        json: async () => ({ pairs: [] }), // DexScreener returns no pairs
+      } as any);
+
+      const mockMarketConfig: any = {
+        collateralMint: new PublicKey('So11111111111111111111111111111111111111112'),
+        oracleAuthority: new PublicKey('11111111111111111111111111111111'),
+        // On-chain price is absurdly high (the bug scenario: $13.3 quadrillion)
+        authorityPriceE6: 13_300_000_000_000_000_000_000n,
+      };
+
+      const slab = 'SLAB_NO_ONCHAIN_FALLBACK';
+
+      // pushPrice should return false (skip) instead of pushing the corrupted on-chain value
+      const result = await oracleService.pushPrice(slab, mockMarketConfig);
+      expect(result).toBe(false);
+    });
+  });
+
   describe('getCurrentPrice', () => {
     it('should return latest price from history', async () => {
       const mockResponse = {


### PR DESCRIPTION
## Problem

The BTC oracle was showing ~$13.3 quadrillion on devnet due to a corrupted on-chain price being re-pushed by the keeper in a feedback loop.

### Root Cause

When external price sources (DexScreener/Jupiter) return null for devnet test tokens, the keeper fell back to reading `marketConfig.authorityPriceE6` from the on-chain slab data. If this value was already corrupted, the keeper would re-push it, creating an infinite corruption loop.

## Fix

- **Removed** the on-chain `authorityPriceE6` fallback in `OracleService.pushPrice()`
- When no external price source is available, the push is skipped entirely
- The `oracle-keeper.ts` script (Binance → CoinGecko → Jupiter failover) is the authoritative price source for devnet markets
- Added regression test validating the fallback is disabled

## Manual Fix Applied

Pushed correct BTC price ($87,000 = 87000000000 in e6) via `PushOraclePrice` to slab `AB3ZN1vxbBEh8FZRfrL55QQUUaLCwawqvCYzTDpgbuLF`:
```
TX: 3f1bzy37DYLtBQrpKWMfWr1uQh4tLBoc9xxHeLLP4YAWEc5ywYHJvJPdYgjKHQcRpANrxk57PsLwj5AryvptT4pW
```

## Testing

- All 40 tests pass (39 existing + 1 new regression test)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced oracle service to enforce stricter validation by removing fallback to on-chain prices when external sources are unavailable, preventing potential corrupted price feedback loops.

* **Tests**
  * Added test suite ensuring price operations correctly fail when all external price data sources are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->