### PR TITLE
fix(liquidation): skip uninitialised/corrupt markets + env-var blocklist (#838 #837)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -95,17 +95,54 @@ export class LiquidationService {
     this.intervalMs = intervalMs;
   }
 
+  // Markets to skip during liquidation scanning (comma-separated slab addresses in env)
+  private static readonly BLOCKED_MARKET_ADDRESSES: ReadonlySet<string> = new Set(
+    (process.env.BLOCKED_MARKET_ADDRESSES ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+
+  // Sentinel lastCrankSlot value used in corrupt/uninitialized test markets
+  private static readonly SENTINEL_CRANK_SLOT = 100_000_000n;
+
   /**
    * Scan a single market for undercollateralized accounts.
    */
   async scanMarket(market: DiscoveredMarket): Promise<LiquidationCandidate[]> {
     const slabAddress = market.slabAddress.toBase58();
 
+    // Skip explicitly blocklisted markets (e.g., wrong oracle_authority — issue #837)
+    if (LiquidationService.BLOCKED_MARKET_ADDRESSES.has(slabAddress)) {
+      logger.debug("Skipping blocklisted market", { slabAddress });
+      return [];
+    }
+
     try {
       const data = await fetchSlabWithRetry(market.slabAddress);
       const engine = parseEngine(data);
       const params = parseParams(data);
       const cfg = parseConfig(data);
+
+      // Guard: skip markets that were never properly InitMarket'd.
+      // maintenanceMarginBps === 0n is the canonical signal — a valid market always
+      // has a non-zero maintenance margin set during initialization.
+      // These corrupt/test markets (e.g. lastCrankSlot=100_000_000 sentinel) trigger
+      // custom program error 0x4 (InvalidArgument) on every crank attempt. (issue #838)
+      if (params.maintenanceMarginBps === 0n) {
+        logger.debug("Skipping uninitialised market (maintenanceMarginBps=0)", { slabAddress });
+        return [];
+      }
+
+      // Additional sentinel check: lastCrankSlot of exactly 100_000_000 is test data,
+      // not a real devnet slot, and indicates the market state was never cranked normally.
+      if (engine.lastCrankSlot === LiquidationService.SENTINEL_CRANK_SLOT) {
+        logger.warn("Skipping market with sentinel lastCrankSlot (corrupt state)", {
+          slabAddress,
+          lastCrankSlot: engine.lastCrankSlot.toString(),
+        });
+        return [];
+      }
       const layout = detectLayout(data.length);
       if (!layout) return [];
 

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -397,6 +397,101 @@ describe('LiquidationService', () => {
 
       expect(candidates).toHaveLength(1);
     });
+
+    it('should skip markets with maintenanceMarginBps=0 (uninitialized market — issue #838)', async () => {
+      const mockMarket = {
+        slabAddress: { toBase58: () => 'A35wGP21WCnpQuiHS3Ec3V8g22ikfmTfM2GHuq15uyfv' },
+        programId: { toBase58: () => 'FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD' },
+        config: {
+          collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+          oracleAuthority: mockNonZeroKey(),
+          indexFeedId: mockNonZeroKey(),
+        },
+      };
+
+      vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+      vi.mocked(core.parseEngine).mockReturnValue({
+        totalOpenInterest: 100_000_000n,
+        lastCrankSlot: 999n, // not the sentinel
+        numUsedAccounts: 1,
+        vault: 0n,
+      } as any);
+      // maintenanceMarginBps === 0n → uninitialized, should be skipped
+      vi.mocked(core.parseParams).mockReturnValue({ maintenanceMarginBps: 0n } as any);
+      vi.mocked(core.parseConfig).mockReturnValue({
+        oracleAuthority: mockNonZeroKey(),
+        indexFeedId: mockNonZeroKey(),
+        authorityPriceE6: 1_000_000n,
+        lastEffectivePriceE6: 1_000_000n,
+        authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
+      } as any);
+
+      const candidates = await liquidationService.scanMarket(mockMarket as any);
+      expect(candidates).toHaveLength(0);
+      // fetchSlab should be called but parseUsedIndices should NOT
+      expect(core.parseUsedIndices).not.toHaveBeenCalled();
+    });
+
+    it('should skip markets with sentinel lastCrankSlot=100_000_000 (corrupt test data — issue #838)', async () => {
+      const mockMarket = {
+        slabAddress: { toBase58: () => '8dJs5dSz9rUcP7f9NMaMEyvBgK3F7dbsPP3G9Sx7Gcwx' },
+        programId: { toBase58: () => 'FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD' },
+        config: {
+          collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+          oracleAuthority: mockNonZeroKey(),
+          indexFeedId: mockNonZeroKey(),
+        },
+      };
+
+      vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+      vi.mocked(core.parseEngine).mockReturnValue({
+        totalOpenInterest: 100_000_000n,
+        lastCrankSlot: 100_000_000n, // sentinel value
+        numUsedAccounts: 1,
+        vault: 0n,
+      } as any);
+      vi.mocked(core.parseParams).mockReturnValue({ maintenanceMarginBps: 500n } as any);
+
+      const candidates = await liquidationService.scanMarket(mockMarket as any);
+      expect(candidates).toHaveLength(0);
+    });
+
+    it('should skip markets in BLOCKED_MARKET_ADDRESSES env var (issue #837)', async () => {
+      const blockedAddr = 'HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT';
+      const origEnv = process.env.BLOCKED_MARKET_ADDRESSES;
+      process.env.BLOCKED_MARKET_ADDRESSES = blockedAddr;
+
+      // Re-import to pick up new env — we test via direct Set injection instead
+      // (static field is already initialised; test the guard by checking fetchSlab not called)
+      // Because the static Set is evaluated at module load time, we verify the logic
+      // by temporarily overriding the Set on the class.
+      const originalSet = (LiquidationService as any).BLOCKED_MARKET_ADDRESSES;
+      (LiquidationService as any).BLOCKED_MARKET_ADDRESSES = new Set([blockedAddr]);
+
+      const mockMarket = {
+        slabAddress: { toBase58: () => blockedAddr },
+        programId: { toBase58: () => 'FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD' },
+        config: {
+          collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+          oracleAuthority: mockNonZeroKey(),
+          indexFeedId: mockNonZeroKey(),
+        },
+      };
+
+      try {
+        const candidates = await liquidationService.scanMarket(mockMarket as any);
+        expect(candidates).toHaveLength(0);
+        // fetchSlab should NOT be called — blocklist check is before any RPC call
+        expect(core.fetchSlab).not.toHaveBeenCalled();
+      } finally {
+        (LiquidationService as any).BLOCKED_MARKET_ADDRESSES = originalSet;
+        if (origEnv === undefined) {
+          delete process.env.BLOCKED_MARKET_ADDRESSES;
+        } else {
+          process.env.BLOCKED_MARKET_ADDRESSES = origEnv;
+        }
+      }
+    });
   });
 
   describe('liquidate', () => {


### PR DESCRIPTION
## Summary

Fixes two related issues:

### Issue #838 — Keeper: Liquidation failing with custom program error 0x4

Markets `A35wGP21WCnpQuiHS3Ec3V8g22ikfmTfM2GHuq15uyfv` and `8dJs5dSz9rUcP7f9NMaMEyvBgK3F7dbsPP3G9Sx7Gcwx` have corrupt/sentinel state and were never `InitMarket`'d. The keeper was attempting to crank them every 60s and getting `custom program error: 0x4` each time.

**Two guards added to `scanMarket()`:**
1. `maintenanceMarginBps === 0n` → market never initialized → skip (most reliable signal)
2. `lastCrankSlot === 100_000_000n` → sentinel slot used in test data → skip with a warning

### Issue #837 — Wrong oracle_authority on HjBePQZ (also keeper-side fix)

Adds `BLOCKED_MARKET_ADDRESSES` env var (comma-separated slab addresses). Set this in Railway to exclude `HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT` from liquidation scanning without a code change.

## How to test

- Deploy to Railway keeper, confirm no more `0x4` errors in logs for these two markets
- Set `BLOCKED_MARKET_ADDRESSES=HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT` in keeper env

## Tests

43 pass (3 new unit tests added for the new guards)