### PR TITLE
feat(PERC-805): devnet token price discovery extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { config, createLogger, initSentry, captureException, sendInfoAlert, crea
 import { OracleService } from "./services/oracle.js";
 import { CrankService } from "./services/crank.js";
 import { LiquidationService } from "./services/liquidation.js";
+import { DevnetPriceResolver } from "./services/devnet-price-resolver.js";
 
 // Monitoring — alerts to Discord on threshold breaches
 export const monitors = createServiceMonitors("Keeper");
@@ -19,7 +20,9 @@ if (!config.crankKeypair) {
 
 logger.info("Keeper service starting");
 
+const devnetResolver = new DevnetPriceResolver();
 const oracleService = new OracleService();
+oracleService.setDevnetResolver(devnetResolver);
 const crankService = new CrankService(oracleService);
 const liquidationService = new LiquidationService(oracleService);
 
@@ -111,6 +114,10 @@ healthServer.listen(healthPort, () => {
 });
 
 async function start() {
+  // Start devnet resolver first so oracle fallbacks are warm before first crank
+  await devnetResolver.start();
+  logger.info("DevnetPriceResolver started");
+
   const markets = await crankService.discover();
   logger.info("Markets discovered", { count: markets.length });
   crankService.start();
@@ -155,6 +162,10 @@ async function shutdown(signal: string): Promise<void> {
     // Stop liquidation service (clears timers)
     logger.info("Stopping liquidation service");
     liquidationService.stop();
+
+    // Stop devnet resolver refresh timer
+    logger.info("Stopping devnet price resolver");
+    devnetResolver.stop();
     
     // Note: Solana connection doesn't need explicit cleanup
     // Oracle service has no persistent state to clean up

--- a/src/services/devnet-price-resolver.ts
+++ b/src/services/devnet-price-resolver.ts
@@ -1,0 +1,133 @@
+/**
+ * DevnetPriceResolver — Supabase-backed price fallback for devnet-only tokens.
+ *
+ * oracle-keeper's primary price sources (DexScreener + Jupiter) use the on-chain
+ * collateralMint address. For devnet-only tokens this fails at two levels:
+ *
+ *   Level 1 — devnet mirror: token was mirrored from mainnet but DexScreener
+ *     uses the mainnet CA. Fix: look up mainnet_ca in devnet_mints and retry.
+ *
+ *   Level 2 — pure devnet: token was created only on devnet, has no mainnet
+ *     equivalent, and therefore no DexScreener/Jupiter listing. Fix: return a
+ *     static price from devnet_price_overrides (admin-seeded table).
+ *
+ * Data is refreshed every REFRESH_INTERVAL_MS (default 5min) from Supabase.
+ * The cache is safe to query synchronously between refreshes.
+ */
+
+import { getSupabase, createLogger } from "@percolator/shared";
+
+const logger = createLogger("keeper:devnet-resolver");
+
+const REFRESH_INTERVAL_MS = 5 * 60 * 1_000; // 5 minutes
+const PRICE_E6_MULTIPLIER = 1_000_000n;
+
+export class DevnetPriceResolver {
+  /** devnet_mint → mainnet_ca */
+  private mainnetCaMap = new Map<string, string>();
+  /** devnet_mint → priceE6 (from devnet_price_overrides) */
+  private staticPriceMap = new Map<string, bigint>();
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private _initialized = false;
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+
+  /**
+   * Load initial data synchronously (awaited) then schedule background refresh.
+   * Call this before starting OracleService so the cache is warm on first push.
+   */
+  async start(): Promise<void> {
+    await this._refresh();
+    this._initialized = true;
+    this.timer = setInterval(() => {
+      this._refresh().catch((err) => {
+        logger.error("DevnetPriceResolver background refresh failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, REFRESH_INTERVAL_MS);
+    logger.info("DevnetPriceResolver started", {
+      mainnetCaEntries: this.mainnetCaMap.size,
+      staticPriceEntries: this.staticPriceMap.size,
+    });
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  get initialized(): boolean {
+    return this._initialized;
+  }
+
+  // ── Public API ───────────────────────────────────────────────────────────
+
+  /**
+   * Returns the mainnet CA for a devnet mint, or null if not found.
+   * Use this to retry DexScreener/Jupiter with the mainnet address.
+   */
+  getMainnetCa(devnetMint: string): string | null {
+    return this.mainnetCaMap.get(devnetMint) ?? null;
+  }
+
+  /**
+   * Returns the static priceE6 override for a devnet-only mint, or null.
+   * Only reached when all external price sources fail.
+   */
+  getStaticPrice(devnetMint: string): bigint | null {
+    return this.staticPriceMap.get(devnetMint) ?? null;
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────────
+
+  private async _refresh(): Promise<void> {
+    const supabase = getSupabase();
+
+    // Load devnet_mints: devnet_mint → mainnet_ca
+    const { data: mintRows, error: mintErr } = await supabase
+      .from("devnet_mints")
+      .select("devnet_mint, mainnet_ca");
+
+    if (mintErr) {
+      logger.warn("Failed to load devnet_mints", { error: mintErr.message });
+    } else if (mintRows) {
+      const newMap = new Map<string, string>();
+      for (const row of mintRows) {
+        if (row.devnet_mint && row.mainnet_ca) {
+          newMap.set(row.devnet_mint as string, row.mainnet_ca as string);
+        }
+      }
+      this.mainnetCaMap = newMap;
+    }
+
+    // Load devnet_price_overrides: devnet_mint → priceE6
+    const { data: overrideRows, error: overrideErr } = await supabase
+      .from("devnet_price_overrides")
+      .select("devnet_mint, price_usd");
+
+    if (overrideErr) {
+      // Table may not exist yet in older deployments — log and continue
+      logger.warn("Failed to load devnet_price_overrides (table may not exist yet)", {
+        error: overrideErr.message,
+      });
+    } else if (overrideRows) {
+      const newMap = new Map<string, bigint>();
+      for (const row of overrideRows) {
+        const priceUsd = Number(row.price_usd);
+        if (row.devnet_mint && isFinite(priceUsd) && priceUsd > 0) {
+          newMap.set(row.devnet_mint as string, BigInt(Math.round(priceUsd * Number(PRICE_E6_MULTIPLIER))));
+        }
+      }
+      this.staticPriceMap = newMap;
+    }
+
+    logger.debug("DevnetPriceResolver refreshed", {
+      mainnetCaEntries: this.mainnetCaMap.size,
+      staticPriceEntries: this.staticPriceMap.size,
+    });
+  }
+}

--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -7,6 +7,7 @@ import {
   type MarketConfig,
 } from "@percolator/sdk";
 import { config, getConnection, loadKeypair, sendWithRetry, eventBus, createLogger } from "@percolator/shared";
+import type { DevnetPriceResolver } from "./devnet-price-resolver.js";
 
 const logger = createLogger("keeper:oracle");
 
@@ -50,6 +51,13 @@ export class OracleService {
   private readonly maxTrackedMarkets = 500;
   // BM2: Deduplicate concurrent requests for the same mint
   private inFlightRequests = new Map<string, Promise<bigint | null>>();
+  // Optional devnet fallback resolver (set via setDevnetResolver after construction)
+  private devnetResolver: DevnetPriceResolver | null = null;
+
+  /** Attach a DevnetPriceResolver for mainnet_ca + static price fallbacks. */
+  setDevnetResolver(resolver: DevnetPriceResolver): void {
+    this.devnetResolver = resolver;
+  }
 
   /** Fetch price from DexScreener (with rate-limit cache) */
   async fetchDexScreenerPrice(mint: string): Promise<bigint | null> {
@@ -191,21 +199,84 @@ export class OracleService {
     }
 
     if (priceE6 === null) {
-      const history = this.priceHistory.get(slabAddress);
-      if (history && history.length > 0) {
-        const last = history[history.length - 1];
-        // Reject stale cached prices (>60s) to prevent bad liquidations
-        if (Date.now() - last.timestamp > CACHED_PRICE_MAX_AGE_MS) {
-          logger.warn("Cached price is stale", {
-            mint,
-            ageSeconds: Math.round((Date.now() - last.timestamp) / 1000),
-            maxAgeSeconds: CACHED_PRICE_MAX_AGE_MS / 1000
-          });
-          return null;
+      // ── Devnet fallback Layer 1: mainnet_ca reverse-lookup ───────────────
+      // Many devnet tokens are mirrors of mainnet tokens. DexScreener/Jupiter
+      // require the mainnet CA for price lookups — retry with it if available.
+      if (this.devnetResolver) {
+        const mainnetCa = this.devnetResolver.getMainnetCa(mint);
+        if (mainnetCa && mainnetCa !== mint) {
+          const [dex2, jup2] = await Promise.all([
+            this.fetchDexScreenerPrice(mainnetCa),
+            this.fetchJupiterPrice(mainnetCa),
+          ]);
+          // Cross-validate the mainnet-CA results using the same threshold
+          if (dex2 !== null && jup2 !== null && dex2 > 0n && jup2 > 0n) {
+            const larger2 = dex2 > jup2 ? dex2 : jup2;
+            const smaller2 = dex2 > jup2 ? jup2 : dex2;
+            const div2 = Number((larger2 - smaller2) * 100n / smaller2);
+            if (div2 <= MAX_CROSS_SOURCE_DEVIATION_PCT) {
+              priceE6 = dex2;
+              source = "dexscreener-mainnet-ca";
+            } else {
+              logger.warn("mainnet_ca cross-source divergence", {
+                mint,
+                mainnetCa,
+                divergencePct: div2,
+              });
+            }
+          } else if (dex2 !== null) {
+            priceE6 = dex2;
+            source = "dexscreener-mainnet-ca";
+          } else if (jup2 !== null) {
+            priceE6 = jup2;
+            source = "jupiter-mainnet-ca";
+          }
+
+          if (priceE6 !== null) {
+            logger.debug("Price resolved via mainnet_ca fallback", {
+              devnetMint: mint,
+              mainnetCa,
+              priceE6: priceE6.toString(),
+              source,
+            });
+          }
         }
-        return { ...last, source: "cached" };
       }
-      return null;
+
+      // ── Devnet fallback Layer 2: static price override ───────────────────
+      // Pure devnet-only tokens (no mainnet CA) can have a static price seeded
+      // by DevOps in the devnet_price_overrides Supabase table.
+      if (priceE6 === null && this.devnetResolver) {
+        const staticPrice = this.devnetResolver.getStaticPrice(mint);
+        if (staticPrice !== null) {
+          logger.debug("Price resolved via devnet static override", {
+            mint,
+            priceE6: staticPrice.toString(),
+          });
+          const entry: PriceEntry = { priceE6: staticPrice, source: "devnet-override", timestamp: Date.now() };
+          this.recordPrice(slabAddress, entry);
+          return entry;
+        }
+      }
+
+      // ── Cached price fallback ─────────────────────────────────────────────
+      if (priceE6 === null) {
+        const history = this.priceHistory.get(slabAddress);
+        if (history && history.length > 0) {
+          const last = history[history.length - 1];
+          // Reject stale cached prices (>60s) to prevent bad liquidations
+          if (Date.now() - last.timestamp > CACHED_PRICE_MAX_AGE_MS) {
+            logger.warn("Cached price is stale", {
+              mint,
+              ageSeconds: Math.round((Date.now() - last.timestamp) / 1000),
+              maxAgeSeconds: CACHED_PRICE_MAX_AGE_MS / 1000
+            });
+            return null;
+          }
+          return { ...last, source: "cached" };
+        }
+        return null;
+      }
     }
 
     // R2-S4: Historical deviation check — reject if >30% change from last known price

--- a/tests/services/devnet-price-resolver.test.ts
+++ b/tests/services/devnet-price-resolver.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mock @percolator/shared ───────────────────────────────────────────────────
+
+const mockSelect = vi.fn();
+const mockFrom = vi.fn().mockReturnValue({ select: mockSelect });
+
+vi.mock('@percolator/shared', () => ({
+  getSupabase: vi.fn(() => ({ from: mockFrom })),
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { DevnetPriceResolver } from '../../src/services/devnet-price-resolver.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Helper: set up mockSelect to return devnet_mints then overrides. */
+function mockSupabaseResponses(
+  mintRows: Array<{ devnet_mint: string; mainnet_ca: string }>,
+  overrideRows: Array<{ devnet_mint: string; price_usd: number }>,
+): void {
+  mockSelect
+    .mockResolvedValueOnce({ data: mintRows, error: null })
+    .mockResolvedValueOnce({ data: overrideRows, error: null });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('DevnetPriceResolver', () => {
+  let resolver: DevnetPriceResolver;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolver = new DevnetPriceResolver();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    resolver.stop();
+    vi.useRealTimers();
+  });
+
+  describe('start() and initial load', () => {
+    it('should load devnet_mints and overrides on start()', async () => {
+      mockSupabaseResponses(
+        [{ devnet_mint: 'DEVNET_MINT_1', mainnet_ca: 'MAINNET_CA_1' }],
+        [{ devnet_mint: 'PURE_DEVNET_MINT', price_usd: 2.5 }],
+      );
+
+      await resolver.start();
+
+      expect(resolver.getMainnetCa('DEVNET_MINT_1')).toBe('MAINNET_CA_1');
+      expect(resolver.getStaticPrice('PURE_DEVNET_MINT')).toBe(2_500_000n);
+      expect(resolver.initialized).toBe(true);
+    });
+
+    it('should return null for unknown mints after load', async () => {
+      mockSupabaseResponses([], []);
+      await resolver.start();
+
+      expect(resolver.getMainnetCa('UNKNOWN_MINT')).toBeNull();
+      expect(resolver.getStaticPrice('UNKNOWN_MINT')).toBeNull();
+    });
+  });
+
+  describe('getMainnetCa()', () => {
+    it('should return correct mainnet CA for a devnet mirror mint', async () => {
+      mockSupabaseResponses(
+        [
+          { devnet_mint: 'DEVNET_A', mainnet_ca: 'MAINNET_A' },
+          { devnet_mint: 'DEVNET_B', mainnet_ca: 'MAINNET_B' },
+        ],
+        [],
+      );
+      await resolver.start();
+
+      expect(resolver.getMainnetCa('DEVNET_A')).toBe('MAINNET_A');
+      expect(resolver.getMainnetCa('DEVNET_B')).toBe('MAINNET_B');
+      expect(resolver.getMainnetCa('DEVNET_C')).toBeNull();
+    });
+  });
+
+  describe('getStaticPrice()', () => {
+    it('should return priceE6 for devnet-only token with $1 override', async () => {
+      mockSupabaseResponses(
+        [],
+        [{ devnet_mint: 'PURE_TOKEN', price_usd: 1.0 }],
+      );
+      await resolver.start();
+
+      expect(resolver.getStaticPrice('PURE_TOKEN')).toBe(1_000_000n);
+    });
+
+    it('should return priceE6 correctly for fractional USD prices', async () => {
+      mockSupabaseResponses(
+        [],
+        [{ devnet_mint: 'FRAC_TOKEN', price_usd: 0.000123 }],
+      );
+      await resolver.start();
+
+      // 0.000123 * 1_000_000 = 123
+      expect(resolver.getStaticPrice('FRAC_TOKEN')).toBe(123n);
+    });
+
+    it('should ignore entries with price_usd = 0 or negative', async () => {
+      mockSupabaseResponses(
+        [],
+        [
+          { devnet_mint: 'ZERO_TOKEN', price_usd: 0 },
+          { devnet_mint: 'NEG_TOKEN', price_usd: -1 },
+        ],
+      );
+      await resolver.start();
+
+      expect(resolver.getStaticPrice('ZERO_TOKEN')).toBeNull();
+      expect(resolver.getStaticPrice('NEG_TOKEN')).toBeNull();
+    });
+  });
+
+  describe('background refresh', () => {
+    it('should refresh data after REFRESH_INTERVAL_MS (5min)', async () => {
+      // Initial load: DEVNET_A → MAINNET_A
+      mockSupabaseResponses(
+        [{ devnet_mint: 'DEVNET_A', mainnet_ca: 'MAINNET_A' }],
+        [],
+      );
+      await resolver.start();
+      expect(resolver.getMainnetCa('DEVNET_A')).toBe('MAINNET_A');
+
+      // Second load (refresh): DEVNET_A → MAINNET_A_V2
+      mockSupabaseResponses(
+        [{ devnet_mint: 'DEVNET_A', mainnet_ca: 'MAINNET_A_V2' }],
+        [],
+      );
+
+      // Advance timer by 5 minutes to trigger refresh
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1_000);
+
+      expect(resolver.getMainnetCa('DEVNET_A')).toBe('MAINNET_A_V2');
+    });
+  });
+
+  describe('Supabase error handling', () => {
+    it('should keep stale data when devnet_mints query fails', async () => {
+      // First load OK
+      mockSupabaseResponses(
+        [{ devnet_mint: 'DEVNET_A', mainnet_ca: 'MAINNET_A' }],
+        [],
+      );
+      await resolver.start();
+
+      // Second load: devnet_mints errors, overrides OK
+      mockSelect
+        .mockResolvedValueOnce({ data: null, error: { message: 'DB error' } })
+        .mockResolvedValueOnce({ data: [], error: null });
+
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1_000);
+
+      // Stale data retained — still resolves
+      expect(resolver.getMainnetCa('DEVNET_A')).toBe('MAINNET_A');
+    });
+
+    it('should handle missing devnet_price_overrides table gracefully', async () => {
+      mockSelect
+        .mockResolvedValueOnce({ data: [], error: null }) // mints OK
+        .mockResolvedValueOnce({                          // overrides table missing
+          data: null,
+          error: { message: 'relation "devnet_price_overrides" does not exist' },
+        });
+
+      // Should not throw
+      await expect(resolver.start()).resolves.not.toThrow();
+      expect(resolver.initialized).toBe(true);
+    });
+  });
+
+  describe('stop()', () => {
+    it('should stop background refresh timer', async () => {
+      mockSupabaseResponses([], []);
+      await resolver.start();
+
+      resolver.stop();
+
+      // Advance past refresh interval — no new Supabase calls expected
+      mockSelect.mockClear();
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1_000);
+
+      expect(mockSelect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/services/oracle.test.ts
+++ b/tests/services/oracle.test.ts
@@ -535,4 +535,117 @@ describe('OracleService', () => {
       expect(current).toBeNull();
     });
   });
+
+  describe('devnet price resolver fallbacks', () => {
+    // Each test uses unique mints to avoid DexScreener module-level cache collisions
+    const SLAB = 'SlabForDevnetToken111111111111111111111111111';
+
+    /** Returns a mock DevnetPriceResolver for testing */
+    function makeResolver(opts: {
+      mainnetCa?: string | null;
+      staticPrice?: bigint | null;
+    }) {
+      return {
+        getMainnetCa: vi.fn().mockReturnValue(opts.mainnetCa ?? null),
+        getStaticPrice: vi.fn().mockReturnValue(opts.staticPrice ?? null),
+      };
+    }
+
+    it('should use mainnet_ca fallback when devnet mint has no DexScreener/Jupiter listing', async () => {
+      const DEVNET_MINT = 'DevnetMintFallback1111111111111111111111111111';
+      const MAINNET_CA  = 'MainnetCaFallback1111111111111111111111111111A';
+
+      // Devnet mint → no price. Mainnet CA → valid DexScreener price.
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({ json: async () => ({ pairs: [] }) } as any)  // dex devnet → null
+        .mockResolvedValueOnce({ json: async () => ({ data: {} }) } as any)   // jup devnet → null
+        .mockResolvedValueOnce({                                              // dex mainnet_ca → $2.50
+          json: async () => ({
+            pairs: [{ priceUsd: '2.50', liquidity: { usd: 50000 } }],
+          }),
+        } as any)
+        .mockResolvedValueOnce({ json: async () => ({ data: {} }) } as any);  // jup mainnet_ca → null
+
+      const resolver = makeResolver({ mainnetCa: MAINNET_CA });
+      oracleService.setDevnetResolver(resolver as any);
+
+      const result = await oracleService.fetchPrice(DEVNET_MINT, SLAB);
+
+      expect(result).not.toBeNull();
+      expect(result!.priceE6).toBe(2_500_000n);
+      expect(result!.source).toBe('dexscreener-mainnet-ca');
+      expect(resolver.getMainnetCa).toHaveBeenCalledWith(DEVNET_MINT);
+    });
+
+    it('should use jupiter-mainnet-ca when DexScreener mainnet CA also fails', async () => {
+      const DEVNET_MINT = 'DevnetMintJupFallback111111111111111111111111';
+      const MAINNET_CA  = 'MainnetCaJupFallback111111111111111111111111B';
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({ json: async () => ({ pairs: [] }) } as any)  // dex devnet → null
+        .mockResolvedValueOnce({ json: async () => ({ data: {} }) } as any)   // jup devnet → null
+        .mockResolvedValueOnce({ json: async () => ({ pairs: [] }) } as any)  // dex mainnet_ca → null
+        .mockResolvedValueOnce({                                               // jup mainnet_ca → $1.75
+          json: async () => ({
+            data: { [MAINNET_CA]: { price: '1.75' } },
+          }),
+        } as any);
+
+      const resolver = makeResolver({ mainnetCa: MAINNET_CA });
+      oracleService.setDevnetResolver(resolver as any);
+
+      const result = await oracleService.fetchPrice(DEVNET_MINT, SLAB);
+
+      expect(result).not.toBeNull();
+      expect(result!.priceE6).toBe(1_750_000n);
+      expect(result!.source).toBe('jupiter-mainnet-ca');
+    });
+
+    it('should use static override when no mainnet_ca and no external price', async () => {
+      const DEVNET_MINT = 'DevnetMintStaticOverride11111111111111111111';
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({ json: async () => ({ pairs: [] }) } as any)
+        .mockResolvedValueOnce({ json: async () => ({ data: {} }) } as any);
+
+      const resolver = makeResolver({ mainnetCa: null, staticPrice: 1_000_000n }); // $1.00
+      oracleService.setDevnetResolver(resolver as any);
+
+      const result = await oracleService.fetchPrice(DEVNET_MINT, SLAB);
+
+      expect(result).not.toBeNull();
+      expect(result!.priceE6).toBe(1_000_000n);
+      expect(result!.source).toBe('devnet-override');
+      expect(resolver.getStaticPrice).toHaveBeenCalledWith(DEVNET_MINT);
+    });
+
+    it('should return null when no resolver attached and all external sources fail', async () => {
+      const DEVNET_MINT = 'DevnetMintNoResolver1111111111111111111111111';
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({ json: async () => ({ pairs: [] }) } as any)
+        .mockResolvedValueOnce({ json: async () => ({ data: {} }) } as any);
+
+      // No resolver set — default null
+      const result = await oracleService.fetchPrice(DEVNET_MINT, SLAB);
+      expect(result).toBeNull();
+    });
+
+    it('should skip mainnet_ca lookup when mainnet_ca equals devnet mint (prevent loop)', async () => {
+      const DEVNET_MINT = 'DevnetMintLoopGuard111111111111111111111111111';
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({ json: async () => ({ pairs: [] }) } as any)
+        .mockResolvedValueOnce({ json: async () => ({ data: {} }) } as any);
+
+      // getMainnetCa returns same address — resolver must NOT retry
+      const resolver = makeResolver({ mainnetCa: DEVNET_MINT, staticPrice: null });
+      oracleService.setDevnetResolver(resolver as any);
+
+      const result = await oracleService.fetchPrice(DEVNET_MINT, SLAB);
+      expect(result).toBeNull();
+      // fetch should only have been called twice (devnet dex + jup), not again for mainnet_ca
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
## Problem
oracle-keeper's `fetchPrice()` uses the on-chain `collateralMint` for DexScreener+Jupiter lookups. Custom devnet tokens fail at two levels:
- **Devnet mirrors** (e.g. SOL mirror): DexScreener needs the *mainnet* CA, not the devnet one
- **Pure devnet tokens** (e.g. SEX slab 3bmCyPee): no mainnet equivalent → no external price → push skipped forever

## Solution — Two-layer fallback

### Layer 1: mainnet_ca reverse-lookup
New `DevnetPriceResolver` service queries Supabase `devnet_mints` table every 5min.  
When DexScreener+Jupiter both return null on the devnet mint, resolves mainnet_ca and retries.  
Sources logged as `dexscreener-mainnet-ca` / `jupiter-mainnet-ca`.

### Layer 2: static price override
New Supabase table `devnet_price_overrides(devnet_mint, price_usd)`.  
For tokens with no mainnet equivalent, DevOps inserts a static price.  
Source logged as `devnet-override`.

## Files
- `src/services/devnet-price-resolver.ts` — new Supabase-backed resolver
- `src/services/oracle.ts` — two fallback layers wired into `fetchPrice()`
- `src/index.ts` — resolver started before CrankService
- `supabase/migrations/043_devnet_price_overrides.sql` — migration (in percolator-launch)
- 5 oracle integration tests + 10 resolver unit tests

## Tests
```
58/58 passing
```

## DevOps Action Required
1. Apply migration 043 from percolator-launch: `supabase db push`
2. Find SEX token collateral mint: `SELECT mint_address FROM markets WHERE slab_address = '3bmCyPee...'`
3. Insert override: `INSERT INTO devnet_price_overrides (devnet_mint, price_usd, notes) VALUES ('<mint>', 1.00, 'SEX token');`
4. Redeploy oracle-keeper on Railway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced price resolution system with devnet-specific fallbacks, including automatic mainnet asset lookup when devnet pricing is unavailable, static price override support, and improved fallback mechanisms to ensure more reliable pricing data availability across different network configurations.

* **Tests**
  * Added comprehensive test coverage for new price resolver functionality and oracle service integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->