### PR TITLE
chore: bump @percolator/sdk to d1f8ddd (V3/V4 slab layout — PR#16)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@percolator/sdk':
         specifier: github:dcccrypto/percolator-sdk
-        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/f08938487d83c5866df354f9a73418457b544c23(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/d1f8ddd8dfd2372d5f0fb0b5d460d2ad8d720e5a(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@percolator/shared':
         specifier: github:dcccrypto/percolator-shared
         version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/bd68a8cede4b8393b295c6f1d16ad79179c9633a(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -422,8 +422,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@percolator/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/f08938487d83c5866df354f9a73418457b544c23':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/f08938487d83c5866df354f9a73418457b544c23}
+  '@percolator/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/d1f8ddd8dfd2372d5f0fb0b5d460d2ad8d720e5a':
+    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/d1f8ddd8dfd2372d5f0fb0b5d460d2ad8d720e5a}
     version: 0.1.0
 
   '@percolator/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/bd68a8cede4b8393b295c6f1d16ad79179c9633a':
@@ -1635,7 +1635,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
 
-  '@percolator/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/f08938487d83c5866df354f9a73418457b544c23(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@percolator/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/d1f8ddd8dfd2372d5f0fb0b5d460d2ad8d720e5a(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -1648,7 +1648,7 @@ snapshots:
 
   '@percolator/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/bd68a8cede4b8393b295c6f1d16ad79179c9633a(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@percolator/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/f08938487d83c5866df354f9a73418457b544c23(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@percolator/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/d1f8ddd8dfd2372d5f0fb0b5d460d2ad8d720e5a(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@sentry/node': 10.40.0
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@supabase/supabase-js': 2.97.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)


### PR DESCRIPTION
Bumps @percolator/sdk lockfile from f089384 (V2/PR#15) to d1f8ddd (V3+V4/PR#16).

**Why:** SDK PR#16 adds V3 (257200-byte, 1024-acct) and V4 (992560-byte, 4096-acct) slab layout constants. Without this, keeper:liquidation logs ERRO for those two slab sizes.

SDK PR#16 has QA ✅ + Security ✅ approval and is merged.

cc: @dcccrypto