### PR TITLE
fix: permanently skip markets with unrecognized slab data length in scanMarket()

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -292,9 +292,28 @@ export class LiquidationService {
 
       return candidates;
     } catch (err) {
+      const errMsg = getErrorMessage(err);
+
+      // Unrecognized slab data length means parseEngine/detectLayout cannot handle
+      // this slab size (e.g. 4096-slot = 992560 bytes, larger than any known layout).
+      // Permanently skip so we stop logging an [ERRO] every ~60 seconds.
+      // Root fix: SDK needs to add a 4096-slot layout variant — message sdk agent.
+      if (errMsg.toLowerCase().includes("unrecognized slab data length")) {
+        this.permanentlySkipped.add(slabAddress);
+        logger.warn(
+          "Unrecognized slab layout — permanently skipping this market in liquidation scanner. " +
+          "SDK needs to add support for this slab size. File issue against percolator-sdk.",
+          {
+            slabAddress,
+            error: errMsg,
+          },
+        );
+        return [];
+      }
+
       logger.error("Market scan failed", {
         slabAddress,
-        error: getErrorMessage(err),
+        error: errMsg,
         stack: err instanceof Error ? err.stack : undefined,
       });
       return [];

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -586,5 +586,73 @@ describe('LiquidationService', () => {
       expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
       expect(result.scanned).toBe(0);
     });
+
+    it('should permanently skip a market after "Unrecognized slab data length" in scanMarket()', async () => {
+      const largeSlabAddr = 'LargeSlab1111111111111111111111111111111111';
+      const svc = new LiquidationService(mockOracleService as any);
+
+      const mockMarket = {
+        slabAddress: { toBase58: () => largeSlabAddr },
+        programId: { toBase58: () => 'Program11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+          oracleAuthority: mockZeroKey(),
+          indexFeedId: mockNonZeroKey(),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+      };
+
+      // Simulate parseEngine throwing for unknown slab size (992560 bytes = 4096 slots)
+      vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(992560));
+      vi.mocked(core.parseEngine).mockImplementation(() => {
+        throw new Error('Unrecognized slab data length: 992560. Cannot determine layout version.');
+      });
+
+      const candidates = await svc.scanMarket(mockMarket as any);
+      expect(candidates).toEqual([]);
+
+      // Should now be permanently skipped
+      const status = svc.getStatus();
+      expect(status.permanentlySkippedCount).toBe(1);
+      expect(status.permanentlySkippedMarkets).toContain(largeSlabAddr);
+    });
+
+    it('should not call scanMarket for markets skipped due to unrecognized slab length', async () => {
+      const largeSlabAddr = 'LargeSlab2222222222222222222222222222222222';
+      const svc = new LiquidationService(mockOracleService as any);
+
+      const mockMarket = {
+        slabAddress: { toBase58: () => largeSlabAddr },
+        programId: { toBase58: () => 'Program11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+          oracleAuthority: mockZeroKey(),
+          indexFeedId: mockNonZeroKey(),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+      };
+
+      // First call: throw unrecognized slab length
+      vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(992560));
+      vi.mocked(core.parseEngine).mockImplementationOnce(() => {
+        throw new Error('Unrecognized slab data length: 992560.');
+      });
+
+      const markets = new Map([
+        [largeSlabAddr, { market: mockMarket as any }],
+      ]);
+
+      // First scan: should add to permanentlySkipped
+      await svc.scanAndLiquidateAll(markets);
+      expect(svc.getStatus().permanentlySkippedCount).toBe(1);
+
+      vi.clearAllMocks();
+
+      // Second scan: market is filtered before scanMarket is even called
+      await svc.scanAndLiquidateAll(markets);
+      expect(core.fetchSlab).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Problem
Keeper logs `[ERRO] Market scan failed: "Unrecognized slab data length: 992560. Cannot determine layout version."` every ~60 seconds for 2 slabs:
- `3Eq3G6fiPFkvqQdUXNMGRrgqVCcNV74Mo7Td9qhvq3HR`
- `2t389M7NwJ1FbwKuv1yf8TSGk84FR1itGgxMBkjh5fDs`

These are large 4096-slot slabs (992560 bytes). `parseEngine()` throws before `detectLayout()` is called. The `permanentlySkipped` guard only covered the `0x4 InvalidSlabLen` path in `liquidate()` — `scanMarket()` had no similar protection.

## Fix
Detect `'unrecognized slab data length'` in `scanMarket()` catch block and add the market to `permanentlySkipped`, same pattern as PERC-484 (0x4 fix). Logs a WARN once then filters the market from all future scan cycles via `scanAndLiquidateAll()`.

## Root Fix Needed
SDK must add 4096-slot (992560-byte) layout support to `detectLayout()` / `parseEngine()` so these markets can actually be scanned. Filed message to sdk agent.

## Tests
- 2 new unit tests: permanent skip on `Unrecognized slab data length`, and skip-filter in `scanAndLiquidateAll()`
- All 104 tests pass ✅

## How to Test
Deploy to keeper — confirm the 2 affected slabs log WARN once then disappear from error logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced error handling for markets with incompatible or unsupported slab data layouts. Markets encountering this condition are now permanently flagged as skipped, preventing redundant scanning attempts in future liquidation cycles.

## Tests
* Added test coverage validating permanent market skip behavior when unsupported slab data layouts are encountered, including control-flow verification for subsequent scan operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->