### PR TITLE
fix: reject devnet fallback RPC on mainnet (C2)

### DIFF
--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -1,3 +1,11 @@
+/** Known devnet RPC hostnames / URL substrings — used to detect network mismatch */
+const DEVNET_INDICATORS = ["devnet", "api.devnet.solana.com"];
+
+function looksLikeDevnet(url: string): boolean {
+  const lower = url.toLowerCase();
+  return DEVNET_INDICATORS.some((indicator) => lower.includes(indicator));
+}
+
 export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): void {
   const supabaseKey = env.SUPABASE_KEY?.trim();
   const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY?.trim();
@@ -38,6 +46,28 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
         `FALLBACK_RPC_URL must use https:// (got ${fallbackRpcUrl.slice(0, 30)}...). ` +
         "Plaintext HTTP exposes signed transactions to MITM. " +
         "Set ALLOW_INSECURE_RPC=true to override for local development."
+      );
+    }
+  }
+
+  // C2: On mainnet, FALLBACK_RPC_URL must be explicitly set and must NOT point to devnet.
+  // The shared config defaults fallbackRpcUrl to "https://api.devnet.solana.com" when
+  // FALLBACK_RPC_URL is unset, which silently sends fallback RPCs (discovery, liquidation
+  // retry, 429 read-only retry) to the wrong network.
+  if (env.NETWORK === "mainnet") {
+    const fallback = env.FALLBACK_RPC_URL?.trim();
+    if (!fallback) {
+      throw new Error(
+        "FALLBACK_RPC_URL must be set when NETWORK=mainnet. " +
+        "The shared config defaults to devnet, which would cause fallback RPCs " +
+        "to read wrong-network data. Set it to a mainnet RPC endpoint."
+      );
+    }
+    if (looksLikeDevnet(fallback)) {
+      throw new Error(
+        `FALLBACK_RPC_URL appears to be a devnet endpoint (${fallback.slice(0, 50)}), ` +
+        "but NETWORK=mainnet. Fallback RPCs would return wrong-network data. " +
+        "Set FALLBACK_RPC_URL to a mainnet RPC endpoint."
       );
     }
   }

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -89,4 +89,54 @@ describe("validateKeeperEnvGuards", () => {
 
     expect(() => validateKeeperEnvGuards(env)).not.toThrow();
   });
+
+  // C2: mainnet fallback RPC network mismatch guard
+  it("throws when NETWORK=mainnet and FALLBACK_RPC_URL is not set", () => {
+    const env = {
+      NETWORK: "mainnet",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).toThrow(
+      "FALLBACK_RPC_URL must be set when NETWORK=mainnet"
+    );
+  });
+
+  it("throws when NETWORK=mainnet and FALLBACK_RPC_URL points to devnet", () => {
+    const env = {
+      NETWORK: "mainnet",
+      FALLBACK_RPC_URL: "https://api.devnet.solana.com",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).toThrow(
+      "appears to be a devnet endpoint"
+    );
+  });
+
+  it("throws when NETWORK=mainnet and FALLBACK_RPC_URL contains devnet in Helius URL", () => {
+    const env = {
+      NETWORK: "mainnet",
+      FALLBACK_RPC_URL: "https://devnet.helius-rpc.com/?api-key=abc123",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).toThrow(
+      "appears to be a devnet endpoint"
+    );
+  });
+
+  it("does not throw when NETWORK=mainnet and FALLBACK_RPC_URL is a mainnet endpoint", () => {
+    const env = {
+      NETWORK: "mainnet",
+      FALLBACK_RPC_URL: "https://mainnet.helius-rpc.com/?api-key=abc123",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
+
+  it("does not throw when NETWORK=devnet and FALLBACK_RPC_URL is not set", () => {
+    const env = {
+      NETWORK: "devnet",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

- The `@percolator/shared` config defaults `FALLBACK_RPC_URL` to `https://api.devnet.solana.com` when the env var is unset
- On mainnet, this silently routes fallback RPCs (market discovery, liquidation retry, 429 read-only retry) to the wrong network
- Adds a startup guard in `env-guards.ts` that requires `FALLBACK_RPC_URL` to be explicitly set on mainnet and rejects devnet-pointing URLs
- Guard is skipped for non-mainnet networks so devnet usage is unaffected

## Affected codepaths

| Caller | File | Impact if unguarded |
|--------|------|---------------------|
| Market discovery | `crank.ts:212` | Discovers devnet programs instead of mainnet |
| Liquidation retry | `liquidation.ts:49` | Reads devnet slab data on retry |
| 429 read-only retry | `shared/rpc-client.ts:130` | Returns devnet account state |

## Test plan

- [x] `throws when NETWORK=mainnet and FALLBACK_RPC_URL is not set`
- [x] `throws when NETWORK=mainnet and FALLBACK_RPC_URL points to devnet`
- [x] `throws when NETWORK=mainnet and FALLBACK_RPC_URL contains devnet in Helius URL`
- [x] `does not throw when NETWORK=mainnet and FALLBACK_RPC_URL is a mainnet endpoint`
- [x] `does not throw when NETWORK=devnet and FALLBACK_RPC_URL is not set`
- [x] All 138 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced environment validation to ensure fallback RPC URLs are configured correctly for mainnet, preventing accidental misconfigurations.

* **Tests**
  * Added comprehensive test coverage for fallback RPC URL network validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->