### PR TITLE
fix: respect maxPnlCap==0 as ADL-disabled, bound insurance excess (C5+C6)

### DIFF
--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -205,14 +205,18 @@ function checkAdlTrigger(
     ADL_INSURANCE_UTIL_THRESHOLD_BPS > 0n &&
     utilizationBps >= ADL_INSURANCE_UTIL_THRESHOLD_BPS;
 
-  // ADL disabled if max_pnl_cap == 0 UNLESS insurance utilization gate fires
+  // ADL disabled when max_pnl_cap == 0 (matches isAdlNeeded semantics)
   const adlNeeded =
-    capExceeded || insuranceDepleted || utilizationTriggered;
+    maxPnlCap > 0n && (capExceeded || insuranceDepleted || utilizationTriggered);
 
+  // When cap is exceeded, deleverage the overshoot.
+  // When triggered by insurance alone (cap not exceeded), deleverage 20%
+  // of pnlPosTot per scan — conservative ramp-down that lets multiple
+  // scans gradually reduce exposure without over-deleveraging.
   const excess =
     capExceeded && maxPnlCap > 0n
       ? pnlPosTot - maxPnlCap
-      : pnlPosTot; // Use full pnlPosTot as excess when triggered by insurance
+      : pnlPosTot / 5n;
 
   return {
     slabAddress,

--- a/tests/services/adl.test.ts
+++ b/tests/services/adl.test.ts
@@ -175,6 +175,25 @@ describe("AdlService", () => {
       const result = await service.scanMarket(slabAddress, makeMarket() as any);
       expect(result).toBe(0);
     });
+
+    it("returns 0 when max_pnl_cap is 0 even with high insurance utilization (C5)", async () => {
+      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+      // High insurance utilization: feeRevenue=10M, balance=1M → 90% utilized
+      vi.mocked(sdk.parseEngine).mockReturnValue({
+        pnlPosTot: 5_000_000n,
+        insuranceFund: {
+          balance: 1_000_000n,
+          feeRevenue: 10_000_000n,
+          isolatedBalance: 0n,
+          isolationBps: 0,
+        },
+      } as any);
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 0n }) as any);
+
+      const result = await service.scanMarket(slabAddress, makeMarket() as any);
+      expect(result).toBe(0);
+      expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+    });
   });
 
   describe("scanMarket — ADL triggered", () => {


### PR DESCRIPTION
## Summary

Two interacting ADL bugs fixed:

**C5 — ADL triggers on disabled markets:**
- `checkAdlTrigger()` allowed ADL on markets where `maxPnlCap==0` (protocol semantics: "ADL disabled") when insurance utilization threshold fired
- The deprecated `isAdlNeeded()` correctly returned false for `maxPnlCap==0`
- Fix: gate `adlNeeded` with `maxPnlCap > 0n`, matching `isAdlNeeded` semantics

**C6 — Over-deleveraging on insurance-triggered ADL:**
- When triggered by insurance (not cap), `excess` was set to the **full `pnlPosTot`** — the entire positive PnL pool
- This caused the deleverage loop to wipe out every profitable position (up to `ADL_MAX_TX_PER_SCAN`)
- Fix: use `pnlPosTot / 5n` (20% per scan) for a conservative ramp-down that lets multiple scans gradually reduce exposure

**Combined impact:** On a `maxPnlCap==0` market with high insurance utilization, C5 triggered ADL and C6 then attempted to deleverage the entire positive PnL pool — maximum damage to traders.

## Changes

| File | Change |
|------|--------|
| `src/services/adl.ts:209` | Gate `adlNeeded` with `maxPnlCap > 0n` |
| `src/services/adl.ts:212-215` | Replace `pnlPosTot` with `pnlPosTot / 5n` in insurance-triggered excess |
| `tests/services/adl.test.ts` | New test: `maxPnlCap==0` with 90% insurance utilization → no ADL |

## Test plan

- [x] New test: `maxPnlCap==0` with high insurance utilization returns 0 (C5)
- [x] All 16 ADL tests pass
- [x] All 134 tests pass across full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)