### PR TITLE
fix: prevent oracle deviation check from permanently bricking markets (H1)

### DIFF
--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -72,6 +72,10 @@ export class OracleService {
   // a prolonged external outage causes the oracle to go stale rather than cycling
   // the same on-chain price forever.
   private lastExternalPriceMs = new Map<string, number>();
+  // H1: Track consecutive deviation rejections per slab to avoid permanent anchor lock.
+  // After DEVIATION_ACCEPT_AFTER consecutive rejections, accept the price as legitimate.
+  private deviationRejections = new Map<string, number>();
+  private static readonly DEVIATION_ACCEPT_AFTER = 5;
 
   /** Fetch price from DexScreener (with rate-limit cache) */
   async fetchDexScreenerPrice(mint: string): Promise<bigint | null> {
@@ -282,6 +286,10 @@ export class OracleService {
     }
 
     // R2-S4: Historical deviation check — reject if >30% change from last known price
+    // H1: After DEVIATION_ACCEPT_AFTER consecutive rejections for the same market,
+    // accept the price as a legitimate move. Cross-validation (DexScreener + Jupiter
+    // within 10%) already guards against bad data, so consecutive cross-validated
+    // prices at the new level are almost certainly legitimate.
     const HISTORICAL_DEVIATION_MAX_BPS = 3000; // 30.00%
     const history = this.priceHistory.get(slabAddress);
     if (history && history.length > 0) {
@@ -291,18 +299,34 @@ export class OracleService {
           ? Number((priceE6 - lastPrice) * 10_000n / lastPrice)
           : Number((lastPrice - priceE6) * 10_000n / lastPrice);
         if (deviationBps > HISTORICAL_DEVIATION_MAX_BPS) {
-          logger.warn("Price deviation exceeds threshold", {
+          const consecutiveCount = (this.deviationRejections.get(slabAddress) ?? 0) + 1;
+          this.deviationRejections.set(slabAddress, consecutiveCount);
+          if (consecutiveCount < OracleService.DEVIATION_ACCEPT_AFTER) {
+            logger.warn("Price deviation exceeds threshold", {
+              mint,
+              deviationBps,
+              thresholdBps: HISTORICAL_DEVIATION_MAX_BPS,
+              lastPrice: lastPrice.toString(),
+              newPrice: priceE6.toString(),
+              source,
+              consecutiveRejections: consecutiveCount,
+              acceptAfter: OracleService.DEVIATION_ACCEPT_AFTER,
+            });
+            return null;
+          }
+          logger.warn("Accepting deviated price after consecutive rejections (H1)", {
             mint,
             deviationBps,
-            thresholdBps: HISTORICAL_DEVIATION_MAX_BPS,
+            consecutiveRejections: consecutiveCount,
             lastPrice: lastPrice.toString(),
             newPrice: priceE6.toString(),
-            source
+            source,
           });
-          return null;
         }
       }
     }
+    // H1: Price accepted — reset consecutive rejection counter
+    this.deviationRejections.delete(slabAddress);
 
     const entry: PriceEntry = { priceE6, source, timestamp: Date.now() };
     this.recordPrice(slabAddress, entry);

--- a/tests/services/oracle-deviation.test.ts
+++ b/tests/services/oracle-deviation.test.ts
@@ -316,6 +316,58 @@ describe('Historical deviation — boundary conditions', () => {
     const r4 = await svc.fetchPrice(mint4, slab);
     expect(r4).toBeNull();
   });
+
+  it('H1: accepts deviated price after 5 consecutive rejections (no permanent brick)', async () => {
+    const slab = freshSlab();
+    // Seed at $1.00
+    await seedPrice(slab, 1.00);
+
+    // Price jumps to $2.00 (100% deviation) — should be rejected 4 times, accepted on 5th
+    for (let i = 0; i < 4; i++) {
+      const mint = freshMint();
+      mockBothSources(2.00, 2.00, mint);
+      const r = await svc.fetchPrice(mint, slab);
+      expect(r).toBeNull();
+    }
+
+    // 5th consecutive rejection — should be accepted
+    const mintAccept = freshMint();
+    mockBothSources(2.00, 2.00, mintAccept);
+    const rAccept = await svc.fetchPrice(mintAccept, slab);
+    expect(rAccept).not.toBeNull();
+    expect(rAccept!.priceE6).toBe(toE6(2.00));
+  });
+
+  it('H1: resets rejection counter when a normal price is accepted', async () => {
+    const slab = freshSlab();
+    await seedPrice(slab, 1.00);
+
+    // 2 consecutive rejections at $2.00
+    for (let i = 0; i < 2; i++) {
+      const mint = freshMint();
+      mockBothSources(2.00, 2.00, mint);
+      expect(await svc.fetchPrice(mint, slab)).toBeNull();
+    }
+
+    // Normal price accepted ($1.10, within 30%)
+    const mintNormal = freshMint();
+    mockBothSources(1.10, 1.10, mintNormal);
+    const rNormal = await svc.fetchPrice(mintNormal, slab);
+    expect(rNormal).not.toBeNull();
+
+    // Counter should be reset — 4 more rejections at $2.00 should NOT accept
+    for (let i = 0; i < 4; i++) {
+      const mint = freshMint();
+      mockBothSources(2.00, 2.00, mint);
+      expect(await svc.fetchPrice(mint, slab)).toBeNull();
+    }
+
+    // 5th consecutive from fresh counter — NOW accepted
+    const mintFinal = freshMint();
+    mockBothSources(2.00, 2.00, mintFinal);
+    const rFinal = await svc.fetchPrice(mintFinal, slab);
+    expect(rFinal).not.toBeNull();
+  });
 });
 
 // ─── 3. Admin-oracle / pumpswap price computation (GH#1376 regression) ─────────


### PR DESCRIPTION
## Summary

- The 30% historical deviation check rejected fast-moving prices but **never recorded the rejection** in price history
- The old anchor price persisted forever, causing every subsequent fetch to also be rejected
- Markets were permanently bricked until keeper restart (which clears in-memory `priceHistory`)

## Fix

Add a consecutive rejection counter per market (`deviationRejections` Map):

- After **5 consecutive** cross-validated prices are rejected, accept the price as a legitimate move
- Counter resets whenever a normal price is accepted (no lingering state)
- Recovery time: ~25 seconds (5 cycles × ~5s rate limit)

## Why this is safe

- Cross-validation (DexScreener + Jupiter within 10%) already guards against bad data
- A single bad data point only counts as 1 rejection — nowhere near the threshold of 5
- Intermittent bad data (2 bad, 1 good, 2 bad) resets the counter on each good fetch

## Test plan

- [x] `H1: accepts deviated price after 5 consecutive rejections (no permanent brick)`
- [x] `H1: resets rejection counter when a normal price is accepted`
- [x] All 47 oracle deviation tests pass
- [x] All 135 tests pass across full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)