### PR TITLE
fix: enforce on-chain fallback 60s cap for new markets (H2)

### DIFF
--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -359,9 +359,15 @@ export class OracleService {
         // failing for longer than ON_CHAIN_FALLBACK_MAX_MS, stop pushing the stale
         // on-chain price. This lets the oracle go stale naturally so the frontend
         // shows a stale warning and the pause guard can halt trading.
-        const lastExternal = this.lastExternalPriceMs.get(slabAddress) ?? 0;
+        // H2: Seed the fallback clock on first encounter so the 60s cap applies
+        // even to markets that have never received an external price.
+        let lastExternal = this.lastExternalPriceMs.get(slabAddress);
+        if (lastExternal === undefined) {
+          lastExternal = now;
+          this.lastExternalPriceMs.set(slabAddress, now);
+        }
         const externalOutageMs = now - lastExternal;
-        if (lastExternal > 0 && externalOutageMs > ON_CHAIN_FALLBACK_MAX_MS) {
+        if (externalOutageMs > ON_CHAIN_FALLBACK_MAX_MS) {
           logger.warn("On-chain fallback exceeded time limit — skipping push to allow oracle to go stale", {
             mint,
             slabAddress,


### PR DESCRIPTION
## Summary

- The M-4 on-chain fallback had a 60s time cap to prevent pushing stale prices indefinitely
- The guard `lastExternal > 0` was bypassed for any market that never received an external price (DexScreener/Jupiter), because `lastExternalPriceMs` defaulted to `0`
- A manipulated on-chain `authorityPriceE6` would be pushed forever for new/unlisted markets

## Fix

Seed `lastExternalPriceMs` to `Date.now()` on first encounter of each market:
- New markets get a 60s grace window from their first fallback attempt
- After 60s with no external price, the oracle goes stale naturally (as M-4 intended)
- Remove the `lastExternal > 0` guard since `lastExternal` is now always a real timestamp
- When an external price is eventually fetched, the clock resets normally

## Test plan

- [x] All 133 existing tests pass
- [x] Fix is a 6-line change with clear semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)