### PR TITLE
fix: stop skipping Hyperp markets from liquidation scanning (H3)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -201,16 +201,11 @@ export class LiquidationService {
         price = resolvedPrice;
         if (price === 0n) return []; // No price resolved yet
       } else if (oracleMode === "hyperp") {
+        // H3: Use lastEffectivePriceE6 (DEX pool mark price) for Hyperp.
+        // authorityPriceE6 is not the price source for Hyperp mode and is
+        // legitimately 0 when the oracle authority hasn't pushed a price.
         price = resolvedPrice;
         if (price === 0n) return []; // Market not bootstrapped yet
-
-        // Sanity check: mark price should also be non-zero in a healthy Hyperp market
-        if (cfg.authorityPriceE6 === 0n) {
-          if (engine.totalOpenInterest > 0n) {
-            logger.warn("Hyperp market has zero mark price, skipping", { slabAddress });
-          }
-          return [];
-        }
       } else {
         // Admin oracle — resolveMarketPrice handles staleness fallback
         price = resolvedPrice;


### PR DESCRIPTION
## Summary

- The liquidation scanner checked `authorityPriceE6 === 0n` inside the Hyperp branch and returned `[]`, skipping the entire market
- For Hyperp markets, price comes from `lastEffectivePriceE6` (DEX pool mark price), NOT `authorityPriceE6`
- `authorityPriceE6` is legitimately zero for Hyperp markets — no authority pushes prices
- This silently excluded **all** Hyperp markets with zero authority price from liquidation scanning
- Undercollateralized positions in those markets were never flagged for liquidation

## Fix

Remove the redundant `authorityPriceE6 === 0n` check (lines 207-213). The existing `price === 0n` guard on line 205 already correctly handles unbootstrapped markets since `resolveMarketPrice()` returns `lastEffectivePriceE6` for Hyperp mode.

## Test plan

- [x] All 133 existing tests pass
- [x] Crank service's true-Hyperp path (lines 438-557) has no such check and works correctly — confirms this check was unnecessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved market price resolution in the liquidation service for more accurate pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->