### PR TITLE
fix: snapshot markets Map in ADL scanAll (H6)

### DIFF
--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -513,7 +513,9 @@ export class AdlService {
   async scanAll(): Promise<{ scanned: number; triggered: number; txSent: number }> {
     if (!this._getMarkets) return { scanned: 0, triggered: 0, txSent: 0 };
 
-    const markets = this._getMarkets();
+    // H6: Snapshot the markets Map to avoid concurrent mutation during async iteration.
+    // CrankService.discover() can add/delete markets while this loop is running.
+    const markets = new Map(this._getMarkets());
     let scanned = 0;
     let triggered = 0;
     let txSent = 0;


### PR DESCRIPTION
## Summary

- ADL `scanAll()` iterated the **live** `CrankService.markets` Map reference
- `CrankService.discover()` can add/delete markets via async interleaving during the ADL scan loop
- This caused undefined iterator behavior when the Map was mutated mid-iteration
- `LiquidationService` already correctly snapshots with `new Map(getMarkets())` at line 611

## Fix

One-line change: `new Map(this._getMarkets())` instead of `this._getMarkets()`.

## Test plan

- [x] All 133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)