### PR TITLE
fix: remove artificial BigInt overflow guard in liquidation PnL (H7)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -256,20 +256,12 @@ export class LiquidationService {
               ? price - entryPrice    // long: profit when price goes up
               : entryPrice - price;   // short: profit when price goes down
             
-            // BH5: Overflow protection - check bounds before multiplication
-            const MAX_SAFE_BIGINT = 9007199254740991n; // Number.MAX_SAFE_INTEGER
+            // H7: BigInt has arbitrary precision — no overflow possible.
+            // The previous guard clamped at Number.MAX_SAFE_INTEGER which is
+            // meaningless for BigInt and caused valid large positions to produce
+            // incorrect PnL (clamped to a positive value, masking liquidations).
             const absPosSize = absBI(account.positionSize);
-            
-            // Check if multiplication would overflow
-            if (diff > 0n && absPosSize > MAX_SAFE_BIGINT / diff) {
-              logger.warn("PnL calculation overflow", { accountIndex: i, slabAddress });
-              markPnl = diff > 0n ? MAX_SAFE_BIGINT : -MAX_SAFE_BIGINT;
-            } else if (diff < 0n && absPosSize > MAX_SAFE_BIGINT / -diff) {
-              logger.warn("PnL calculation overflow", { accountIndex: i, slabAddress });
-              markPnl = -MAX_SAFE_BIGINT;
-            } else {
-              markPnl = (diff * absPosSize) / price;
-            }
+            markPnl = (diff * absPosSize) / price;
           }
           const equity = account.capital + markPnl;
 


### PR DESCRIPTION
## Summary

- The overflow check clamped PnL at `Number.MAX_SAFE_INTEGER` (9e15), which is meaningless for BigInt (arbitrary precision)
- Large positions where `diff * positionSize > 9e15` were clamped to a **positive** value
- This could make deeply underwater accounts appear healthy, **preventing valid liquidations**
- The re-verification path (line 435) never had this guard and worked correctly

## Fix

Remove the `MAX_SAFE_BIGINT` overflow guard. BigInt arithmetic in JavaScript has arbitrary precision — no overflow is possible. The PnL calculation now matches the re-verification path.

## Test plan

- [x] All 133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed large position liquidation PnL calculations by removing unnecessary overflow safeguards that were incorrectly clamping profit/loss values for substantial trading positions, ensuring accurate calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->