### PR TITLE
fix: graceful shutdown on uncaughtException (H8)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -571,9 +571,14 @@ process.on("unhandledRejection", (reason, promise) => {
   });
 });
 
+// H8: uncaughtException means the process is in an undefined state.
+// Log the error and trigger graceful shutdown instead of continuing
+// with potentially corrupted state (half-written maps, broken invariants).
+// Railway's ON_FAILURE restart policy will bring the keeper back up cleanly.
 process.on("uncaughtException", (err) => {
-  logger.error("Uncaught exception — keeping process alive", {
+  logger.error("Uncaught exception — initiating graceful shutdown", {
     error: err.message,
     stack: err.stack,
   });
+  shutdown("uncaughtException").catch(() => process.exit(1));
 });


### PR DESCRIPTION
## Summary

- The `uncaughtException` handler swallowed the exception and continued execution
- Per Node.js docs, after an uncaught exception the process may be in undefined state
- Continuing risks corrupted in-memory state while signing financial transactions
- Now triggers graceful shutdown; Railway's `ON_FAILURE` restart policy brings the keeper back cleanly

## Test plan

- [x] All 133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)