### PR TITLE
fix: reject ALLOW_INSECURE_RPC on mainnet (H9)

### DIFF
--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -13,6 +13,14 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
   // http:// and ws:// transmit signed transactions and account data unencrypted,
   // enabling MITM attacks on the network path.
   const allowInsecure = env.ALLOW_INSECURE_RPC === "true";
+  // H9: Never allow insecure RPC on mainnet — signed transactions with real funds
+  // would be exposed to MITM interception over plaintext HTTP/WS.
+  if (allowInsecure && env.NETWORK === "mainnet") {
+    throw new Error(
+      "ALLOW_INSECURE_RPC=true is not permitted when NETWORK=mainnet. " +
+      "Plaintext RPC exposes signed transactions to MITM attacks."
+    );
+  }
   if (!allowInsecure) {
     const rpcUrl = env.SOLANA_RPC_URL?.trim();
     if (rpcUrl && !rpcUrl.startsWith("https://")) {

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -89,4 +89,25 @@ describe("validateKeeperEnvGuards", () => {
 
     expect(() => validateKeeperEnvGuards(env)).not.toThrow();
   });
+
+  // H9: ALLOW_INSECURE_RPC must be rejected on mainnet
+  it("throws when ALLOW_INSECURE_RPC=true and NETWORK=mainnet", () => {
+    const env = {
+      ALLOW_INSECURE_RPC: "true",
+      NETWORK: "mainnet",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).toThrow(
+      "ALLOW_INSECURE_RPC=true is not permitted when NETWORK=mainnet"
+    );
+  });
+
+  it("does not throw when ALLOW_INSECURE_RPC=true on devnet", () => {
+    const env = {
+      ALLOW_INSECURE_RPC: "true",
+      NETWORK: "devnet",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

- `ALLOW_INSECURE_RPC=true` bypassed all RPC URL scheme validation, including on mainnet
- A misconfigured deploy could send signed transactions with real funds over plaintext HTTP
- Now throws at startup when `ALLOW_INSECURE_RPC=true` and `NETWORK=mainnet`

## Test plan

- [x] `throws when ALLOW_INSECURE_RPC=true and NETWORK=mainnet`
- [x] `does not throw when ALLOW_INSECURE_RPC=true on devnet`
- [x] All 135 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)