### PR TITLE
fix: add timeout to bare getAccountInfo calls in crank service (M1+M2)

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -180,7 +180,11 @@ export class CrankService {
       for (const addr of slabAddresses) {
         try {
           const pubkey = new PublicKey(addr);
-          const info = await conn.getAccountInfo(pubkey);
+          const info = await withTimeout(
+            conn.getAccountInfo(pubkey),
+            RPC_TIMEOUT_MS,
+            `MARKETS_FILTER getAccountInfo(${addr.slice(0, 8)})`,
+          );
           if (!info?.data) {
             logger.warn("MARKETS_FILTER: slab not found on-chain", { slab: addr.slice(0, 8) });
             continue;
@@ -500,7 +504,23 @@ export class CrankService {
           //   PumpSwap:    [3] base_vault, [4] quote_vault  (from pool data at offsets 131, 163)
           //   Meteora DLMM: [3] vault_y / reserve_y         (from pool data at offset 184)
           //   Raydium CLMM: no additional accounts needed
-          const poolAccountInfo = await connection.getAccountInfo(poolKey);
+          // M1: Wrap pool lookup with timeout — a hung RPC should not block
+          // the entire crank batch. Pool data is optional; the crank proceeds
+          // without remaining accounts if the lookup fails.
+          let poolAccountInfo: Awaited<ReturnType<typeof connection.getAccountInfo>> = null;
+          try {
+            poolAccountInfo = await withTimeout(
+              connection.getAccountInfo(poolKey),
+              RPC_TIMEOUT_MS,
+              `HYPERP getAccountInfo(pool ${poolKey.toBase58().slice(0, 8)})`,
+            );
+          } catch (poolErr) {
+            logger.warn("HYPERP: pool getAccountInfo failed — sending without remaining accounts", {
+              slabAddress,
+              poolAddress: poolKey.toBase58(),
+              error: poolErr instanceof Error ? poolErr.message : String(poolErr),
+            });
+          }
           if (poolAccountInfo !== null) {
             const dexType = detectDexType(poolAccountInfo.owner);
             if (dexType === "pumpswap") {


### PR DESCRIPTION
## Summary

Two bare `getAccountInfo` calls in `crank.ts` had no timeout wrapper, allowing hung RPC nodes to block the keeper indefinitely.

**M1 — HYPERP pool lookup (line 503):**
- Fetches DEX pool account to detect type (PumpSwap/Meteora/Raydium)
- A hung RPC blocked the entire crank batch of 10 markets
- Fix: `withTimeout()` + local try/catch — pool data is optional, so timeout degrades gracefully (crank proceeds without vault remaining accounts)

**M2 — MARKETS_FILTER discovery (line 183):**
- Sequential `getAccountInfo` for each filtered slab address at startup
- A hung RPC blocked startup indefinitely
- Fix: `withTimeout()` — existing try/catch catches timeout and continues to next address

## Test plan

- [x] All 133 tests pass
- [x] Both fixes use existing `withTimeout()` and `RPC_TIMEOUT_MS` (15s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)