### PR TITLE
fix: validate Supabase fields independently (M3)

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -272,16 +272,18 @@ export class CrankService {
       }
       if (data) {
         const base58Re = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+        // M3: Validate each field independently — don't discard the entire row
+        // when only one field is invalid.
         for (const row of data) {
-          const pool = row.dex_pool_address ?? undefined;
-          const ca = row.mainnet_ca ?? undefined;
+          let pool = row.dex_pool_address ?? undefined;
+          let ca = row.mainnet_ca ?? undefined;
           if (pool && !base58Re.test(pool)) {
-            logger.warn("Invalid dex_pool_address from Supabase, ignoring", { slabAddress: row.slab_address, dexPoolAddress: pool });
-            continue;
+            logger.warn("Invalid dex_pool_address from Supabase, ignoring field", { slabAddress: row.slab_address, dexPoolAddress: pool });
+            pool = undefined;
           }
           if (ca && !base58Re.test(ca)) {
-            logger.warn("Invalid mainnet_ca from Supabase, ignoring", { slabAddress: row.slab_address, mainnetCA: ca });
-            continue;
+            logger.warn("Invalid mainnet_ca from Supabase, ignoring field", { slabAddress: row.slab_address, mainnetCA: ca });
+            ca = undefined;
           }
           dbMarkets.set(row.slab_address, {
             dexPoolAddress: pool,


### PR DESCRIPTION
## Summary

- Supabase row validation used `continue` which discarded the entire row when **one** field failed base58 check
- A HYPERP market with a valid `dex_pool_address` but corrupted `mainnet_ca` lost its pool address
- Now validates each field independently — invalid field is set to `undefined`, valid sibling is preserved

## Test plan

- [x] All 133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)