### PR TITLE
fix: validate DexScreener response before caching (M7)

### DIFF
--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -123,23 +123,26 @@ export class OracleService {
       if (!res.ok) return null;
       
       const json = (await res.json()) as DexScreenerResponse;
-      // BH7: Use captured timestamp for atomicity.
-      // Delete before set so refreshed entries move to the end of Map
-      // iteration order — ensures eviction targets the least-recently-used
-      // entry, not a frequently-refreshed one stuck at its insertion position.
-      dexScreenerCache.delete(mint);
-      dexScreenerCache.set(mint, { data: json, fetchedAt: now });
-      // Evict oldest entry when cache exceeds size cap
-      if (dexScreenerCache.size > DEX_SCREENER_CACHE_MAX_SIZE) {
-        const oldestKey = dexScreenerCache.keys().next().value;
-        if (oldestKey !== undefined) dexScreenerCache.delete(oldestKey);
-      }
 
+      // M7: Validate BEFORE caching — don't cache bad responses that would
+      // suppress fresh fetches for the full 10s TTL window.
       const pair = sortPairsByLiquidity(json.pairs)?.[0];
       if (!pair?.priceUsd) return null;
       if ((pair.liquidity?.usd ?? 0) < MIN_LIQUIDITY_USD) return null;
       const parsed = parseFloat(pair.priceUsd);
       if (!isFinite(parsed) || parsed <= 0) return null;
+
+      // Only cache validated responses with a usable price.
+      // BH7: Delete before set so refreshed entries move to the end of Map
+      // iteration order — ensures eviction targets the least-recently-used
+      // entry, not a frequently-refreshed one stuck at its insertion position.
+      dexScreenerCache.delete(mint);
+      dexScreenerCache.set(mint, { data: json, fetchedAt: now });
+      if (dexScreenerCache.size > DEX_SCREENER_CACHE_MAX_SIZE) {
+        const oldestKey = dexScreenerCache.keys().next().value;
+        if (oldestKey !== undefined) dexScreenerCache.delete(oldestKey);
+      }
+
       return BigInt(Math.round(parsed * PRICE_E6_MULTIPLIER));
     } catch {
       return null;


### PR DESCRIPTION
## Summary

- DexScreener responses were cached **before** validation (empty pairs, low liquidity, invalid price)
- A single bad 200 OK response suppressed fresh fetches for the full 10s cache TTL
- Move cache write to **after** all validation gates pass
- Bad responses now allow immediate retry; good responses still cached for rate-limit protection

## Test plan

- [x] All 133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced price data validation to occur before caching. Only valid price responses meeting liquidity and validity requirements are now cached, preventing invalid price data from being served during the cache period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->