### PR TITLE
fix: per-slab single-source counter, per-scan ADL errors (M8+M14)

### DIFF
--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -438,6 +438,7 @@ export class AdlService {
 
     let sent = 0;
     let remainingExcess = excess;
+    let scanHadError = false;
 
     for (const pos of ranked) {
       if (sent >= ADL_MAX_TX_PER_SCAN) {
@@ -481,29 +482,25 @@ export class AdlService {
           targetIdx: pos.idx,
           error: errMsg,
         });
-
-        const state = this._getOrCreateState(slabAddress);
-        state.consecutiveErrors++;
-
-        if (state.consecutiveErrors >= 3) {
-          await sendWarningAlert("ADL consecutive failures", [
-            { name: "Market", value: slabAddress.slice(0, 12), inline: true },
-            {
-              name: "Consecutive Errors",
-              value: state.consecutiveErrors.toString(),
-              inline: true,
-            },
-            { name: "Error", value: errMsg.slice(0, 100), inline: false },
-          ]).catch(() => {});
-        }
+        scanHadError = true;
         // Continue to next position — one failure shouldn't abort the whole run.
       }
     }
 
+    // M14: Track errors at scan level, not per-position. The counter means
+    // "consecutive scans with zero successes" rather than individual tx failures.
+    const state = this._getOrCreateState(slabAddress);
     if (sent > 0) {
-      const state = this._getOrCreateState(slabAddress);
       state.adlTxSent += sent;
       state.consecutiveErrors = 0;
+    } else if (scanHadError) {
+      state.consecutiveErrors++;
+      if (state.consecutiveErrors >= 3) {
+        await sendWarningAlert("ADL consecutive scan failures", [
+          { name: "Market", value: slabAddress.slice(0, 12), inline: true },
+          { name: "Consecutive Failed Scans", value: state.consecutiveErrors.toString(), inline: true },
+        ]).catch(() => {});
+      }
     }
 
     return sent;

--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -63,9 +63,9 @@ export class OracleService {
   private readonly maxTrackedMarkets = 500;
   // BM2: Deduplicate concurrent requests for the same mint
   private inFlightRequests = new Map<string, Promise<bigint | null>>();
-  // Track consecutive single-source fetches to detect degraded cross-validation
-  private _consecutiveSingleSource = 0;
-  private _singleSourceAlertSent = false;
+  // M8: Track consecutive single-source fetches per slab (not global)
+  private _consecutiveSingleSource = new Map<string, number>();
+  private _singleSourceAlertSent = new Set<string>();
   private static readonly SINGLE_SOURCE_ALERT_THRESHOLD = 10;
   // M-4: Track when an external source (DexScreener or Jupiter) last returned a
   // valid price for each slab. Used to cap the on-chain fallback duration so that
@@ -223,34 +223,41 @@ export class OracleService {
       }
     }
 
-    // Track cross-validation coverage: alert when single-source mode persists
+    // M8: Track cross-validation coverage per slab, not globally.
+    // A global counter was reset by any market getting dual-source,
+    // masking degradation for markets stuck on single-source.
     const bothAvailable = dexPrice !== null && jupPrice !== null;
     if (bothAvailable) {
-      if (this._consecutiveSingleSource > 0) {
+      const prev = this._consecutiveSingleSource.get(slabAddress) ?? 0;
+      if (prev > 0) {
         logger.info("Cross-source validation restored", {
-          previousSingleSourceCount: this._consecutiveSingleSource,
+          slabAddress,
+          previousSingleSourceCount: prev,
         });
       }
-      this._consecutiveSingleSource = 0;
-      this._singleSourceAlertSent = false;
+      this._consecutiveSingleSource.set(slabAddress, 0);
+      this._singleSourceAlertSent.delete(slabAddress);
     } else if (dexPrice !== null || jupPrice !== null) {
-      this._consecutiveSingleSource++;
+      const count = (this._consecutiveSingleSource.get(slabAddress) ?? 0) + 1;
+      this._consecutiveSingleSource.set(slabAddress, count);
       const degradedSource = dexPrice !== null ? "dexscreener" : "jupiter";
       const downSource = dexPrice !== null ? "jupiter" : "dexscreener";
       if (
-        this._consecutiveSingleSource >= OracleService.SINGLE_SOURCE_ALERT_THRESHOLD &&
-        !this._singleSourceAlertSent
+        count >= OracleService.SINGLE_SOURCE_ALERT_THRESHOLD &&
+        !this._singleSourceAlertSent.has(slabAddress)
       ) {
-        this._singleSourceAlertSent = true;
+        this._singleSourceAlertSent.add(slabAddress);
         logger.warn("Cross-source validation degraded — operating on single source", {
-          consecutiveSingleSource: this._consecutiveSingleSource,
+          slabAddress,
+          consecutiveSingleSource: count,
           activeSource: degradedSource,
           downSource,
         });
         sendWarningAlert("Oracle cross-validation degraded", [
+          { name: "Market", value: slabAddress.slice(0, 12), inline: true },
           { name: "Active Source", value: degradedSource, inline: true },
           { name: "Down Source", value: downSource, inline: true },
-          { name: "Consecutive", value: String(this._consecutiveSingleSource), inline: true },
+          { name: "Consecutive", value: String(count), inline: true },
         ])?.catch(() => {});
       }
     }


### PR DESCRIPTION
## Summary

**M8 — Oracle single-source counter was global:**
- `_consecutiveSingleSource` was a scalar shared across all markets
- Any dual-source market reset the counter, masking degradation for single-source markets
- Now a per-slab `Map` — each market tracks its own cross-validation coverage independently
- Alert includes the affected market slab address for targeted debugging

**M14 — ADL errors counted per-position instead of per-scan:**
- `consecutiveErrors` was incremented for each individual position tx failure inside the loop
- 3 failed positions in one cycle fired the alert meant for 3 consecutive failed *scan cycles*
- Now uses a `scanHadError` flag — counter increments once per failed scan, not per position
- Reset only when a scan has at least one successful send

## Test plan

- [x] All 133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)