### PR TITLE
fix: cache oracle keypair, remove dead replay code, fix pnlPct (L1+L2+L7)

### DIFF
--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -465,7 +465,7 @@ export class AdlService {
         logger.info("ADL tx sent", {
           slabAddress,
           targetIdx: pos.idx,
-          pnlPct: (Number(pos.pnlPct) / 1_000_000).toFixed(4) + "%",
+          pnlPct: (Number(pos.pnlPct) / 10_000).toFixed(2) + "%",
           sig,
         });
 

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -122,9 +122,6 @@ export class CrankService {
   private readonly oracleService: OracleService;
   private lastCycleResult = { success: 0, failed: 0, skipped: 0 };
   private lastDiscoveryTime = 0;
-  // BC1: Signature replay protection
-  private recentSignatures = new Map<string, number>(); // signature -> timestamp
-  private readonly signatureTTLMs = 60_000; // 60 seconds
   private _isRunning = false;
   private _cycling = false;
   private _cycleStartedAt = 0;
@@ -659,9 +656,6 @@ export class CrankService {
       // PERC-204: Use keeper-optimized send (skipPreflight + multi-RPC + tight CU)
       const sig = await sendWithRetryKeeper(connection, instructions, [keypair]);
 
-      // BC1: Track signature to prevent replay attacks
-      this.recentSignatures.set(sig, Date.now());
-
       state.lastCrankTime = Date.now();
       state.successCount++;
       state.consecutiveFailures = 0;
@@ -887,12 +881,6 @@ export class CrankService {
       for (const [slab, error] of batchResult.errors) {
         logger.error("Batch error detail", { slabAddress: slab, error: error.message });
       }
-    }
-
-    // P2 FIX: Clean up stale signatures every cycle (was only on success path)
-    const now = Date.now();
-    for (const [oldSig, ts] of this.recentSignatures.entries()) {
-      if (now - ts > this.signatureTTLMs) this.recentSignatures.delete(oldSig);
     }
 
     // P0 FIX: Always log cycle result with skip breakdown. Previously only logged

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -158,9 +158,6 @@ export class LiquidationService {
   // Overlap guard: prevent concurrent scan cycles from interleaving
   private _scanning = false;
   private _scanStartedAt = 0;
-  // BC1: Signature replay protection
-  private recentSignatures = new Map<string, number>(); // signature -> timestamp
-  private readonly signatureTTLMs = 60_000; // 60 seconds
   // PERC-134: Exponential backoff on consecutive scan failures
   private consecutiveFailures = 0;
   private readonly maxBackoffMs = 300_000; // 5 minutes max backoff
@@ -452,16 +449,6 @@ export class LiquidationService {
       //   - Multi-RPC parallel broadcast (+20-40% landing rate)
       //   - Simulation-based tight CU limit (better queue position)
       const sig = await sendWithRetryKeeper(connection, instructions, [keypair], 3);
-
-      // BC1: Track signature to prevent replay attacks
-      const now = Date.now();
-      this.recentSignatures.set(sig, now);
-      // Clean up signatures older than TTL
-      for (const [oldSig, timestamp] of this.recentSignatures.entries()) {
-        if (now - timestamp > this.signatureTTLMs) {
-          this.recentSignatures.delete(oldSig);
-        }
-      }
 
       this.liquidationCount++;
       eventBus.publish("liquidation.success", slabAddress.toBase58(), {

--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -55,6 +55,8 @@ interface JupiterResponse {
 }
 
 export class OracleService {
+  // L1: Cache keypair at construction — was re-parsing from env on every pushPrice call
+  private readonly _keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
   private priceHistory = new Map<string, PriceEntry[]>();
   private lastPushTime = new Map<string, number>();
   private _nonAuthorityLogged = new Set<string>();
@@ -380,7 +382,7 @@ export class OracleService {
 
     try {
       const connection = getConnection();
-      const keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
+      const keypair = this._keypair;
       const slabPubkey = new PublicKey(slabAddress);
       const programId = marketProgramId ?? new PublicKey(config.programId);
 


### PR DESCRIPTION
## Summary

Three low-severity cleanups:

**L1 — Oracle keypair not cached:**
- `loadKeypair()` called on every `pushPrice()` invocation, re-parsing from env/disk each cycle
- Now cached as `private readonly _keypair` at construction, matching all other services

**L2 — Dead signature replay tracking:**
- `recentSignatures` Maps in CrankService and LiquidationService were written to but **never read**
- No `.has()` or `.get()` calls existed — the "BC1: Signature replay protection" was dead code
- Removed Maps, TTL constants, `.set()` calls, and cleanup loops from both services
- Solana's runtime already prevents signature replay at the protocol level

**L7 — ADL pnlPct display off by 100x:**
- Divided by 1,000,000 then appended `%`, showing 30% as "0.3000%"
- Now divides by 10,000 to correctly display as "30.00%"

## Test plan

- [x] All 133 tests pass
- [x] Net -23 lines of dead code removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated PNL percentage display format for improved readability.

* **Refactor**
  * Streamlined transaction signature handling mechanisms across services.
  * Optimized keypair initialization to enhance efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->