### PR TITLE
fix: correct oracle account derivation in liquidate() (N1)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -358,11 +358,18 @@ export class LiquidationService {
       // Build multi-instruction tx: push price → crank → liquidate
       const instructions = [];
 
-      // Determine oracle account for crank/liquidate
-      const feedIdBytes = market.config.indexFeedId.toBytes();
-      const feedHex = Array.from(feedIdBytes).map(b => b.toString(16).padStart(2, "0")).join("");
-      const isAllZeros = feedHex === "0".repeat(64);
-      const oracleAccount = isAllZeros ? slabAddress : derivePythPushOraclePDA(feedHex)[0];
+      // N1: Determine oracle account using detectOracleMode to match crank/ADL logic.
+      // Admin-oracle markets use slabAddress regardless of indexFeedId; only
+      // pyth-pinned markets derive a Pyth PDA from the feed ID.
+      const oracleMode = detectOracleMode(market.config);
+      let oracleAccount: PublicKey;
+      if (oracleMode === "pyth-pinned") {
+        const feedHex = Array.from(market.config.indexFeedId.toBytes())
+          .map(b => b.toString(16).padStart(2, "0")).join("");
+        oracleAccount = derivePythPushOraclePDA(feedHex)[0];
+      } else {
+        oracleAccount = slabAddress;
+      }
 
       // 1. Push oracle price only if crank wallet IS the oracle authority
       // (user-owned oracle markets skip the push — user pushes manually)


### PR DESCRIPTION
## Summary

The `liquidate()` oracle account derivation only checked if `indexFeedId` was all-zeros, ignoring `oracleAuthority`. For **admin-oracle markets with a non-zero indexFeedId**, it derived a Pyth PDA instead of the slab address — causing the on-chain program to reject the transaction with `OracleInvalid (0xc)`.

This meant **liquidations silently failed** for these markets. Undercollateralized positions went unliquidated.

Both `crankMarket()` and ADL `scanMarket()` correctly check `oracleAuthority` first.

## Fix

Use the existing `detectOracleMode()` helper (already in the file, used by `scanMarket()`) to derive the oracle account:

| Mode | Oracle Account |
|------|---------------|
| admin | `slabAddress` (regardless of indexFeedId) |
| hyperp | `slabAddress` |
| pyth-pinned | `derivePythPushOraclePDA(feedHex)` |

## Test plan

- [x] All 133 tests pass
- [x] Logic now matches crank.ts and adl.ts oracle derivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)