### PR TITLE
fix: don't count transient RPC errors toward market deactivation (N2)

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -675,10 +675,27 @@ export class CrankService {
       eventBus.publish("crank.success", slabAddress, { signature: sig });
       return true;
     } catch (err) {
-      state.failureCount++;
-      state.consecutiveFailures++;
-
       const errMsg = err instanceof Error ? err.message : String(err);
+      const errLower = errMsg.toLowerCase();
+
+      // N2: Classify transient RPC/network errors — these should not count toward
+      // the consecutiveFailures threshold that deactivates markets. A burst of 429s
+      // during RPC congestion should not disable a healthy market.
+      const isTransient = errLower.includes("429") || errLower.includes("too many requests")
+        || errLower.includes("rate limit") || errLower.includes("timeout")
+        || errLower.includes("socket") || errLower.includes("econnrefused")
+        || errLower.includes("econnreset") || errLower.includes("502")
+        || errLower.includes("503") || errLower.includes("block height exceeded");
+
+      state.failureCount++;
+      if (!isTransient) {
+        state.consecutiveFailures++;
+      } else {
+        logger.warn("Crank transient error — not counting toward deactivation", {
+          slabAddress, error: errMsg.slice(0, 120),
+          consecutiveFailures: state.consecutiveFailures,
+        });
+      }
 
       // P1 FIX: Detect InsufficientDexLiquidity (error 0x25 = 37) specifically.
       // This is a permanent program-level rejection — the DEX pool doesn't meet the


### PR DESCRIPTION
## Summary

- `crankMarket()` catch block incremented `consecutiveFailures` for **all** errors, including transient RPC errors (429, timeout, socket reset, 502/503)
- After 10 consecutive transient errors (common during RPC provider hiccups), a **healthy market was deactivated** until the next discovery cycle (5 min)
- Now classifies errors: transient RPC/network errors are logged but do NOT count toward deactivation
- Only deterministic program-level errors increment `consecutiveFailures`

## Transient error patterns detected

`429`, `too many requests`, `rate limit`, `timeout`, `socket`, `econnrefused`, `econnreset`, `502`, `503`, `block height exceeded`

## Test plan

- [x] All 133 tests pass
- [x] Matches the transient error classification already used by `liquidation.ts` `fetchSlabWithRetry()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)