### PR TITLE
fix: remove watchdog force-reset to prevent concurrent cycle overlap (N3)

### DIFF
--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -554,15 +554,17 @@ export class AdlService {
       if (this._cycling) {
         const elapsed = Date.now() - this._cycleStartedAt;
         if (elapsed > MAX_CYCLE_MS) {
-          logger.error("ADL cycle watchdog: cycle exceeded max duration, force-resetting", {
+          logger.error("ADL cycle watchdog: cycle exceeded max duration — waiting for natural completion", {
             elapsedMs: elapsed,
             maxCycleMs: MAX_CYCLE_MS,
           });
-          sendWarningAlert("ADL cycle hung — watchdog reset", [
+          sendWarningAlert("ADL cycle hung — exceeded max duration", [
             { name: "Elapsed", value: `${Math.round(elapsed / 1000)}s`, inline: true },
             { name: "Max", value: `${Math.round(MAX_CYCLE_MS / 1000)}s`, inline: true },
           ])?.catch(() => {});
-          this._cycling = false;
+          // N3: Do NOT reset _cycling — the old cycle will finish via RPC timeouts.
+          // Resetting would allow a concurrent cycle, causing duplicate ADL txs
+          // and state corruption from two async operations mutating shared maps.
         }
         return;
       }

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -1027,15 +1027,17 @@ export class CrankService {
       if (this._cycling) {
         const elapsed = Date.now() - this._cycleStartedAt;
         if (elapsed > MAX_CYCLE_MS) {
-          logger.error("Crank cycle watchdog: cycle exceeded max duration, force-resetting", {
+          logger.error("Crank cycle watchdog: cycle exceeded max duration — waiting for natural completion", {
             elapsedMs: elapsed,
             maxCycleMs: MAX_CYCLE_MS,
           });
-          sendCriticalAlert("Crank cycle hung — watchdog reset", [
+          sendCriticalAlert("Crank cycle hung — exceeded max duration", [
             { name: "Elapsed", value: `${Math.round(elapsed / 1000)}s`, inline: true },
             { name: "Max", value: `${Math.round(MAX_CYCLE_MS / 1000)}s`, inline: true },
           ])?.catch(() => {});
-          this._cycling = false;
+          // N3: Do NOT reset _cycling — the old cycle will finish via RPC timeouts.
+          // Resetting would allow a concurrent cycle, causing duplicate transactions
+          // and state corruption from two async operations mutating shared maps.
         }
         return;
       }

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -597,11 +597,13 @@ export class LiquidationService {
       if (this._scanning) {
         const elapsed = Date.now() - this._scanStartedAt;
         if (elapsed > MAX_SCAN_MS) {
-          logger.error("Liquidation scan watchdog: cycle exceeded max duration, force-resetting", {
+          logger.error("Liquidation scan watchdog: cycle exceeded max duration — waiting for natural completion", {
             elapsedMs: elapsed,
             maxScanMs: MAX_SCAN_MS,
           });
-          this._scanning = false;
+          // N3: Do NOT reset _scanning — the old cycle will finish via RPC timeouts.
+          // Resetting would allow a concurrent cycle, causing duplicate liquidations
+          // and state corruption from two async operations mutating shared counters.
         }
         return;
       }

--- a/tests/services/adl.test.ts
+++ b/tests/services/adl.test.ts
@@ -320,24 +320,24 @@ describe("AdlService", () => {
       vi.useRealTimers();
     });
 
-    it("resets _cycling flag when cycle exceeds MAX_CYCLE_MS (5x interval)", async () => {
+    it("logs alert but does NOT reset _cycling when cycle exceeds MAX_CYCLE_MS (N3)", async () => {
       // Setup: start the service with a market source
       const markets = new Map();
       service.start(() => markets);
 
       // Simulate a stuck cycle: manually set _cycling=true with an old timestamp
-      // Access internal state for testing
       (service as any)._cycling = true;
       (service as any)._cycleStartedAt = Date.now() - 60_000; // 60s ago (> 5 * 10s default)
 
       // Advance timer to trigger the next interval tick
       await vi.advanceTimersByTimeAsync(10_001);
 
-      // The watchdog should have reset _cycling to false
-      expect((service as any)._cycling).toBe(false);
-      // Should have sent a warning alert about the hung cycle
+      // N3: The watchdog should NOT reset _cycling — resetting would allow
+      // concurrent cycles. The old cycle finishes naturally via RPC timeouts.
+      expect((service as any)._cycling).toBe(true);
+      // Should still send a warning alert about the hung cycle
       expect(shared.sendWarningAlert).toHaveBeenCalledWith(
-        "ADL cycle hung — watchdog reset",
+        "ADL cycle hung — exceeded max duration",
         expect.any(Array),
       );
     });


### PR DESCRIPTION
## Summary

All three service watchdogs detected hung cycles by resetting the `_cycling`/`_scanning` flag. But the old async operation **continued running** — it was never cancelled. The next interval tick started a **new** cycle, so two cycles ran concurrently:

- **Duplicate transactions** sent to the same markets (wasted SOL)
- **State corruption** from two async operations mutating shared Maps/counters
- The old cycle's `finally` block eventually cleared the flag mid-way through a newer cycle, potentially enabling a **third** concurrent cycle

## Fix

Remove `this._cycling = false` / `this._scanning = false` from all three watchdog branches. The watchdog now **logs + alerts** but does NOT reset the flag. Cycles finish naturally via RPC timeouts (15s per call via `withTimeout`).

**Affected services:**
- `CrankService` — `crank.ts`
- `LiquidationService` — `liquidation.ts`
- `AdlService` — `adl.ts`

## Test plan

- [x] All 133 tests pass
- [x] Updated ADL watchdog test to expect `_cycling = true` (flag preserved) while still verifying alert is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)