### PR TITLE
fix: add minimum notional threshold for liquidation profitability (N4)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -79,6 +79,13 @@ async function fetchSlabWithRetry(
 const PRICE_E6_DIVISOR = 1_000_000n; // Price precision divisor (6 decimals)
 const BPS_MULTIPLIER = 10_000n; // Basis points multiplier (100% = 10000 bps)
 
+// N4: Minimum notional value (in collateral token base units) below which
+// liquidation is skipped — tx cost exceeds the reward for dust positions.
+// Default 0 = no filter (preserve existing behavior). Override via env var.
+const MIN_LIQUIDATION_NOTIONAL = BigInt(
+  process.env.MIN_LIQUIDATION_NOTIONAL ?? "0"
+);
+
 /**
  * Oracle mode for a market.
  * - 'pyth-pinned': oracle_authority == [0;32] && index_feed_id != [0;32]
@@ -247,6 +254,8 @@ export class LiquidationService {
           // On-chain pnl is only updated during cranks; between cranks it can be stale
           const notional = absBI(account.positionSize) * price / PRICE_E6_DIVISOR;
           if (notional === 0n) continue;
+          // N4: Skip dust positions where liquidation tx cost exceeds reward
+          if (MIN_LIQUIDATION_NOTIONAL > 0n && notional < MIN_LIQUIDATION_NOTIONAL) continue;
 
           // Compute mark PnL from live price instead of stale on-chain pnl
           const entryPrice = account.entryPrice;


### PR DESCRIPTION
## Summary

- The keeper executed **all** liquidations regardless of position size
- Dust positions where the liquidation reward < transaction cost drained the keeper wallet
- Each liquidation is a 3-instruction tx (push oracle + crank + liquidate) costing SOL fees

## Fix

Add configurable `MIN_LIQUIDATION_NOTIONAL` env var. Positions with notional below the threshold are skipped in `scanMarket()` — before the expensive PnL/margin calculation and slab re-fetch.

- **Default:** `0` (no filter, preserves existing behavior)
- **Recommended:** Set based on collateral token value and priority fees
- **Example:** `MIN_LIQUIDATION_NOTIONAL=10000000` for a ~0.01 SOL floor

Filter is placed at the earliest possible point (right after notional is computed, line 256) to avoid wasted work on dust positions.

## Test plan

- [x] All 133 tests pass
- [x] Default of 0 is non-breaking — existing behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable minimum liquidation threshold to filter out liquidation candidates below a specified notional value, with an option to disable filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->