### PR TITLE
fix: add logging to silent oracle price fetch error paths (N5)

### DIFF
--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -120,8 +120,11 @@ export class OracleService {
       });
       clearTimeout(timeoutId);
 
-      if (!res.ok) return null;
-      
+      if (!res.ok) {
+        logger.warn("DexScreener API returned non-OK status", { mint, status: res.status });
+        return null;
+      }
+
       const json = (await res.json()) as DexScreenerResponse;
       // BH7: Use captured timestamp for atomicity.
       // Delete before set so refreshed entries move to the end of Map
@@ -141,7 +144,8 @@ export class OracleService {
       const parsed = parseFloat(pair.priceUsd);
       if (!isFinite(parsed) || parsed <= 0) return null;
       return BigInt(Math.round(parsed * PRICE_E6_MULTIPLIER));
-    } catch {
+    } catch (err) {
+      logger.debug("DexScreener fetch failed", { mint, error: err instanceof Error ? err.message : String(err) });
       return null;
     }
   }
@@ -175,15 +179,19 @@ export class OracleService {
       });
       clearTimeout(timeoutId);
 
-      if (!res.ok) return null;
-      
+      if (!res.ok) {
+        logger.warn("Jupiter API returned non-OK status", { mint, status: res.status });
+        return null;
+      }
+
       const json = (await res.json()) as JupiterResponse;
       const priceStr = json.data?.[mint]?.price;
       if (!priceStr) return null;
       const parsed = parseFloat(priceStr);
       if (!isFinite(parsed) || parsed <= 0) return null;
       return BigInt(Math.round(parsed * PRICE_E6_MULTIPLIER));
-    } catch {
+    } catch (err) {
+      logger.debug("Jupiter fetch failed", { mint, error: err instanceof Error ? err.message : String(err) });
       return null;
     }
   }


### PR DESCRIPTION
## Summary

- Both DexScreener and Jupiter fetchers had bare `catch { return null }` blocks — **zero logging**
- Non-OK HTTP responses (429, 500) were also silently discarded
- Both price sources could be completely down with no operator-visible signal

## Fix

| Location | Log Level | Rationale |
|----------|-----------|-----------|
| DexScreener HTTP error (line 123) | `warn` | 429/500 = API degradation, operationally noteworthy |
| DexScreener catch (line 144) | `debug` | Network errors are frequent/noisy, available for debugging |
| Jupiter HTTP error (line 178) | `warn` | Same as DexScreener |
| Jupiter catch (line 186) | `debug` | Same as DexScreener |

## Test plan

- [x] All 133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)