### PR TITLE
fix: log account parse failures in liquidation scanner (N6)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -303,8 +303,12 @@ export class LiquidationService {
               maintenanceMarginBps,
             });
           }
-        } catch {
-          // Skip accounts that fail to parse
+        } catch (err) {
+          // N6: Log parse failures — a silent skip could hide systematic issues
+          logger.debug("Failed to parse account at index", {
+            slabAddress, accountIndex: i,
+            error: err instanceof Error ? err.message : String(err),
+          });
           continue;
         }
       }


### PR DESCRIPTION
## Summary

- Liquidation scanner had bare `catch { continue }` in the account iteration loop (line 306)
- Accounts failing to parse were silently skipped — no log, no diagnostic trail
- A systematic issue (SDK schema change, corrupt slab) would silently skip ALL accounts

## Fix

Add `logger.debug` with slab address, account index, and error message. Debug level keeps production logs clean while providing diagnostic info when investigating missed liquidations.

## Test plan

- [x] All 133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)