### PR TITLE
fix: wire captureException into critical error handlers (N7)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -497,6 +497,7 @@ async function start() {
 }
 
 start().catch((err) => {
+  captureException(err instanceof Error ? err : new Error(String(err)));
   logger.error("Failed to start keeper", { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined });
   // Don't exit — keep the process alive for healthcheck + retry
   logger.info("Keeper will stay alive for healthcheck despite startup error");
@@ -565,6 +566,9 @@ process.on("SIGINT", () => shutdown("SIGINT"));
 // and retry on the next interval. Without these handlers, Node.js 15+ exits on
 // unhandled rejections by default, causing the crash-loop seen in Railway logs.
 process.on("unhandledRejection", (reason, promise) => {
+  // N7: Report to Sentry before logging — ensures Sentry gets the error
+  // even if the logger itself throws.
+  captureException(reason instanceof Error ? reason : new Error(String(reason)));
   logger.error("Unhandled promise rejection — keeping process alive", {
     reason: reason instanceof Error ? reason.message : String(reason),
     stack: reason instanceof Error ? reason.stack : undefined,
@@ -572,6 +576,7 @@ process.on("unhandledRejection", (reason, promise) => {
 });
 
 process.on("uncaughtException", (err) => {
+  captureException(err);
   logger.error("Uncaught exception — keeping process alive", {
     error: err.message,
     stack: err.stack,


### PR DESCRIPTION
## Summary

- `captureException` was imported from `@percolator/shared` but **never called** anywhere in `src/`
- `initSentry("keeper")` initialized Sentry, but zero exceptions were ever reported
- The Sentry integration was effectively dead for the most critical class of errors

## Fix

Add `captureException` calls to three critical error paths:

| Handler | Location | Why |
|---------|----------|-----|
| `unhandledRejection` | `index.ts:567` | Process-level safety net — errors that escaped all try/catch blocks |
| `uncaughtException` | `index.ts:574` | Fatal errors — process is in undefined state |
| `start().catch()` | `index.ts:499` | Startup failure — keeper couldn't start |

Called **before** `logger.error` so Sentry gets the error even if the logger throws.

## Test plan

- [x] All 133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)