### PR TITLE
fix: extract error message and stack in crank cycle catch (N12)

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -1059,7 +1059,7 @@ export class CrankService {
         }
         }
       } catch (err) {
-        logger.error("Crank cycle failed", { error: err });
+        logger.error("Crank cycle failed", { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined });
       } finally {
         this._cycling = false;
       }


### PR DESCRIPTION
## Summary

- Crank cycle top-level catch logged `{ error: err }` — the raw error object
- Structured loggers serialize `Error` as `{}` or `[object Object]`, losing message and stack
- This is the outermost catch for the entire crank cycle — critical diagnostic info was lost

## Fix

One-line change: extract `err.message` and `err.stack` matching the pattern used everywhere else:

\`\`\`typescript
// Before
logger.error("Crank cycle failed", { error: err });

// After
logger.error("Crank cycle failed", { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined });
\`\`\`

## Test plan

- [x] All 133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)