### PR TITLE
chore: pin SDK to exact 2.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@percolatorct/sdk": "^2.0.9",
+    "@percolatorct/sdk": "2.0.9",
     "@percolatorct/shared": "1.0.0-beta.8",
     "@solana/web3.js": "^1.98.0",
     "dotenv": "^16.4.7"


### PR DESCRIPTION
Prevents accidental pull of a sync-era SDK that would mismatch deployed v12.19.1 mainnet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned a dependency version to a specific release for improved stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-keeper/pull/109)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->