### PR TITLE
fix(keeper): require explicit ADL_ENABLED on mainnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,12 @@ KEEPER_HEALTH_PORT=8081
 # Shared secret for /register endpoint (optional)
 # KEEPER_REGISTER_SECRET=
 
-# ADL service (disabled by default — requires on-chain T8+T10)
-# ADL_ENABLED=true
+# ADL service
+# REQUIRED on mainnet — must be "true" or "false" (no default).
+# Optional on devnet/testnet (defaults to disabled).
+# Set ADL_ENABLED=true to enable Auto-Deleveraging on mainnet (recommended).
+# Set ADL_ENABLED=false ONLY to deliberately disable the insurance-fund safety mechanism.
+ADL_ENABLED=false
 # ADL_INTERVAL_MS=10000
 # ADL_MAX_TX_PER_SCAN=10
 # ADL_INSURANCE_THRESHOLD_LAMPORTS=0

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker run --env-file .env percolator-keeper
 | `SENTRY_DSN` | ❌ | Sentry error tracking DSN |
 | `KEEPER_HEALTH_PORT` | ❌ | Health check port (default: 8081) |
 | `KEEPER_REGISTER_SECRET` | ❌ | Shared secret for `/register` endpoint |
-| `ADL_ENABLED` | ❌ | Set to `true` to enable ADL service |
+| `ADL_ENABLED` | ✅ on mainnet | Must be `true` or `false` when `NETWORK=mainnet` (no default — guards against silent disable of the insurance-fund safety mechanism). Optional on devnet/testnet, defaults to disabled. |
 
 ## License
 

--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -53,4 +53,23 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
       );
     }
   }
+
+  // K-3 (HIGH): ADL_ENABLED must be set explicitly on mainnet.
+  // Auto-Deleveraging protects the protocol when the insurance fund cannot
+  // cover losses. The legacy default-off behaviour means an operator who
+  // forgets to set the var on a mainnet Railway deploy ships a keeper that
+  // will never send ExecuteAdl, leaving the protocol unprotected. Require
+  // an explicit "true" or "false" on mainnet; devnet keeps the legacy
+  // permissive default so local/CI workflows are unaffected.
+  if (env.NETWORK?.trim().toLowerCase() === "mainnet") {
+    const adl = env.ADL_ENABLED?.trim().toLowerCase();
+    if (adl !== "true" && adl !== "false") {
+      throw new Error(
+        "SECURITY: ADL_ENABLED must be explicitly set to \"true\" or \"false\" " +
+        `when NETWORK=mainnet (got ${JSON.stringify(env.ADL_ENABLED)}). ` +
+        "Set ADL_ENABLED=true to enable Auto-Deleveraging (recommended on mainnet), " +
+        "or ADL_ENABLED=false to acknowledge the insurance-fund risk explicitly."
+      );
+    }
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,12 +44,22 @@ const crankService = new CrankService(oracleService);
 const liquidationService = new LiquidationService(oracleService);
 const monitorService = new MonitorService();
 
-// ADL service — gated by ADL_ENABLED=true env var until on-chain instruction
-// (PERC-8273 T8) is live and T10 devnet upgrade is done (PERC-8275).
-const adlEnabled = process.env.ADL_ENABLED === "true";
+// ADL service — gated by ADL_ENABLED env var. On mainnet the value must be
+// set explicitly to "true" or "false" (enforced by validateKeeperEnvGuards
+// K-3). On devnet/testnet a missing var defaults to disabled for back-compat
+// with the original T8/T10 rollout flow (see PERC-8273 / PERC-8275).
+const adlEnabled = process.env.ADL_ENABLED?.trim().toLowerCase() === "true";
 const adlService = adlEnabled ? new AdlService() : null;
 if (adlEnabled) {
   logger.info("ADL service enabled (ADL_ENABLED=true)");
+} else if (isMainnet()) {
+  // Mainnet + explicit ADL_ENABLED=false: operator deliberately disabled the
+  // insurance-fund safety mechanism. Page ops loudly so this is never silent.
+  logger.warn("ADL service DISABLED on mainnet — insurance fund will not trigger ExecuteAdl");
+  sendCriticalAlert("Keeper booted on mainnet with ADL_ENABLED=false", [
+    { name: "Effect", value: "Insurance-fund shortfalls will NOT trigger ExecuteAdl", inline: false },
+    { name: "Remediation", value: "Set ADL_ENABLED=true unless this was intentional", inline: false },
+  ]).catch(() => {});
 } else {
   logger.info("ADL service disabled — set ADL_ENABLED=true to enable (requires T8+T10)");
 }

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -95,4 +95,77 @@ describe("validateKeeperEnvGuards", () => {
 
     expect(() => validateKeeperEnvGuards(env)).not.toThrow();
   });
+
+  // K-3 (HIGH): ADL_ENABLED must be explicit on mainnet so an operator who
+  // forgets the var cannot silently ship a keeper with the insurance-fund
+  // safety mechanism disabled.
+  it("throws when NETWORK=mainnet and ADL_ENABLED is unset", () => {
+    const env = {
+      NETWORK: "mainnet",
+      SOLANA_RPC_URL: "https://api.mainnet-beta.solana.com",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).toThrow(
+      "ADL_ENABLED must be explicitly set"
+    );
+  });
+
+  it("throws when NETWORK=mainnet and ADL_ENABLED is a non-boolean value", () => {
+    const env = {
+      NETWORK: "mainnet",
+      ADL_ENABLED: "1",
+      SOLANA_RPC_URL: "https://api.mainnet-beta.solana.com",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).toThrow(
+      "ADL_ENABLED must be explicitly set"
+    );
+  });
+
+  it("does not throw when NETWORK=mainnet and ADL_ENABLED=true", () => {
+    const env = {
+      NETWORK: "mainnet",
+      ADL_ENABLED: "true",
+      SOLANA_RPC_URL: "https://api.mainnet-beta.solana.com",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
+
+  it("does not throw when NETWORK=mainnet and ADL_ENABLED=false", () => {
+    const env = {
+      NETWORK: "mainnet",
+      ADL_ENABLED: "false",
+      SOLANA_RPC_URL: "https://api.mainnet-beta.solana.com",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
+
+  it("normalizes ADL_ENABLED case and whitespace on mainnet", () => {
+    const env = {
+      NETWORK: "mainnet",
+      ADL_ENABLED: "  True  ",
+      SOLANA_RPC_URL: "https://api.mainnet-beta.solana.com",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
+
+  it("does not require ADL_ENABLED on devnet", () => {
+    const env = {
+      NETWORK: "devnet",
+      SOLANA_RPC_URL: "https://api.devnet.solana.com",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
+
+  it("does not require ADL_ENABLED when NETWORK is unset", () => {
+    const env = {
+      SOLANA_RPC_URL: "https://api.devnet.solana.com",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

`ADL_ENABLED` was read with strict equality to `"true"` at [src/index.ts:49](src/index.ts#L49), so an unset or non-matching value silently disabled Auto-Deleveraging. An operator who forgot the var on a mainnet Railway deploy would ship a keeper that never sends `ExecuteAdl`, leaving the protocol exposed when the insurance fund cannot cover losses. The README also marked the var as optional with no mainnet warning.

This PR makes `ADL_ENABLED` a mainnet-required, explicit-only env var:

- New **K-3** rule in [src/env-guards.ts](src/env-guards.ts) — throws on boot when `NETWORK=mainnet` and `ADL_ENABLED` is not exactly `"true"` or `"false"` (after `.trim().toLowerCase()` normalization). Mirrors the existing K-2 SUPABASE pattern and runs before any service constructor.
- [src/index.ts](src/index.ts) — normalize parsing with `.trim().toLowerCase()`; when ADL is deliberately disabled on mainnet (`ADL_ENABLED=false`), fire `sendCriticalAlert` so the off state pages ops loudly instead of staying silent.
- Devnet and testnet keep the legacy permissive default, so existing local and CI workflows are unaffected.
- [README.md](README.md) and [.env.example](.env.example) updated to document the new requirement.

### Why not flip the default to `true` on mainnet
`AdlService.scanMarket` calls `encodeExecuteAdl` and `sendWithRetryKeeper` unconditionally — there is no on-chain feature-detect for the T8 instruction (PERC-8273) or the T10 devnet upgrade (PERC-8275). A silent default-on would make any operator pulling main start sending failed `ExecuteAdl` txs on chains where T8 has not landed, burning SOL and tripping the consecutive-failure watchdog. An explicit-required guard surfaces the decision without changing program semantics.

## Test plan

- [x] `pnpm test` passes (178 passed, 3 pre-existing skips)
- [x] `tests/env-guards.test.ts` covers: unset on mainnet (throws), invalid value on mainnet (throws), `"true"` on mainnet (passes), `"false"` on mainnet (passes), case/whitespace normalization (`"  True  "` passes), devnet permissive (no var → no throw), `NETWORK` unset (no throw)
- [x] `tsc` compiles clean
- [ ] Manual: deploy with `NETWORK=mainnet` and unset `ADL_ENABLED` — keeper must refuse to start with the K-3 error
- [ ] Manual: deploy with `NETWORK=mainnet ADL_ENABLED=false` — keeper must start and fire one Discord critical alert

## Notes

The related `notifyAdlTx` zero-callsite bug (the ADL staleness alarm in `src/services/monitor.ts:93` is never notified) is a separate defect with a distinct root cause and will be addressed in its own PR per the one-fix-per-PR convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment configuration and setup guides with clearer ADL (Auto-Deleveraging) requirements and network-specific behavior.

* **Improvements**
  * Enhanced validation of Auto-Deleveraging configuration on mainnet with stricter enforcement of explicit settings.
  * Added system alerts when Auto-Deleveraging is disabled on mainnet to ensure operators are aware of the insurance-fund implications.

* **Tests**
  * Expanded test coverage for configuration validation with mainnet-specific scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-keeper/pull/110)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->