### PR TITLE
fix(keeper): wire AdlService to notify MonitorService on landed tx

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,9 @@ crankService.setStalePauseCheck(isMarketStalePaused);
 
 // 6.2: Wire crank cycle counter into MonitorService so it can track ADL staleness
 crankService.setOnCrankCycle(() => monitorService.notifyCrankCycle());
+if (adlService) {
+  adlService.setOnAdlTx((slab) => monitorService.notifyAdlTx(slab));
+}
 
 // Subscribe to crank events to track health
 crankService.getMarkets().forEach((_, slabAddress) => {

--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -295,10 +295,19 @@ export class AdlService {
   // Cache keypair at construction — avoids re-parsing from env on every scanMarket() call
   private readonly _keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
   private _cycleStartedAt = 0;
+  // Optional observer fired after each successfully landed ExecuteAdl tx.
+  // Mirrors CrankService._onCrankCycle so MonitorService can be notified
+  // without AdlService taking a direct dependency on it.
+  private _onAdlTx?: (slabAddress: string) => void;
 
   /** Inject the crank service's market map so ADL can iterate tracked markets. */
   setMarketSource(fn: () => Map<string, MarketCrankState>): void {
     this._getMarkets = fn;
+  }
+
+  /** Register a callback fired after each landed ExecuteAdl tx. */
+  setOnAdlTx(fn: (slabAddress: string) => void): void {
+    this._onAdlTx = fn;
   }
 
   get isRunning(): boolean {
@@ -483,6 +492,7 @@ export class AdlService {
         });
 
         sent++;
+        this._onAdlTx?.(slabAddress);
         // Optimistic: reduce remaining excess by the position's PnL.
         // On next cycle we re-fetch fresh state anyway.
         remainingExcess =

--- a/tests/services/adl.test.ts
+++ b/tests/services/adl.test.ts
@@ -310,6 +310,60 @@ describe("AdlService", () => {
     });
   });
 
+  describe("scanMarket — setOnAdlTx callback", () => {
+    beforeEach(() => {
+      service = new AdlService();
+      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+      vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 2_000_000n }) as any);
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
+    });
+
+    it("fires the callback with slabAddress for each landed ADL tx", async () => {
+      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+        makeAccounts([
+          { idx: 1, pnl: 900_000n, capital: 1_000_000n, positionSize: 100n },
+          { idx: 2, pnl: 600_000n, capital: 1_000_000n, positionSize: 100n },
+        ]) as any
+      );
+      const onAdlTx = vi.fn();
+      service.setOnAdlTx(onAdlTx);
+
+      const result = await service.scanMarket(slabAddress, makeMarket() as any);
+
+      expect(result).toBe(2);
+      expect(onAdlTx).toHaveBeenCalledTimes(2);
+      expect(onAdlTx).toHaveBeenNthCalledWith(1, slabAddress);
+      expect(onAdlTx).toHaveBeenNthCalledWith(2, slabAddress);
+    });
+
+    it("does not fire the callback when the tx fails", async () => {
+      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+        makeAccounts([
+          { idx: 1, pnl: 900_000n, capital: 1_000_000n, positionSize: 100n },
+        ]) as any
+      );
+      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValueOnce(new Error("tx failed"));
+      const onAdlTx = vi.fn();
+      service.setOnAdlTx(onAdlTx);
+
+      const result = await service.scanMarket(slabAddress, makeMarket() as any);
+
+      expect(result).toBe(0);
+      expect(onAdlTx).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when no callback is registered (back-compat)", async () => {
+      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+        makeAccounts([
+          { idx: 1, pnl: 900_000n, capital: 1_000_000n, positionSize: 100n },
+        ]) as any
+      );
+
+      const result = await service.scanMarket(slabAddress, makeMarket() as any);
+      expect(result).toBe(1);
+    });
+  });
+
   describe("watchdog timer — cycling guard", () => {
     beforeEach(() => {
       vi.useFakeTimers();


### PR DESCRIPTION
## Summary

[MonitorService.notifyAdlTx](src/services/monitor.ts#L93) exists and is consumed by the ADL staleness alarm at [src/services/monitor.ts:218-256](src/services/monitor.ts#L218-L256), but a repo-wide grep finds **zero callsites** outside the definition. Because `cycleCountAtLastAdl` stays at its init value of `0` forever, `cyclesSinceLastAdl` equals `_totalCrankCycles` from the moment any market first needs ADL — the staleness alarm fires spuriously on healthy keepers and never resets even when `ExecuteAdl` is working correctly.

This PR wires the missing notification using the existing `CrankService.setOnCrankCycle` pattern:

- [src/services/adl.ts](src/services/adl.ts) — new `_onAdlTx` field + `setOnAdlTx(fn)` setter, mirroring [CrankService at crank.ts:154 and 1156](src/services/crank.ts#L154). Callback fires per landed `ExecuteAdl` tx, right after the existing `sent++` line at [adl.ts:485](src/services/adl.ts#L485).
- [src/index.ts](src/index.ts) — wire `adlService.setOnAdlTx((slab) => monitorService.notifyAdlTx(slab))` alongside the existing `setOnCrankCycle` line at [index.ts:169](src/index.ts#L169). Guarded by the existing `adlService` null check, so deployments with ADL disabled are unaffected.
- [tests/services/adl.test.ts](tests/services/adl.test.ts) — new `describe` block covering per-tx invocation, no-fire on tx failure, and back-compat when no callback is registered.

### Design notes
- **Callback over constructor injection**: matches the established `setOnCrankCycle` precedent and keeps `AdlService`'s zero-arg constructor untouched — no changes needed to the 6 `new AdlService()` callsites in tests.
- **Per-landed-tx (not per-scanMarket)**: `MonitorService._adlTxCounts` increments per call, so per-position notification is more accurate when a multi-tx scan deleverages several positions in one cycle.
- **No `try/catch` around the callback**: matches the bare `this._onCrankCycle?.()` invocation pattern in `CrankService`. `notifyAdlTx` is two `Map` ops on instance state — surfacing real bugs is preferable to swallowing them.

## Test plan

- [x] `pnpm test` — 174 passed, 3 pre-existing skips
- [x] `tsc` compiles clean
- [x] Three new tests in `tests/services/adl.test.ts`:
  - callback fires once per landed tx with the slab address (2-position scan → 2 invocations)
  - callback does not fire when `sendWithRetryKeeper` rejects
  - `scanMarket` runs without `setOnAdlTx` wired (back-compat)
- [ ] Manual on devnet: enable ADL, observe `monitorService.getStatus()` — `cycleCountAtLastAdl` should advance after each successful ExecuteAdl, and the staleness warning at [monitor.ts:248](src/services/monitor.ts#L248) should NOT fire on a healthy keeper.

## Notes

Composes cleanly with #110 (require explicit `ADL_ENABLED` on mainnet) — that PR makes ADL reliably enableable; this PR makes the staleness alarm meaningful once it is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ADL service now supports configurable transaction notifications when enabled, allowing transaction events to be forwarded to monitoring services.

* **Tests**
  * Added comprehensive test coverage for transaction notification callbacks, verifying proper callback execution on successful transactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-keeper/pull/111)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->