### PR TITLE
fix(keeper): abort liquidation on oracle drift between scan and submit

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -78,6 +78,18 @@ async function fetchSlabWithRetry(
 const PRICE_E6_DIVISOR = 1_000_000n; // Price precision divisor (6 decimals)
 const BPS_MULTIPLIER = 10_000n; // Basis points multiplier (100% = 10000 bps)
 
+// Oracle-drift guard: abort liquidation if the oracle price has drifted more
+// than this between scan-time candidacy and pre-submit re-verification.
+// The on-chain LiquidateAtOracle instruction is 3 bytes (tag + u16 targetIdx —
+// see @percolatorct/sdk encodeLiquidateAtOracle) and cannot carry a [min,max]
+// bound, so keeper-side drift detection is the only available mitigation.
+// Default 150 bps (1.5%) — wider than typical intra-minute moves on SOL/BTC/ETH
+// but tight enough to cap keeper-wallet exposure on a 60s scan interval.
+// Set to 0 to disable the guard.
+const MAX_LIQUIDATION_DRIFT_BPS = BigInt(
+  parseInt(process.env.LIQUIDATION_MAX_ORACLE_DRIFT_BPS ?? "150", 10),
+);
+
 /**
  * Oracle mode for a market.
  * - 'pyth-pinned': oracle_authority == [0;32] && index_feed_id != [0;32]
@@ -145,6 +157,10 @@ interface LiquidationCandidate {
   pnl: bigint;
   marginRatio: number;  // as percentage
   maintenanceMarginBps: bigint;
+  // Oracle price (E6) at the moment candidacy was decided. Used by liquidate()
+  // to detect oracle drift between scan and submit and abort if it exceeds
+  // MAX_LIQUIDATION_DRIFT_BPS.
+  scanPriceE6: bigint;
 }
 
 export class LiquidationService {
@@ -263,6 +279,7 @@ export class LiquidationService {
               pnl: markPnl,
               marginRatio: equity <= 0n ? 0 : -1,
               maintenanceMarginBps,
+              scanPriceE6: price,
             });
             continue;
           }
@@ -280,6 +297,7 @@ export class LiquidationService {
               pnl: markPnl,
               marginRatio: Number(marginRatioBps) / 100,
               maintenanceMarginBps,
+              scanPriceE6: price,
             });
           }
         } catch {
@@ -325,6 +343,7 @@ export class LiquidationService {
   async liquidate(
     market: DiscoveredMarket,
     accountIdx: number,
+    scanPriceE6: bigint = 0n,
   ): Promise<string | null> {
     const slabAddress = market.slabAddress;
 
@@ -385,6 +404,35 @@ export class LiquidationService {
         // (fixes bug where admin-oracle staleness fallback was missing here)
         const freshMode = detectOracleMode(freshCfg);
         const { price: freshPrice } = resolveMarketPrice(freshCfg, freshMode);
+
+        // Oracle-drift guard: the on-chain LiquidateAtOracle instruction cannot
+        // carry a price bound (encodeLiquidateAtOracle is 3 bytes — tag + u16
+        // targetIdx). If the oracle has moved more than MAX_LIQUIDATION_DRIFT_BPS
+        // since candidacy was decided in scanMarket(), the on-chain execution
+        // price may differ enough to flip the liquidation's P&L. Abort rather
+        // than absorb that drift on the keeper wallet.
+        if (
+          MAX_LIQUIDATION_DRIFT_BPS > 0n &&
+          scanPriceE6 > 0n &&
+          freshPrice > 0n
+        ) {
+          const delta = freshPrice > scanPriceE6
+            ? freshPrice - scanPriceE6
+            : scanPriceE6 - freshPrice;
+          const driftBps = delta * BPS_MULTIPLIER / scanPriceE6;
+          if (driftBps > MAX_LIQUIDATION_DRIFT_BPS) {
+            logger.warn("Aborting liquidation: oracle drift exceeds limit", {
+              accountIndex: accountIdx,
+              slabAddress: slabAddress.toBase58(),
+              scanPriceE6: scanPriceE6.toString(),
+              freshPriceE6: freshPrice.toString(),
+              driftBps: driftBps.toString(),
+              limitBps: MAX_LIQUIDATION_DRIFT_BPS.toString(),
+            });
+            return null;
+          }
+        }
+
         if (freshPrice > 0n) {
           const notional = absBI(freshAccount.positionSize) * freshPrice / PRICE_E6_DIVISOR;
           if (notional > 0n) {
@@ -540,7 +588,11 @@ export class LiquidationService {
 
         // Liquidations are sequential (each is a transaction)
         for (const candidate of candidates) {
-          const sig = await this.liquidate(filteredBatch[j]!.market, candidate.accountIdx);
+          const sig = await this.liquidate(
+            filteredBatch[j]!.market,
+            candidate.accountIdx,
+            candidate.scanPriceE6,
+          );
           if (sig) liquidated++;
         }
       }

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -476,10 +476,78 @@ describe('LiquidationService', () => {
     });
   });
 
+  describe('liquidate — oracle drift guard', () => {
+    function setupDriftMocks(freshPriceE6: bigint) {
+      vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+      vi.mocked(core.parseEngine).mockReturnValue({} as any);
+      vi.mocked(core.parseParams).mockReturnValue({ maintenanceMarginBps: 500n } as any);
+      vi.mocked(core.parseConfig).mockReturnValue({
+        oracleAuthority: mockNonZeroKey(),
+        indexFeedId: mockZeroKey(),
+        authorityPriceE6: freshPriceE6,
+        lastEffectivePriceE6: freshPriceE6,
+        authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
+      } as any);
+      vi.mocked(core.parseUsedIndices).mockReturnValue([0]);
+      vi.mocked(core.parseAccount).mockReturnValue({
+        kind: 0,
+        owner: { toBase58: () => 'User6111111111111111111111111111111111111' },
+        positionSize: 10_000_000_000n,
+        capital: 1_000_000n,
+        entryPrice: 1_000_000n,
+        pnl: 0n,
+      } as any);
+    }
+
+    function mockMarket() {
+      return {
+        slabAddress: { toBase58: () => 'MarketDrift1111111111111111111111111111' },
+        programId: { toBase58: () => 'Program11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+          oracleAuthority: mockNonZeroKey(),
+          indexFeedId: mockZeroKey(),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+      };
+    }
+
+    it('aborts when oracle drift exceeds the default 150 bps limit', async () => {
+      // Scan-time price: 1.000000 USDC; fresh price: 1.020000 (+200 bps, > 150 bps default)
+      setupDriftMocks(1_020_000n);
+
+      const result = await liquidationService.liquidate(mockMarket() as any, 0, 1_000_000n);
+
+      expect(result).toBeNull();
+      expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when oracle drift is within the limit', async () => {
+      // Scan-time price: 1.000000 USDC; fresh price: 1.010000 (+100 bps, < 150 bps default)
+      setupDriftMocks(1_010_000n);
+
+      const result = await liquidationService.liquidate(mockMarket() as any, 0, 1_000_000n);
+
+      expect(result).not.toBeNull();
+      expect(shared.sendWithRetryKeeper).toHaveBeenCalled();
+    });
+
+    it('skips the drift guard when scanPriceE6 is 0 (back-compat default)', async () => {
+      // Even with a huge fresh price, the guard is bypassed when no scan price is provided
+      setupDriftMocks(5_000_000n);
+
+      const result = await liquidationService.liquidate(mockMarket() as any, 0);
+
+      expect(result).not.toBeNull();
+      expect(shared.sendWithRetryKeeper).toHaveBeenCalled();
+    });
+  });
+
   describe('start and stop', () => {
     it('should start and stop timer', () => {
       const markets = new Map();
-      
+
       liquidationService.start(() => markets);
       expect(liquidationService.getStatus().running).toBe(true);
 


### PR DESCRIPTION
## Summary

`encodeLiquidateAtOracle` is a fixed 3-byte instruction (`tag + u16 targetIdx` — verified in `node_modules/@percolatorct/sdk/dist/abi/instructions.d.ts:349-352` and `dist/index.js:403-408`) and cannot carry an oracle price bound. If the oracle moves between when [scanMarket](src/services/liquidation.ts) decides a candidate is liquidatable and when [liquidate](src/services/liquidation.ts) sends the tx, the on-chain execution price differs from the keeper's assumption and the keeper-controlled wallet absorbs the difference.

This PR adds a keeper-side drift guard:

1. [src/services/liquidation.ts](src/services/liquidation.ts) — new `MAX_LIQUIDATION_DRIFT_BPS` constant (default 150 bps, configurable via `LIQUIDATION_MAX_ORACLE_DRIFT_BPS`; set to `0` to disable).
2. New `scanPriceE6: bigint` field on `LiquidationCandidate` capturing the price resolved by `resolveMarketPrice` at candidacy time.
3. Inside the existing pre-check `freshData` block — right where `freshPrice` is already computed — compare against `scanPriceE6` and abort with a `logger.warn` if drift exceeds the limit.
4. `scanAndLiquidateAll` callsite updated to thread `candidate.scanPriceE6` into `liquidate()`. The third parameter defaults to `0n` so any existing direct callers (e.g. tests) keep working with the guard skipped.

### Window covered
This bounds keeper exposure to oracle drift in the **scan→pre-check** window — the dominant gap, up to `intervalMs = 60_000` by default plus per-batch overhead. The narrower pre-check→submit window (~50-200ms) is **not** covered and can be added later if production metrics show meaningful drift there.

### Why a keeper-side mitigation rather than a program-side bound
The on-chain `LiquidateAtOracle` instruction wire format is 3 bytes — there is no field to populate. A true on-chain bound requires a program + SDK change. This PR is the highest-impact protection available from the keeper alone.

### Why 150 bps default
~2-3 sigma of typical intra-minute moves on SOL/BTC/ETH; wide enough to avoid spurious aborts during normal volatility, tight enough to cap exposure on a 60s scan interval. Tune via `LIQUIDATION_MAX_ORACLE_DRIFT_BPS` if mainnet observations suggest otherwise.

## Test plan

- [x] `pnpm test` — 174 passed, 3 pre-existing skips
- [x] `tsc` compiles clean
- [x] Three new tests in `tests/services/liquidation.test.ts`:
  - aborts when drift exceeds 150 bps (returns null, `sendWithRetryKeeper` not called)
  - proceeds when drift is within limit (sig returned, `sendWithRetryKeeper` called)
  - back-compat: skips the guard when `scanPriceE6` defaults to `0n`
- [ ] Manual on devnet: observe `liquidation.scanCount` and the new warn-log to size actual drift frequency before/after.

## Notes

Composes cleanly with #110 (`ADL_ENABLED` mainnet guard) and #111 (wire ADL→Monitor) — independent code paths, no overlap.

A follow-up could add: (a) a second slab fetch right before submit to bound the pre-check→submit window, or (b) a metrics counter on aborts so the team can size the residual risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Liquidation execution now includes an oracle-drift guard. The system records oracle prices during the scanning phase and compares them against prices at execution time. If prices differ beyond the configured threshold (default: 150 basis points), liquidation is aborted. The drift tolerance is configurable via environment variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-keeper/pull/112)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->