### PR TITLE
feat(keeper): assert mainnet program id at boot — Phase 1 A1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     dependencies:
       '@percolatorct/sdk':
-        specifier: ^2.0.9
+        specifier: 2.0.9
         version: 2.0.9(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@percolatorct/shared':
         specifier: 1.0.0-beta.8

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { AdlService } from "./services/adl.js";
 import { MonitorService } from "./services/monitor.js";
 import { validateKeeperEnvGuards } from "./env-guards.js";
 import { isMainnet } from "./config/network.js";
+import { assertMainnetProgramId } from "./lib/boot-assertions.js";
 import { snapshotMetrics as snapshotSenderMetrics } from "./lib/sender-metrics.js";
 
 // Monitoring — alerts to Discord on threshold breaches
@@ -33,6 +34,7 @@ validateKeeperEnvGuards();
 // If NETWORK=mainnet, the keeper runs against mainnet program (requires FORCE_MAINNET=1).
 // On mainnet, HYPERP markets (SOL-PERP, BTC-PERP, ETH-PERP) use the keeper as oracle authority
 // and price lookups use mainnet mints directly (no mainnetCA override needed).
+assertMainnetProgramId({ isMainnet: isMainnet(), programId: config.programId });
 if (isMainnet()) {
   logger.info("Running in MAINNET mode", { programId: config.programId });
 }

--- a/src/lib/boot-assertions.ts
+++ b/src/lib/boot-assertions.ts
@@ -1,0 +1,37 @@
+/**
+ * Boot-time invariants the keeper refuses to start without.
+ *
+ * Why these live in a dedicated module: index.ts performs heavy side effects
+ * at module load (Sentry init, service construction, interval registration),
+ * which makes the boot path hard to unit-test. Pure assertions live here so
+ * they can be exercised in isolation.
+ */
+
+/**
+ * The single program id the keeper is authorized to sign mainnet txs against.
+ * Sourced from the v12.19.1 hotfix deploy (slot 419199595, program upgrade
+ * authority on file). Hardcoded — never read from env on mainnet — so a typo
+ * or stale config cannot redirect the keeper to a different program.
+ */
+export const MAINNET_PROGRAM_ID =
+  "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv";
+
+/**
+ * Refuse to boot when NETWORK=mainnet but the configured program id is not
+ * the canonical mainnet program. Catches the failure mode where the keeper
+ * is pointed at mainnet RPC but a devnet/test program id is still in the
+ * config — which would cause real user funds to be signed against the
+ * wrong program.
+ */
+export function assertMainnetProgramId(opts: {
+  isMainnet: boolean;
+  programId: string;
+}): void {
+  if (!opts.isMainnet) return;
+  if (opts.programId === MAINNET_PROGRAM_ID) return;
+  throw new Error(
+    `SECURITY: NETWORK=mainnet but PROGRAM_ID=${opts.programId} — ` +
+      `expected ${MAINNET_PROGRAM_ID}. Refusing to boot to prevent signing ` +
+      `transactions against an unintended program.`,
+  );
+}

--- a/tests/lib/boot-assertions.test.ts
+++ b/tests/lib/boot-assertions.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  assertMainnetProgramId,
+  MAINNET_PROGRAM_ID,
+} from "../../src/lib/boot-assertions.js";
+
+describe("assertMainnetProgramId", () => {
+  it("is a no-op when isMainnet=false (any programId)", () => {
+    expect(() =>
+      assertMainnetProgramId({ isMainnet: false, programId: "anything" }),
+    ).not.toThrow();
+    expect(() =>
+      assertMainnetProgramId({
+        isMainnet: false,
+        programId: MAINNET_PROGRAM_ID,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertMainnetProgramId({ isMainnet: false, programId: "" }),
+    ).not.toThrow();
+  });
+
+  it("is a no-op when isMainnet=true and programId matches canonical mainnet id", () => {
+    expect(() =>
+      assertMainnetProgramId({
+        isMainnet: true,
+        programId: MAINNET_PROGRAM_ID,
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws when isMainnet=true and programId is a different value", () => {
+    const wrongId = "GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24";
+    expect(() =>
+      assertMainnetProgramId({ isMainnet: true, programId: wrongId }),
+    ).toThrow(/SECURITY: NETWORK=mainnet but PROGRAM_ID=/);
+  });
+
+  it("throws when isMainnet=true and programId is empty", () => {
+    expect(() =>
+      assertMainnetProgramId({ isMainnet: true, programId: "" }),
+    ).toThrow(/SECURITY: NETWORK=mainnet but PROGRAM_ID=/);
+  });
+
+  it("error message names both the actual and expected program ids", () => {
+    const wrongId = "GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24";
+    try {
+      assertMainnetProgramId({ isMainnet: true, programId: wrongId });
+      throw new Error("expected throw");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).toContain(wrongId);
+      expect(msg).toContain(MAINNET_PROGRAM_ID);
+    }
+  });
+
+  it("MAINNET_PROGRAM_ID is the canonical v12.19.1 deploy", () => {
+    expect(MAINNET_PROGRAM_ID).toBe(
+      "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv",
+    );
+    expect(MAINNET_PROGRAM_ID).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
+  });
+});


### PR DESCRIPTION
## Summary

Refuse to start when \`NETWORK=mainnet\` and \`PROGRAM_ID\` is not the canonical mainnet program (\`ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv\`).

This catches the failure mode where the keeper is pointed at mainnet RPC but a devnet/test program id is still in the config — preventing real user funds from being signed against an unintended program.

**Scope:** Phase 1 Workstream A1. ~25 LOC of production code + 50 LOC of tests. Deliberately the smallest possible change in the Phase 1 backlog — opened first to validate the development + review + shadow-deploy pattern before the larger workstreams (B′, C, D, E, F) begin.

## What changed

- New module `src/lib/boot-assertions.ts` exporting \`assertMainnetProgramId({ isMainnet, programId })\` and the hardcoded \`MAINNET_PROGRAM_ID\` constant. Lives in its own file so the assertion is unit-testable in isolation from \`index.ts\`'s heavy side-effect boot path.
- \`src/index.ts\` calls the assertion immediately after \`validateKeeperEnvGuards()\` and before any service is constructed.
- \`tests/lib/boot-assertions.test.ts\` covers: no-op when devnet, no-op when mainnet+correct id, throws when mainnet+wrong id, throws when mainnet+empty id, error message references both ids, sanity check on the constant value.

## Test plan

- [x] \`pnpm build\` clean (tsc)
- [x] \`pnpm test\` — 177 passed | 3 skipped (was 171 | 3) — 6 new tests added
- [x] Manual smoke: existing devnet keeper boots unchanged (assertion is a no-op when NETWORK≠mainnet)
- [ ] Shadow keeper (DRY_RUN=true) in us-east4 for 24h: should boot cleanly against mainnet config; no new errors in Sentry
- [ ] Promote to live keeper (eu-west4); verify boot log shows the existing \"Running in MAINNET mode\" line followed by normal startup

## Why this is non-coupled to v16 / v12.19 work

The hardcoded program id is the *deployed mainnet* program id — independent of which engine version the binary corresponds to. When v16 eventually replaces v12.19 on the same program id, this assertion still holds. When/if the program id itself changes (program redeploy under a new id), the constant must be updated as part of that deploy procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup validation to ensure the configured program ID matches the expected mainnet program ID when running in mainnet mode, providing safeguards against configuration errors.

* **Tests**
  * Added comprehensive test suite for the startup validation logic, verifying correct behavior across all configuration scenarios and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-keeper/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->