### PR TITLE
feat(keeper): Phase 1 Workstream A safety hardening (A2-A8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.2.2",
+    "fast-check": "^4.8.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^4.0.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     dependencies:
       '@percolatorct/sdk':
-        specifier: ^2.0.9
+        specifier: 2.0.9
         version: 2.0.9(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@percolatorct/shared':
         specifier: 1.0.0-beta.8
@@ -27,6 +27,9 @@ importers:
       '@types/node':
         specifier: ^25.2.2
         version: 25.5.0
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -927,6 +930,10 @@ packages:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
@@ -1134,6 +1141,9 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
@@ -2310,6 +2320,10 @@ snapshots:
 
   eyes@0.1.8: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-stable-stringify@1.0.0: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
@@ -2480,6 +2494,8 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  pure-rand@8.4.0: {}
 
   require-in-the-middle@8.0.1:
     dependencies:

--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -1,5 +1,36 @@
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]);
+const TEST_VALIDATOR_PORT = "8899";
+
+function isMainnetEnv(env: NodeJS.ProcessEnv): boolean {
+  return env.NETWORK === "mainnet";
+}
+
+// A2: When NETWORK=mainnet, refuse any RPC URL that points at a local validator.
+// The keeper would otherwise sign mainnet-config transactions against a test
+// validator with no real funds backing — at best wasting cycles, at worst
+// confusing operators into thinking the keeper is healthy when it is not.
+function rejectLocalRpcUrl(varName: string, raw: string | undefined): void {
+  if (!raw) return;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`${varName} is not a valid URL: ${raw.slice(0, 60)}`);
+  }
+  if (LOCAL_HOSTS.has(parsed.hostname)) {
+    throw new Error(
+      `${varName} points at ${parsed.hostname} but NETWORK=mainnet — refusing to boot. ` +
+        `Unset NETWORK (or set NETWORK=devnet) for local development.`,
+    );
+  }
+  if (parsed.port === TEST_VALIDATOR_PORT) {
+    throw new Error(
+      `${varName} uses port 8899 (Solana test validator) but NETWORK=mainnet — refusing to boot.`,
+    );
+  }
+}
+
 export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): void {
-  const supabaseKey = env.SUPABASE_KEY?.trim();
   const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY?.trim();
 
   // K-2 (HIGH): hard-reject SUPABASE_SERVICE_ROLE_KEY being present at all.
@@ -9,17 +40,14 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
   if (serviceRoleKey && serviceRoleKey !== "") {
     throw new Error(
       "SECURITY: SUPABASE_SERVICE_ROLE_KEY must NOT be set in keeper env. " +
-      "Keeper needs only the anon key (SUPABASE_KEY). " +
-      "Remove SUPABASE_SERVICE_ROLE_KEY from .env and Railway config. (PERC-8232)"
+        "Keeper needs only the anon key (SUPABASE_KEY). " +
+        "Remove SUPABASE_SERVICE_ROLE_KEY from .env and Railway config. (PERC-8232)",
     );
   }
 
-  if (supabaseKey && serviceRoleKey && supabaseKey === serviceRoleKey) {
-    throw new Error(
-      "Keeper misconfiguration: SUPABASE_KEY must not equal SUPABASE_SERVICE_ROLE_KEY. " +
-      "Set SUPABASE_KEY to the anon key for keeper runtime."
-    );
-  }
+  // A3 (L-2): the secondary "anon == service-role" equality check was
+  // unreachable — the hard-reject above already throws on any non-empty
+  // service-role key. Deleted; the supabaseKey lookup that fed it is gone too.
 
   // Reject insecure (plaintext) RPC URLs unless explicitly allowed.
   // http:// and ws:// transmit signed transactions and account data unencrypted,
@@ -30,16 +58,16 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
     if (rpcUrl && !rpcUrl.startsWith("https://")) {
       throw new Error(
         `SOLANA_RPC_URL must use https:// (got ${rpcUrl.slice(0, 30)}...). ` +
-        "Plaintext HTTP exposes signed transactions to MITM. " +
-        "Set ALLOW_INSECURE_RPC=true to override for local development."
+          "Plaintext HTTP exposes signed transactions to MITM. " +
+          "Set ALLOW_INSECURE_RPC=true to override for local development.",
       );
     }
     const wsUrl = env.SOLANA_RPC_WS_URL?.trim();
     if (wsUrl && !wsUrl.startsWith("wss://")) {
       throw new Error(
         `SOLANA_RPC_WS_URL must use wss:// (got ${wsUrl.slice(0, 30)}...). ` +
-        "Plaintext WebSocket exposes account data to MITM. " +
-        "Set ALLOW_INSECURE_RPC=true to override for local development."
+          "Plaintext WebSocket exposes account data to MITM. " +
+          "Set ALLOW_INSECURE_RPC=true to override for local development.",
       );
     }
     // Validate fallback RPC URL — used by discovery and liquidation retry.
@@ -48,9 +76,15 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
     if (fallbackRpcUrl && !fallbackRpcUrl.startsWith("https://")) {
       throw new Error(
         `FALLBACK_RPC_URL must use https:// (got ${fallbackRpcUrl.slice(0, 30)}...). ` +
-        "Plaintext HTTP exposes signed transactions to MITM. " +
-        "Set ALLOW_INSECURE_RPC=true to override for local development."
+          "Plaintext HTTP exposes signed transactions to MITM. " +
+          "Set ALLOW_INSECURE_RPC=true to override for local development.",
       );
     }
+  }
+
+  if (isMainnetEnv(env)) {
+    rejectLocalRpcUrl("SOLANA_RPC_URL", env.SOLANA_RPC_URL?.trim());
+    rejectLocalRpcUrl("SOLANA_RPC_WS_URL", env.SOLANA_RPC_WS_URL?.trim());
+    rejectLocalRpcUrl("FALLBACK_RPC_URL", env.FALLBACK_RPC_URL?.trim());
   }
 }

--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -86,5 +86,9 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
     rejectLocalRpcUrl("SOLANA_RPC_URL", env.SOLANA_RPC_URL?.trim());
     rejectLocalRpcUrl("SOLANA_RPC_WS_URL", env.SOLANA_RPC_WS_URL?.trim());
     rejectLocalRpcUrl("FALLBACK_RPC_URL", env.FALLBACK_RPC_URL?.trim());
+    // A.7: @percolatorct/shared and src/lib/priority-fee.ts read RPC_URL
+    // (not SOLANA_RPC_URL). Without this guard a RPC_URL=http://localhost
+    // on mainnet would be accepted while the other vars are caught.
+    rejectLocalRpcUrl("RPC_URL", env.RPC_URL?.trim());
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { MonitorService } from "./services/monitor.js";
 import { validateKeeperEnvGuards } from "./env-guards.js";
 import { isMainnet } from "./config/network.js";
 import { snapshotMetrics as snapshotSenderMetrics } from "./lib/sender-metrics.js";
+import { captureAndExit } from "./lib/exit-handlers.js";
+import { StartupTracker } from "./lib/startup-tracker.js";
 
 // Monitoring — alerts to Discord on threshold breaches
 export const monitors = createServiceMonitors("Keeper");
@@ -54,9 +56,10 @@ if (adlEnabled) {
   logger.info("ADL service disabled — set ADL_ENABLED=true to enable (requires T8+T10)");
 }
 
-// Health state tracking
-let lastSuccessfulCrankTime = 0;
-let lastOracleUpdateTime = 0;
+// A5: gate /health on real readiness — Railway otherwise marks the container
+// healthy the moment the HTTP server binds, well before start() finishes
+// discovering markets and wiring services.
+const startupTracker = new StartupTracker();
 
 // Stale oracle pause guard — markets paused due to stale oracle data
 const stalePausedMarkets = new Set<string>();
@@ -86,7 +89,9 @@ const solBalanceCheckInterval = setInterval(async () => {
         logger.warn("Keeper SOL balance below threshold", {
           solBalance: solBalance.toFixed(4),
           thresholdSol: SOL_BALANCE_WARN_THRESHOLD,
-          walletAddress: keypair.publicKey.toBase58(),
+          // A8: truncate to match the Discord field below — full pubkey in logs is
+          // noise and exposes the keeper wallet identity to anyone with log access.
+          walletAddress: keypair.publicKey.toBase58().slice(0, 16) + "...",
         });
         sendWarningAlert("Keeper wallet SOL balance low", [
           { name: "Balance", value: `${solBalance.toFixed(4)} SOL`, inline: true },
@@ -168,18 +173,12 @@ crankService.setStalePauseCheck(isMarketStalePaused);
 // 6.2: Wire crank cycle counter into MonitorService so it can track ADL staleness
 crankService.setOnCrankCycle(() => monitorService.notifyCrankCycle());
 
-// Subscribe to crank events to track health
-crankService.getMarkets().forEach((_, slabAddress) => {
-  const checkCrankHealth = () => {
-    const markets = crankService.getMarkets();
-    for (const [_, state] of markets) {
-      if (state.lastCrankTime > lastSuccessfulCrankTime) {
-        lastSuccessfulCrankTime = state.lastCrankTime;
-      }
-    }
-  };
-  setInterval(checkCrankHealth, 10_000); // Check every 10s
-});
+// A4: deleted the per-market setInterval loop that used to live here. It was
+// unreachable: crankService.getMarkets() is called at module load time, before
+// discover() has populated the map, so the forEach iterated an empty Map and
+// registered zero intervals. The variables it wrote (lastSuccessfulCrankTime,
+// lastOracleUpdateTime) were never read — /health computes most-recent crank
+// time on every request from the live crank state.
 
 // Health endpoint
 const startupTime = Date.now();
@@ -340,6 +339,18 @@ res.writeHead(401, secureJsonHeaders);
   }
 
   if (req.url === "/health" && req.method === "GET") {
+    // A5: hard 503 until start() resolved. Railway otherwise marks the
+    // container healthy as soon as healthServer.listen() returns — long
+    // before discover() + service.start() have wired anything up.
+    if (!startupTracker.isReady()) {
+      res.writeHead(503, secureJsonHeaders);
+      res.end(JSON.stringify({
+        status: startupTracker.isFailed() ? "failed" : "starting",
+        failureReason: startupTracker.failureReason,
+      }));
+      return;
+    }
+
     const markets = crankService.getMarkets();
     const marketsTracked = markets.size;
     
@@ -554,11 +565,26 @@ async function start() {
   ]).catch(() => {}); // Don't crash if alert fails
 }
 
-start().catch((err) => {
-  logger.error("Failed to start keeper", { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined });
-  // Don't exit — keep the process alive for healthcheck + retry
-  logger.info("Keeper will stay alive for healthcheck despite startup error");
-});
+// A5: explicit success → ready, failure → captureAndExit. Previously a
+// start() rejection only logged and left the process up, which let Railway
+// keep marking the container healthy while no actual work was happening.
+start()
+  .then(() => {
+    startupTracker.markReady();
+    logger.info("Keeper start() resolved — health endpoint now reports ready");
+  })
+  .catch((err) => {
+    startupTracker.markFailed(err instanceof Error ? err.message : String(err));
+    captureAndExit("Failed to start keeper — exiting", err, {
+      capture: captureException,
+      logger,
+      exit: process.exit,
+      setTimer: (cb, ms) => {
+        const t = setTimeout(cb, ms);
+        t.unref();
+      },
+    });
+  });
 
 const SHUTDOWN_TIMEOUT_MS = 15_000;
 
@@ -620,20 +646,26 @@ async function shutdown(signal: string): Promise<void> {
 process.on("SIGTERM", () => shutdown("SIGTERM"));
 process.on("SIGINT", () => shutdown("SIGINT"));
 
-// Safety net: catch any unhandled rejections or exceptions so Railway doesn't kill
-// the process mid-cycle. Log the error, but keep the keeper alive for healthcheck
-// and retry on the next interval. Without these handlers, Node.js 15+ exits on
-// unhandled rejections by default, causing the crash-loop seen in Railway logs.
-process.on("unhandledRejection", (reason, promise) => {
-  logger.error("Unhandled promise rejection — keeping process alive", {
-    reason: reason instanceof Error ? reason.message : String(reason),
-    stack: reason instanceof Error ? reason.stack : undefined,
-  });
+// A6: crash on unhandled rejections / exceptions. Previously we logged and kept
+// the process alive — but the keeper signs against live funds, and silent
+// recovery from an unhandled error risks operating with corrupt in-process
+// state (half-written maps, dangling promises holding resources). Better to
+// capture to Sentry, wait briefly for flush, then exit so Railway restarts a
+// clean process.
+const crashDeps = {
+  capture: captureException,
+  logger,
+  exit: process.exit,
+  setTimer: (cb: () => void, ms: number) => {
+    const t = setTimeout(cb, ms);
+    t.unref();
+  },
+};
+
+process.on("unhandledRejection", (reason) => {
+  captureAndExit("Unhandled promise rejection — exiting", reason, crashDeps);
 });
 
 process.on("uncaughtException", (err) => {
-  logger.error("Uncaught exception — keeping process alive", {
-    error: err.message,
-    stack: err.stack,
-  });
+  captureAndExit("Uncaught exception — exiting", err, crashDeps);
 });

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -1,0 +1,345 @@
+/**
+ * KeeperBudget — circuit breaker for keeper send-path spending.
+ *
+ * Why this exists: the keeper signs transactions against a wallet with real
+ * funds. A misconfigured priority fee, a stuck retry loop, or a malicious
+ * input can drain that wallet faster than ops can notice. The budget caps
+ * lamport spend per cycle / hour / day and tx count per cycle, plus a
+ * rolling-window success-rate guard that catches "we're sending but nothing
+ * lands". On breach, the budget halts: every subsequent canSpend() returns
+ * false until an operator manually resume()s. Day-cap breaches especially
+ * never auto-recover — that's a real signal something is wrong.
+ *
+ * Concurrency: every public method is synchronous. Under Node's single-
+ * threaded event loop, no two calls can interleave between their reads and
+ * writes, so the internal counters cannot drift even under thousands of
+ * concurrent canSpend() / recordTx() callers.
+ */
+
+import { createLogger } from "@percolatorct/shared";
+
+const logger = createLogger("keeper:budget");
+
+export type TxType = "crank" | "liquidation" | "oracle";
+export type TxResult = "success" | "fail" | "drop";
+
+export interface KeeperBudgetConfig {
+  /** Per cycle cap in lamports (default 50_000_000 = 0.05 SOL). */
+  maxSolPerCycle: number;
+  /** Rolling 1-hour cap in lamports (default 500_000_000 = 0.5 SOL). */
+  maxSolPerHour: number;
+  /** Rolling 24-hour cap in lamports (default 3_000_000_000 = 3 SOL). Manual-resume-only on breach. */
+  maxSolPerDay: number;
+  /** Cap on tx attempts per cycle (default 60). */
+  maxTxPerCycle: number;
+  /** Window length in ms over which success rate is computed (default 60_000). */
+  txSuccessRateWindow: number;
+  /** Floor for success rate within the window (default 0.70). */
+  txSuccessRateThreshold: number;
+  /** Minimum samples before the success-rate guard activates (default 10). */
+  txSuccessRateMinSamples: number;
+}
+
+export interface BudgetStats {
+  cycleSpend: number;
+  hourSpend: number;
+  daySpend: number;
+  cycleTxCount: number;
+  txSuccessRate: number | null;
+  txWindowSize: number;
+  halted: boolean;
+  haltReason?: string;
+  haltKind?: HaltKind;
+  config: KeeperBudgetConfig;
+}
+
+export type HaltKind =
+  | "cycle-spend-cap"
+  | "hour-spend-cap"
+  | "day-spend-cap"
+  | "cycle-tx-count-cap"
+  | "tx-success-rate"
+  | "operator";
+
+export interface KeeperBudgetDeps {
+  now?: () => number;
+  env?: NodeJS.ProcessEnv;
+  onHalt?: (kind: HaltKind, reason: string) => void;
+}
+
+interface SpendEvent {
+  ts: number;
+  lamports: number;
+}
+
+interface TxRecord {
+  ts: number;
+  success: boolean;
+}
+
+const DEFAULTS: KeeperBudgetConfig = {
+  maxSolPerCycle: 50_000_000,
+  maxSolPerHour: 500_000_000,
+  maxSolPerDay: 3_000_000_000,
+  maxTxPerCycle: 60,
+  txSuccessRateWindow: 60_000,
+  txSuccessRateThreshold: 0.7,
+  txSuccessRateMinSamples: 10,
+};
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
+
+const INT_ENV_KEYS: Array<[keyof KeeperBudgetConfig, string]> = [
+  ["maxSolPerCycle", "KEEPER_MAX_SOL_PER_CYCLE"],
+  ["maxSolPerHour", "KEEPER_MAX_SOL_PER_HOUR"],
+  ["maxSolPerDay", "KEEPER_MAX_SOL_PER_DAY"],
+  ["maxTxPerCycle", "KEEPER_MAX_TX_PER_CYCLE"],
+  ["txSuccessRateWindow", "KEEPER_TX_SUCCESS_RATE_WINDOW_MS"],
+  ["txSuccessRateMinSamples", "KEEPER_TX_SUCCESS_RATE_MIN_SAMPLES"],
+];
+
+function parseEnvOverrides(env: NodeJS.ProcessEnv): Partial<KeeperBudgetConfig> {
+  const result: Partial<KeeperBudgetConfig> = {};
+  for (const [key, envName] of INT_ENV_KEYS) {
+    const raw = env[envName];
+    if (raw === undefined || raw === "") continue;
+    const n = Number(raw);
+    if (Number.isFinite(n) && n > 0 && Number.isInteger(n)) {
+      (result as Record<string, number>)[key] = n;
+    }
+  }
+  const rateRaw = env.KEEPER_TX_SUCCESS_RATE_THRESHOLD;
+  if (rateRaw !== undefined && rateRaw !== "") {
+    const n = Number(rateRaw);
+    if (Number.isFinite(n) && n >= 0 && n <= 1) {
+      result.txSuccessRateThreshold = n;
+    }
+  }
+  return result;
+}
+
+export class KeeperBudget {
+  readonly config: KeeperBudgetConfig;
+  private readonly _now: () => number;
+  private readonly _onHalt: ((kind: HaltKind, reason: string) => void) | undefined;
+
+  private _cycleSpend = 0;
+  private _cycleTxCount = 0;
+  private readonly _hourEvents: SpendEvent[] = [];
+  private _hourSpendSum = 0;
+  private readonly _dayEvents: SpendEvent[] = [];
+  private _daySpendSum = 0;
+  private readonly _txWindow: TxRecord[] = [];
+  private _txWindowSuccesses = 0;
+  private _txWindowFailures = 0;
+
+  private _isHalted = false;
+  private _haltKind: HaltKind | undefined;
+  private _haltReason: string | undefined;
+
+  constructor(config: Partial<KeeperBudgetConfig> = {}, deps: KeeperBudgetDeps = {}) {
+    const envOverrides = parseEnvOverrides(deps.env ?? process.env);
+    this.config = { ...DEFAULTS, ...envOverrides, ...config };
+    this._now = deps.now ?? (() => Date.now());
+    this._onHalt = deps.onHalt;
+  }
+
+  /**
+   * Pre-flight check: would sending a tx that costs `lamports` lamports breach
+   * any cap? Returns false on breach AND latches the halt so subsequent calls
+   * also return false until resume() is called.
+   *
+   * txType is currently advisory (logged on breach); planned use is to attribute
+   * Prometheus halt counters per tx category.
+   */
+  canSpend(lamports: number, txType: TxType): boolean {
+    if (this._isHalted) return false;
+
+    const nowMs = this._now();
+    this._pruneOld(nowMs);
+
+    if (this._cycleSpend + lamports > this.config.maxSolPerCycle) {
+      this._halt(
+        "cycle-spend-cap",
+        `proposed cycle spend ${this._cycleSpend + lamports} > cap ${this.config.maxSolPerCycle} (txType=${txType})`,
+      );
+      return false;
+    }
+    if (this._hourSpendSum + lamports > this.config.maxSolPerHour) {
+      this._halt(
+        "hour-spend-cap",
+        `proposed hour spend ${this._hourSpendSum + lamports} > cap ${this.config.maxSolPerHour} (txType=${txType})`,
+      );
+      return false;
+    }
+    if (this._daySpendSum + lamports > this.config.maxSolPerDay) {
+      this._halt(
+        "day-spend-cap",
+        `proposed day spend ${this._daySpendSum + lamports} > cap ${this.config.maxSolPerDay} (txType=${txType})`,
+      );
+      return false;
+    }
+    if (this._cycleTxCount + 1 > this.config.maxTxPerCycle) {
+      this._halt(
+        "cycle-tx-count-cap",
+        `proposed cycle tx count ${this._cycleTxCount + 1} > cap ${this.config.maxTxPerCycle} (txType=${txType})`,
+      );
+      return false;
+    }
+
+    const rate = this._computeSuccessRate();
+    if (rate !== null && rate < this.config.txSuccessRateThreshold) {
+      this._halt(
+        "tx-success-rate",
+        `tx success rate ${rate.toFixed(3)} < threshold ${this.config.txSuccessRateThreshold} over ${this._txWindow.length} samples (txType=${txType})`,
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Record a settled tx. Called regardless of halt state — accounts for
+   * in-flight txs that settle after the budget has already tripped.
+   *
+   * - 'success' / 'fail': lamports are added to spend trackers (fees pay on
+   *   failed txs that landed in a block).
+   * - 'drop': lamports are NOT added (we never reached the chain). Still
+   *   counts toward cycleTxCount as an attempt.
+   */
+  recordTx(lamports: number, txType: string, result: TxResult): void {
+    if (lamports < 0 || !Number.isFinite(lamports)) return;
+    const nowMs = this._now();
+    this._cycleTxCount++;
+
+    if (result !== "drop") {
+      this._cycleSpend += lamports;
+      this._hourEvents.push({ ts: nowMs, lamports });
+      this._hourSpendSum += lamports;
+      this._dayEvents.push({ ts: nowMs, lamports });
+      this._daySpendSum += lamports;
+      const success = result === "success";
+      this._txWindow.push({ ts: nowMs, success });
+      if (success) this._txWindowSuccesses++;
+      else this._txWindowFailures++;
+    }
+
+    this._pruneOld(nowMs);
+
+    if (process.env.KEEPER_BUDGET_DEBUG === "true") {
+      logger.debug("recordTx", {
+        txType,
+        result,
+        lamports,
+        cycleSpend: this._cycleSpend,
+        hourSpend: this._hourSpendSum,
+        daySpend: this._daySpendSum,
+      });
+    }
+  }
+
+  /**
+   * Reset per-cycle counters at the top of a new cycle. Does NOT clear halt
+   * state — that requires resume().
+   */
+  beginCycle(): void {
+    this._cycleSpend = 0;
+    this._cycleTxCount = 0;
+  }
+
+  getStats(): BudgetStats {
+    this._pruneOld(this._now());
+    return {
+      cycleSpend: this._cycleSpend,
+      hourSpend: this._hourSpendSum,
+      daySpend: this._daySpendSum,
+      cycleTxCount: this._cycleTxCount,
+      txSuccessRate: this._computeSuccessRate(),
+      txWindowSize: this._txWindow.length,
+      halted: this._isHalted,
+      haltReason: this._haltReason,
+      haltKind: this._haltKind,
+      config: { ...this.config },
+    };
+  }
+
+  isHalted(): boolean {
+    return this._isHalted;
+  }
+
+  get haltReason(): string | undefined {
+    return this._haltReason;
+  }
+
+  get haltKind(): HaltKind | undefined {
+    return this._haltKind;
+  }
+
+  /**
+   * Clear halt state. Logs the operator name so the audit trail records who
+   * authorized the resume. Pass a recognizable identifier (e.g. on-call
+   * pager handle) so the alert thread can reference it.
+   */
+  resume(operator: string): void {
+    if (!this._isHalted) return;
+    logger.warn("Keeper budget resumed", {
+      operator,
+      previousHaltKind: this._haltKind,
+      previousHaltReason: this._haltReason,
+    });
+    this._isHalted = false;
+    this._haltKind = undefined;
+    this._haltReason = undefined;
+  }
+
+  /**
+   * Operator-initiated halt. Useful for cordoning the keeper before a
+   * deploy or in response to an external incident.
+   */
+  haltManually(reason: string): void {
+    this._halt("operator", reason);
+  }
+
+  private _halt(kind: HaltKind, reason: string): void {
+    if (this._isHalted) return;
+    this._isHalted = true;
+    this._haltKind = kind;
+    this._haltReason = reason;
+    logger.error("Keeper budget halted — refusing further sends until manual resume()", {
+      kind,
+      reason,
+    });
+    try {
+      this._onHalt?.(kind, reason);
+    } catch (err) {
+      logger.warn("onHalt hook threw — ignoring", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private _pruneOld(nowMs: number): void {
+    const hourCutoff = nowMs - HOUR_MS;
+    while (this._hourEvents.length > 0 && this._hourEvents[0]!.ts < hourCutoff) {
+      this._hourSpendSum -= this._hourEvents.shift()!.lamports;
+    }
+    const dayCutoff = nowMs - DAY_MS;
+    while (this._dayEvents.length > 0 && this._dayEvents[0]!.ts < dayCutoff) {
+      this._daySpendSum -= this._dayEvents.shift()!.lamports;
+    }
+    const windowCutoff = nowMs - this.config.txSuccessRateWindow;
+    while (this._txWindow.length > 0 && this._txWindow[0]!.ts < windowCutoff) {
+      const evicted = this._txWindow.shift()!;
+      if (evicted.success) this._txWindowSuccesses--;
+      else this._txWindowFailures--;
+    }
+  }
+
+  private _computeSuccessRate(): number | null {
+    const total = this._txWindow.length;
+    if (total < this.config.txSuccessRateMinSamples) return null;
+    return this._txWindowSuccesses / total;
+  }
+}

--- a/src/lib/exit-handlers.ts
+++ b/src/lib/exit-handlers.ts
@@ -1,0 +1,47 @@
+/**
+ * Crash + startup-failure exit pattern.
+ *
+ * Why a module: keeps the side-effecting bits (process.exit, Sentry capture,
+ * setTimeout) injectable so we can assert call order in tests without actually
+ * tearing down the test runner.
+ */
+
+export interface CaptureAndExitDeps {
+  /** Sentry capture — failures here are swallowed (never block exit). */
+  capture: (err: unknown) => void;
+  /** Structured logger; only .error is used. */
+  logger: { error: (msg: string, ctx?: Record<string, unknown>) => void };
+  /** Process exit; mocked in tests so the runner stays alive. */
+  exit: (code: number) => void;
+  /** Scheduling primitive; mocked in tests to run synchronously. */
+  setTimer: (cb: () => void, ms: number) => void;
+  /** Sentry flush window before hard-exit. Default 2000ms. */
+  flushMs?: number;
+}
+
+/**
+ * Log, capture to Sentry, wait briefly for flush, then exit(1).
+ *
+ * Used by start() rejection handler and uncaughtException / unhandledRejection
+ * handlers. The keeper signs against live funds — silent recovery from an
+ * unhandled error risks operating with corrupt in-process state. Better to
+ * crash and let Railway restart a clean process.
+ */
+export function captureAndExit(
+  reason: string,
+  err: unknown,
+  deps: CaptureAndExitDeps,
+): void {
+  const error = err instanceof Error ? err : new Error(String(err));
+  deps.logger.error(reason, {
+    error: error.message,
+    stack: error.stack,
+  });
+  try {
+    deps.capture(error);
+  } catch {
+    // Sentry must never block exit. Network outage, DSN unset — swallow.
+  }
+  const flushMs = deps.flushMs ?? 2000;
+  deps.setTimer(() => deps.exit(1), flushMs);
+}

--- a/src/lib/startup-tracker.ts
+++ b/src/lib/startup-tracker.ts
@@ -1,0 +1,40 @@
+/**
+ * Tracks whether the asynchronous keeper boot (RPC connectivity probe,
+ * market discovery, service start) has completed.
+ *
+ * The /health endpoint must return 503 until start() resolves successfully;
+ * Railway otherwise marks the container healthy the moment the HTTP server
+ * binds — well before the keeper can actually crank anything.
+ */
+export type StartupState = "starting" | "ready" | "failed";
+
+export class StartupTracker {
+  private _state: StartupState = "starting";
+  private _failureReason?: string;
+
+  markReady(): void {
+    if (this._state === "failed") return;
+    this._state = "ready";
+  }
+
+  markFailed(reason: string): void {
+    this._state = "failed";
+    this._failureReason = reason;
+  }
+
+  get state(): StartupState {
+    return this._state;
+  }
+
+  get failureReason(): string | undefined {
+    return this._failureReason;
+  }
+
+  isReady(): boolean {
+    return this._state === "ready";
+  }
+
+  isFailed(): boolean {
+    return this._state === "failed";
+  }
+}

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -11,7 +11,7 @@ describe("validateKeeperEnvGuards", () => {
     } as NodeJS.ProcessEnv;
 
     expect(() => validateKeeperEnvGuards(env)).toThrow(
-      "SECURITY: SUPABASE_SERVICE_ROLE_KEY must NOT be set in keeper env"
+      "SECURITY: SUPABASE_SERVICE_ROLE_KEY must NOT be set in keeper env",
     );
   });
 
@@ -24,7 +24,7 @@ describe("validateKeeperEnvGuards", () => {
     } as NodeJS.ProcessEnv;
 
     expect(() => validateKeeperEnvGuards(env)).toThrow(
-      "SECURITY: SUPABASE_SERVICE_ROLE_KEY must NOT be set in keeper env"
+      "SECURITY: SUPABASE_SERVICE_ROLE_KEY must NOT be set in keeper env",
     );
   });
 
@@ -93,6 +93,93 @@ describe("validateKeeperEnvGuards", () => {
       FALLBACK_RPC_URL: "https://api.devnet.solana.com",
     } as NodeJS.ProcessEnv;
 
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
+
+  // A2: mainnet-mode local-host rejection
+  describe("when NETWORK=mainnet", () => {
+    it.each([
+      ["localhost", "https://localhost/"],
+      ["127.0.0.1", "https://127.0.0.1/"],
+      ["0.0.0.0", "https://0.0.0.0/"],
+      ["[::1]", "https://[::1]/"],
+    ])("rejects SOLANA_RPC_URL pointing at %s", (host, url) => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: url,
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        new RegExp(`SOLANA_RPC_URL points at .* but NETWORK=mainnet`),
+      );
+    });
+
+    it("rejects FALLBACK_RPC_URL pointing at localhost", () => {
+      const env = {
+        NETWORK: "mainnet",
+        FALLBACK_RPC_URL: "https://localhost/",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /FALLBACK_RPC_URL points at .* but NETWORK=mainnet/,
+      );
+    });
+
+    it("rejects SOLANA_RPC_WS_URL pointing at 127.0.0.1", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_WS_URL: "wss://127.0.0.1/",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /SOLANA_RPC_WS_URL points at .* but NETWORK=mainnet/,
+      );
+    });
+
+    it("rejects URLs using port 8899 (test validator)", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: "https://some-host.example.com:8899/",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /SOLANA_RPC_URL uses port 8899 \(Solana test validator\) but NETWORK=mainnet/,
+      );
+    });
+
+    it("rejects mainnet+localhost even when ALLOW_INSECURE_RPC=true (separate guard)", () => {
+      // ALLOW_INSECURE_RPC bypasses the http:// guard but NOT the mainnet+localhost guard
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: "http://localhost:8899",
+        ALLOW_INSECURE_RPC: "true",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /SOLANA_RPC_URL points at .* but NETWORK=mainnet/,
+      );
+    });
+
+    it("accepts real mainnet RPC URLs", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: "https://mainnet.helius-rpc.com/?api-key=xxx",
+        SOLANA_RPC_WS_URL: "wss://mainnet.helius-rpc.com/?api-key=xxx",
+        FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
+
+    it("throws on URL that fails to parse", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: "not a url at all",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow();
+    });
+  });
+
+  // A2: NETWORK unset (or non-mainnet) — local URLs are fine when paired with ALLOW_INSECURE_RPC
+  it("allows localhost when NETWORK is not mainnet (devnet/local dev)", () => {
+    const env = {
+      SOLANA_RPC_URL: "http://localhost:8899",
+      ALLOW_INSECURE_RPC: "true",
+    } as NodeJS.ProcessEnv;
     expect(() => validateKeeperEnvGuards(env)).not.toThrow();
   });
 });

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -161,8 +161,36 @@ describe("validateKeeperEnvGuards", () => {
         SOLANA_RPC_URL: "https://mainnet.helius-rpc.com/?api-key=xxx",
         SOLANA_RPC_WS_URL: "wss://mainnet.helius-rpc.com/?api-key=xxx",
         FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
+        RPC_URL: "https://mainnet.helius-rpc.com/?api-key=xxx",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
+
+    // A.7 (HIGH): RPC_URL is the var actually read by @percolatorct/shared and
+    // src/lib/priority-fee.ts. Without this guard, a RPC_URL=http://localhost
+    // on mainnet would be accepted while SOLANA_RPC_URL is guarded.
+    it.each([
+      ["localhost", "https://localhost/"],
+      ["127.0.0.1", "https://127.0.0.1/"],
+      ["0.0.0.0", "https://0.0.0.0/"],
+    ])("A.7: rejects RPC_URL pointing at %s on mainnet", (host, url) => {
+      const env = {
+        NETWORK: "mainnet",
+        RPC_URL: url,
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /RPC_URL points at .* but NETWORK=mainnet/,
+      );
+    });
+
+    it("A.7: rejects RPC_URL on port 8899 on mainnet", () => {
+      const env = {
+        NETWORK: "mainnet",
+        RPC_URL: "https://some-host.example.com:8899/",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /RPC_URL uses port 8899 \(Solana test validator\) but NETWORK=mainnet/,
+      );
     });
 
     it("throws on URL that fails to parse", () => {
@@ -178,6 +206,16 @@ describe("validateKeeperEnvGuards", () => {
   it("allows localhost when NETWORK is not mainnet (devnet/local dev)", () => {
     const env = {
       SOLANA_RPC_URL: "http://localhost:8899",
+      ALLOW_INSECURE_RPC: "true",
+    } as NodeJS.ProcessEnv;
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
+
+  // A.7: RPC_URL is unguarded outside mainnet — local dev should still work.
+  it("A.7: allows RPC_URL=http://localhost:8899 when NETWORK=devnet", () => {
+    const env = {
+      NETWORK: "devnet",
+      RPC_URL: "http://localhost:8899",
       ALLOW_INSECURE_RPC: "true",
     } as NodeJS.ProcessEnv;
     expect(() => validateKeeperEnvGuards(env)).not.toThrow();

--- a/tests/lib/budget.property.test.ts
+++ b/tests/lib/budget.property.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { KeeperBudget, type TxResult } from "../../src/lib/budget.js";
+
+const PROPERTY_CONFIG = {
+  maxSolPerCycle: 10_000_000,
+  maxSolPerHour: 100_000_000,
+  maxSolPerDay: 1_000_000_000,
+  maxTxPerCycle: 1_000,
+  txSuccessRateWindow: 60_000,
+  txSuccessRateThreshold: 0.5,
+  txSuccessRateMinSamples: 4,
+} as const;
+
+const txResultArb: fc.Arbitrary<TxResult> = fc.constantFrom("success", "fail", "drop");
+const lamportsArb = fc.integer({ min: 1, max: 100_000 });
+const advanceArb = fc.integer({ min: 0, max: 5_000 });
+
+describe("KeeperBudget — property tests", () => {
+  it(
+    "once halted, every subsequent canSpend returns false until resume()",
+    () => {
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.tuple(lamportsArb, txResultArb, advanceArb),
+            { minLength: 1, maxLength: 200 },
+          ),
+          fc.array(lamportsArb, { minLength: 0, maxLength: 50 }),
+          (recordSeq, probeSeq) => {
+            let t = 1_700_000_000_000;
+            const b = new KeeperBudget(PROPERTY_CONFIG, { now: () => t });
+            for (const [lamports, result, advance] of recordSeq) {
+              b.recordTx(lamports, "crank", result);
+              t += advance;
+            }
+            // Probe canSpend until we trip the halt
+            let halted = false;
+            for (const lamports of probeSeq) {
+              const allowed = b.canSpend(lamports, "crank");
+              if (b.isHalted()) {
+                // From this point on, no canSpend may return true.
+                halted = true;
+              }
+              if (halted) {
+                expect(allowed).toBe(false);
+              }
+            }
+          },
+        ),
+        { numRuns: 500 },
+      );
+    },
+    30_000,
+  );
+
+  it(
+    "isHalted() never transitions halted → not-halted without resume() call",
+    () => {
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.tuple(lamportsArb, txResultArb, advanceArb),
+            { minLength: 1, maxLength: 300 },
+          ),
+          (ops) => {
+            let t = 1_700_000_000_000;
+            const b = new KeeperBudget(PROPERTY_CONFIG, { now: () => t });
+            let everHalted = false;
+            for (const [lamports, result, advance] of ops) {
+              b.recordTx(lamports, "crank", result);
+              b.canSpend(lamports, "crank");
+              t += advance;
+              if (b.isHalted()) everHalted = true;
+              if (everHalted) {
+                expect(b.isHalted()).toBe(true);
+              }
+            }
+          },
+        ),
+        { numRuns: 500 },
+      );
+    },
+    30_000,
+  );
+
+  it(
+    "cycle spend invariant: cycleSpend equals sum of non-drop recordTx since last beginCycle",
+    () => {
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.tuple(lamportsArb, txResultArb),
+            { minLength: 1, maxLength: 100 },
+          ),
+          (ops) => {
+            const b = new KeeperBudget(
+              { ...PROPERTY_CONFIG, maxSolPerCycle: Number.MAX_SAFE_INTEGER },
+              { now: () => 1_700_000_000_000 },
+            );
+            let expected = 0;
+            for (const [lamports, result] of ops) {
+              b.recordTx(lamports, "crank", result);
+              if (result !== "drop") expected += lamports;
+            }
+            expect(b.getStats().cycleSpend).toBe(expected);
+          },
+        ),
+        { numRuns: 500 },
+      );
+    },
+    30_000,
+  );
+
+  it(
+    "hourSpendSum stays nonnegative and equals sum of unexpired events",
+    () => {
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.tuple(lamportsArb, txResultArb, advanceArb),
+            { minLength: 1, maxLength: 200 },
+          ),
+          (ops) => {
+            let t = 1_700_000_000_000;
+            const b = new KeeperBudget(
+              { ...PROPERTY_CONFIG, maxSolPerHour: Number.MAX_SAFE_INTEGER, maxSolPerDay: Number.MAX_SAFE_INTEGER, maxSolPerCycle: Number.MAX_SAFE_INTEGER, maxTxPerCycle: Number.MAX_SAFE_INTEGER },
+              { now: () => t },
+            );
+            for (const [lamports, result, advance] of ops) {
+              b.recordTx(lamports, "crank", result);
+              t += advance;
+              const stats = b.getStats();
+              expect(stats.hourSpend).toBeGreaterThanOrEqual(0);
+              expect(stats.daySpend).toBeGreaterThanOrEqual(0);
+              expect(stats.hourSpend).toBeLessThanOrEqual(stats.daySpend);
+            }
+          },
+        ),
+        { numRuns: 500 },
+      );
+    },
+    30_000,
+  );
+
+  it(
+    "success rate within [0,1] when defined",
+    () => {
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.tuple(lamportsArb, fc.constantFrom<TxResult>("success", "fail")),
+            { minLength: 1, maxLength: 100 },
+          ),
+          (ops) => {
+            const b = new KeeperBudget(
+              { ...PROPERTY_CONFIG, txSuccessRateMinSamples: 1 },
+              { now: () => 1_700_000_000_000 },
+            );
+            for (const [lamports, result] of ops) {
+              b.recordTx(lamports, "crank", result);
+              const rate = b.getStats().txSuccessRate;
+              if (rate !== null) {
+                expect(rate).toBeGreaterThanOrEqual(0);
+                expect(rate).toBeLessThanOrEqual(1);
+              }
+            }
+          },
+        ),
+        { numRuns: 500 },
+      );
+    },
+    30_000,
+  );
+});

--- a/tests/lib/budget.stress.test.ts
+++ b/tests/lib/budget.stress.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { KeeperBudget } from "../../src/lib/budget.js";
+
+const STRESS = process.env.STRESS === "true";
+
+const STRESS_CONFIG = {
+  maxSolPerCycle: Number.MAX_SAFE_INTEGER,
+  maxSolPerHour: Number.MAX_SAFE_INTEGER,
+  maxSolPerDay: Number.MAX_SAFE_INTEGER,
+  maxTxPerCycle: Number.MAX_SAFE_INTEGER,
+  txSuccessRateWindow: 60_000,
+  txSuccessRateThreshold: 0.5,
+  txSuccessRateMinSamples: 10,
+} as const;
+
+describe.skipIf(!STRESS)("KeeperBudget — stress (10k concurrent ops)", () => {
+  it(
+    "10,000 interleaved canSpend + recordTx calls — no counter drift",
+    async () => {
+      const b = new KeeperBudget(STRESS_CONFIG, { now: () => 1_700_000_000_000 });
+      const N = 10_000;
+      const LAMPORTS = 100;
+      const promises: Promise<void>[] = [];
+      let expectedSpendNonDrop = 0;
+      let expectedTxCount = 0;
+      for (let i = 0; i < N; i++) {
+        promises.push(
+          new Promise<void>((resolve) => {
+            b.canSpend(LAMPORTS, "crank");
+            const result = i % 3 === 0 ? "drop" : i % 2 === 0 ? "success" : "fail";
+            if (result !== "drop") expectedSpendNonDrop += LAMPORTS;
+            expectedTxCount += 1;
+            b.recordTx(LAMPORTS, "crank", result);
+            resolve();
+          }),
+        );
+      }
+      await Promise.all(promises);
+
+      const stats = b.getStats();
+      expect(stats.cycleTxCount).toBe(expectedTxCount);
+      expect(stats.cycleSpend).toBe(expectedSpendNonDrop);
+      expect(stats.hourSpend).toBe(expectedSpendNonDrop);
+      expect(stats.daySpend).toBe(expectedSpendNonDrop);
+    },
+    60_000,
+  );
+
+  it(
+    "10,000 ops finish under 5 seconds wall clock",
+    async () => {
+      const b = new KeeperBudget(STRESS_CONFIG, { now: () => 1_700_000_000_000 });
+      const N = 10_000;
+      const start = performance.now();
+      for (let i = 0; i < N; i++) {
+        b.canSpend(100, "crank");
+        b.recordTx(100, "crank", i % 2 === 0 ? "success" : "fail");
+      }
+      const elapsedMs = performance.now() - start;
+      expect(elapsedMs).toBeLessThan(5_000);
+    },
+    30_000,
+  );
+
+  it(
+    "halt latches under 10k op stream — exactly one halt fires",
+    async () => {
+      let haltCount = 0;
+      const tight = { ...STRESS_CONFIG, maxSolPerCycle: 50 };
+      const b = new KeeperBudget(tight, {
+        now: () => 1_700_000_000_000,
+        onHalt: () => {
+          haltCount++;
+        },
+      });
+      for (let i = 0; i < 10_000; i++) {
+        b.canSpend(10, "crank");
+        b.recordTx(10, "crank", "success");
+      }
+      expect(haltCount).toBe(1);
+      expect(b.isHalted()).toBe(true);
+    },
+    30_000,
+  );
+});
+
+// Always-on lightweight version: 1k ops to catch egregious bugs in CI without STRESS=true
+describe("KeeperBudget — lightweight concurrency smoke (1k ops, always on)", () => {
+  it("1,000 interleaved ops keep counters consistent", async () => {
+    const b = new KeeperBudget(STRESS_CONFIG, { now: () => 1_700_000_000_000 });
+    const N = 1_000;
+    const LAMPORTS = 100;
+    let expectedSpendNonDrop = 0;
+    let expectedTxCount = 0;
+    const promises: Promise<void>[] = [];
+    for (let i = 0; i < N; i++) {
+      promises.push(
+        Promise.resolve().then(() => {
+          b.canSpend(LAMPORTS, "crank");
+          const result = i % 3 === 0 ? "drop" : i % 2 === 0 ? "success" : "fail";
+          if (result !== "drop") expectedSpendNonDrop += LAMPORTS;
+          expectedTxCount += 1;
+          b.recordTx(LAMPORTS, "crank", result);
+        }),
+      );
+    }
+    await Promise.all(promises);
+    const stats = b.getStats();
+    expect(stats.cycleTxCount).toBe(expectedTxCount);
+    expect(stats.cycleSpend).toBe(expectedSpendNonDrop);
+    expect(stats.hourSpend).toBe(expectedSpendNonDrop);
+  });
+});

--- a/tests/lib/budget.test.ts
+++ b/tests/lib/budget.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi } from "vitest";
+import { KeeperBudget, type TxResult } from "../../src/lib/budget.js";
+
+function makeClock(start = 1_700_000_000_000) {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+    set: (ms: number) => {
+      t = ms;
+    },
+  };
+}
+
+const TIGHT_CONFIG = {
+  maxSolPerCycle: 1_000,
+  maxSolPerHour: 5_000,
+  maxSolPerDay: 20_000,
+  maxTxPerCycle: 5,
+  txSuccessRateWindow: 60_000,
+  txSuccessRateThreshold: 0.7,
+  txSuccessRateMinSamples: 4,
+} as const;
+
+describe("KeeperBudget — defaults", () => {
+  it("starts with sane defaults when constructed with no config", () => {
+    const b = new KeeperBudget({}, { env: {} });
+    const stats = b.getStats();
+    expect(stats.config.maxSolPerCycle).toBe(50_000_000);
+    expect(stats.config.maxSolPerHour).toBe(500_000_000);
+    expect(stats.config.maxSolPerDay).toBe(3_000_000_000);
+    expect(stats.config.maxTxPerCycle).toBe(60);
+    expect(stats.config.txSuccessRateThreshold).toBe(0.7);
+    expect(stats.halted).toBe(false);
+  });
+
+  it("env overrides take precedence over defaults", () => {
+    const b = new KeeperBudget(
+      {},
+      {
+        env: {
+          KEEPER_MAX_SOL_PER_CYCLE: "12345",
+          KEEPER_MAX_SOL_PER_DAY: "9999",
+          KEEPER_TX_SUCCESS_RATE_THRESHOLD: "0.5",
+        },
+      },
+    );
+    expect(b.config.maxSolPerCycle).toBe(12345);
+    expect(b.config.maxSolPerDay).toBe(9999);
+    expect(b.config.txSuccessRateThreshold).toBe(0.5);
+  });
+
+  it("constructor-passed config takes precedence over env", () => {
+    const b = new KeeperBudget(
+      { maxSolPerCycle: 99 },
+      { env: { KEEPER_MAX_SOL_PER_CYCLE: "12345" } },
+    );
+    expect(b.config.maxSolPerCycle).toBe(99);
+  });
+
+  it("ignores invalid env values (NaN, negative, non-integer for ints)", () => {
+    const b = new KeeperBudget(
+      {},
+      {
+        env: {
+          KEEPER_MAX_SOL_PER_CYCLE: "not-a-number",
+          KEEPER_MAX_SOL_PER_HOUR: "-100",
+          KEEPER_MAX_SOL_PER_DAY: "1.5",
+          KEEPER_TX_SUCCESS_RATE_THRESHOLD: "1.5",
+        },
+      },
+    );
+    expect(b.config.maxSolPerCycle).toBe(50_000_000);
+    expect(b.config.maxSolPerHour).toBe(500_000_000);
+    expect(b.config.maxSolPerDay).toBe(3_000_000_000);
+    expect(b.config.txSuccessRateThreshold).toBe(0.7);
+  });
+});
+
+describe("KeeperBudget — cycle spend cap", () => {
+  it("permits spending up to the cycle cap", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    expect(b.canSpend(500, "crank")).toBe(true);
+    b.recordTx(500, "crank", "success");
+    expect(b.canSpend(500, "crank")).toBe(true);
+    b.recordTx(500, "crank", "success");
+    // 1000/1000 spent — next 1 lamport must trip
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(true);
+    expect(b.haltKind).toBe("cycle-spend-cap");
+  });
+
+  it("beginCycle resets cycleSpend but does not clear halt", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    b.recordTx(1_500, "crank", "success");
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(true);
+    b.beginCycle();
+    expect(b.getStats().cycleSpend).toBe(0);
+    // halt still in effect
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(true);
+  });
+});
+
+describe("KeeperBudget — hour spend cap", () => {
+  it("trips when rolling-hour spend would exceed cap", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    for (let i = 0; i < 5; i++) {
+      b.beginCycle();
+      b.recordTx(1_000, "crank", "success");
+    }
+    // hourSpend now 5_000 == cap. Reset cycle so the cycle-spend guard does
+    // not trip first; we want to isolate the hour-spend guard.
+    b.beginCycle();
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.haltKind).toBe("hour-spend-cap");
+  });
+
+  it("auto-prunes events older than 1 hour", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    b.recordTx(4_000, "crank", "success");
+    expect(b.getStats().hourSpend).toBe(4_000);
+    clock.advance(3_600_001);
+    // trigger prune via getStats
+    expect(b.getStats().hourSpend).toBe(0);
+  });
+});
+
+describe("KeeperBudget — day spend cap", () => {
+  it("trips on day-cap breach and requires manual resume", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    for (let i = 0; i < 20; i++) {
+      b.beginCycle();
+      b.recordTx(1_000, "crank", "success");
+      clock.advance(3_600_001); // skip over hour window so hour cap doesn't trip first
+    }
+    // day spend == 20_000 == cap. Reset cycle to isolate the day-spend guard.
+    b.beginCycle();
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.haltKind).toBe("day-spend-cap");
+    // resume requires explicit operator call
+    b.resume("test-operator");
+    expect(b.isHalted()).toBe(false);
+  });
+});
+
+describe("KeeperBudget — cycle tx count cap", () => {
+  it("trips when cycle tx count would exceed cap", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    for (let i = 0; i < 5; i++) {
+      b.recordTx(1, "crank", "success");
+    }
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.haltKind).toBe("cycle-tx-count-cap");
+  });
+});
+
+describe("KeeperBudget — success rate guard", () => {
+  it("does not trip until min samples present", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(
+      { ...TIGHT_CONFIG, maxTxPerCycle: 999 },
+      { now: clock.now },
+    );
+    // 3 fails — below min samples (4) so the guard does not engage
+    for (let i = 0; i < 3; i++) b.recordTx(1, "crank", "fail");
+    expect(b.canSpend(1, "crank")).toBe(true);
+    expect(b.isHalted()).toBe(false);
+  });
+
+  it("trips when rate below threshold and samples sufficient", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(
+      { ...TIGHT_CONFIG, maxTxPerCycle: 999 },
+      { now: clock.now },
+    );
+    // 4 fails, 0 success → rate 0 < 0.7
+    for (let i = 0; i < 4; i++) b.recordTx(1, "crank", "fail");
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.haltKind).toBe("tx-success-rate");
+  });
+
+  it("does not trip when rate above threshold", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(
+      { ...TIGHT_CONFIG, maxTxPerCycle: 999 },
+      { now: clock.now },
+    );
+    // 3 success, 1 fail → rate 0.75 > 0.7
+    for (let i = 0; i < 3; i++) b.recordTx(1, "crank", "success");
+    b.recordTx(1, "crank", "fail");
+    expect(b.canSpend(1, "crank")).toBe(true);
+  });
+
+  it("auto-prunes tx records older than window", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(
+      { ...TIGHT_CONFIG, maxTxPerCycle: 999 },
+      { now: clock.now },
+    );
+    for (let i = 0; i < 4; i++) b.recordTx(1, "crank", "fail");
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.haltKind).toBe("tx-success-rate");
+    // resume + advance past window — fresh slate
+    b.resume("op");
+    clock.advance(60_001);
+    expect(b.getStats().txWindowSize).toBe(0);
+    expect(b.canSpend(1, "crank")).toBe(true);
+  });
+});
+
+describe("KeeperBudget — drop result accounting", () => {
+  it("counts toward tx count but not spend", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    b.recordTx(500, "crank", "drop");
+    const s = b.getStats();
+    expect(s.cycleSpend).toBe(0);
+    expect(s.cycleTxCount).toBe(1);
+    expect(s.hourSpend).toBe(0);
+    expect(s.daySpend).toBe(0);
+    expect(s.txWindowSize).toBe(0);
+  });
+});
+
+describe("KeeperBudget — resume() semantics", () => {
+  it("resume clears halt state and lets canSpend return true again", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    b.recordTx(2_000, "crank", "success");
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(true);
+
+    b.beginCycle();
+    b.resume("operator-alice");
+
+    expect(b.isHalted()).toBe(false);
+    expect(b.haltReason).toBeUndefined();
+    expect(b.haltKind).toBeUndefined();
+    expect(b.canSpend(1, "crank")).toBe(true);
+  });
+
+  it("resume() on a non-halted budget is a no-op", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    expect(() => b.resume("op")).not.toThrow();
+    expect(b.isHalted()).toBe(false);
+  });
+
+  it("haltManually trips with kind=operator and respects resume", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    b.haltManually("cordoning for deploy");
+    expect(b.isHalted()).toBe(true);
+    expect(b.haltKind).toBe("operator");
+    expect(b.canSpend(1, "crank")).toBe(false);
+    b.resume("op");
+    expect(b.canSpend(1, "crank")).toBe(true);
+  });
+});
+
+describe("KeeperBudget — onHalt hook", () => {
+  it("fires once on first halt with kind + reason", () => {
+    const clock = makeClock();
+    const onHalt = vi.fn();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, onHalt });
+    b.recordTx(2_000, "crank", "success");
+    b.canSpend(1, "crank");
+    expect(onHalt).toHaveBeenCalledTimes(1);
+    expect(onHalt).toHaveBeenCalledWith("cycle-spend-cap", expect.any(String));
+  });
+
+  it("does not double-fire on subsequent canSpend calls", () => {
+    const clock = makeClock();
+    const onHalt = vi.fn();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, onHalt });
+    b.recordTx(2_000, "crank", "success");
+    b.canSpend(1, "crank");
+    b.canSpend(1, "crank");
+    b.canSpend(1, "crank");
+    expect(onHalt).toHaveBeenCalledTimes(1);
+  });
+
+  it("hook errors are caught and do not break canSpend", () => {
+    const clock = makeClock();
+    const onHalt = vi.fn(() => {
+      throw new Error("metric backend down");
+    });
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, onHalt });
+    b.recordTx(2_000, "crank", "success");
+    expect(() => b.canSpend(1, "crank")).not.toThrow();
+    expect(b.isHalted()).toBe(true);
+  });
+});
+
+describe("KeeperBudget — recordTx input validation", () => {
+  it("ignores negative lamports", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    b.recordTx(-100, "crank", "success");
+    expect(b.getStats().cycleSpend).toBe(0);
+    expect(b.getStats().cycleTxCount).toBe(0);
+  });
+
+  it("ignores NaN lamports", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    b.recordTx(NaN, "crank", "success");
+    expect(b.getStats().cycleSpend).toBe(0);
+    expect(b.getStats().cycleTxCount).toBe(0);
+  });
+});
+
+describe("KeeperBudget — counter consistency under sequential ops", () => {
+  it("hourSpendSum matches the sum of unexpired events at all times", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    const results: TxResult[] = ["success", "fail", "drop"];
+    for (let i = 0; i < 100; i++) {
+      const r = results[i % 3]!;
+      b.recordTx(7, "crank", r);
+      if (i % 17 === 0) {
+        clock.advance(40_000);
+      }
+    }
+    const stats = b.getStats();
+    expect(stats.hourSpend).toBeGreaterThanOrEqual(0);
+    expect(stats.hourSpend).toBeLessThanOrEqual(stats.daySpend);
+  });
+});

--- a/tests/lib/exit-handlers.test.ts
+++ b/tests/lib/exit-handlers.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+import { captureAndExit } from "../../src/lib/exit-handlers.js";
+
+function makeDeps() {
+  const exit = vi.fn();
+  const capture = vi.fn();
+  const error = vi.fn();
+  const timers: Array<{ cb: () => void; ms: number }> = [];
+  const setTimer = vi.fn((cb: () => void, ms: number) => {
+    timers.push({ cb, ms });
+  });
+  return {
+    deps: { exit, capture, logger: { error }, setTimer },
+    timers,
+  };
+}
+
+describe("captureAndExit", () => {
+  it("logs reason and error message + stack", () => {
+    const { deps } = makeDeps();
+    const err = new Error("boom");
+    captureAndExit("the keeper exploded", err, deps);
+    expect(deps.logger.error).toHaveBeenCalledWith("the keeper exploded", {
+      error: "boom",
+      stack: err.stack,
+    });
+  });
+
+  it("captures the original Error instance to Sentry", () => {
+    const { deps } = makeDeps();
+    const err = new Error("boom");
+    captureAndExit("the keeper exploded", err, deps);
+    expect(deps.capture).toHaveBeenCalledWith(err);
+  });
+
+  it("wraps non-Error rejections in a synthetic Error before capture", () => {
+    const { deps } = makeDeps();
+    captureAndExit("rejection", "some string reason", deps);
+    const captured = deps.capture.mock.calls[0]?.[0] as Error;
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toBe("some string reason");
+  });
+
+  it("schedules process.exit(1) after the flush window", () => {
+    const { deps, timers } = makeDeps();
+    captureAndExit("reason", new Error("x"), deps);
+    expect(timers).toHaveLength(1);
+    expect(timers[0].ms).toBe(2000);
+    expect(deps.exit).not.toHaveBeenCalled();
+    timers[0].cb();
+    expect(deps.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("honors custom flushMs", () => {
+    const { deps, timers } = makeDeps();
+    captureAndExit("reason", new Error("x"), { ...deps, flushMs: 7777 });
+    expect(timers[0].ms).toBe(7777);
+  });
+
+  it("swallows Sentry capture failures (still exits)", () => {
+    const { deps, timers } = makeDeps();
+    deps.capture.mockImplementation(() => {
+      throw new Error("sentry down");
+    });
+    expect(() =>
+      captureAndExit("reason", new Error("x"), deps),
+    ).not.toThrow();
+    timers[0].cb();
+    expect(deps.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("call order is log → capture → schedule exit", () => {
+    const events: string[] = [];
+    const exit = vi.fn(() => events.push("exit"));
+    const capture = vi.fn(() => events.push("capture"));
+    const error = vi.fn(() => events.push("log"));
+    const setTimer = vi.fn((cb: () => void) => {
+      events.push("setTimer");
+      cb();
+    });
+    captureAndExit("reason", new Error("x"), {
+      exit,
+      capture,
+      logger: { error },
+      setTimer,
+    });
+    expect(events).toEqual(["log", "capture", "setTimer", "exit"]);
+  });
+});

--- a/tests/lib/startup-tracker.test.ts
+++ b/tests/lib/startup-tracker.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { StartupTracker } from "../../src/lib/startup-tracker.js";
+
+describe("StartupTracker", () => {
+  it("starts in 'starting' state", () => {
+    const t = new StartupTracker();
+    expect(t.state).toBe("starting");
+    expect(t.isReady()).toBe(false);
+    expect(t.isFailed()).toBe(false);
+    expect(t.failureReason).toBeUndefined();
+  });
+
+  it("transitions to 'ready' after markReady()", () => {
+    const t = new StartupTracker();
+    t.markReady();
+    expect(t.state).toBe("ready");
+    expect(t.isReady()).toBe(true);
+    expect(t.isFailed()).toBe(false);
+  });
+
+  it("transitions to 'failed' after markFailed() and captures the reason", () => {
+    const t = new StartupTracker();
+    t.markFailed("RPC unreachable");
+    expect(t.state).toBe("failed");
+    expect(t.isFailed()).toBe(true);
+    expect(t.isReady()).toBe(false);
+    expect(t.failureReason).toBe("RPC unreachable");
+  });
+
+  it("markReady() is ignored after markFailed() — failure is terminal", () => {
+    const t = new StartupTracker();
+    t.markFailed("RPC unreachable");
+    t.markReady();
+    expect(t.state).toBe("failed");
+    expect(t.isReady()).toBe(false);
+  });
+
+  it("markFailed() overrides markReady() if called after — operator killswitch semantics", () => {
+    const t = new StartupTracker();
+    t.markReady();
+    t.markFailed("late failure");
+    expect(t.state).toBe("failed");
+    expect(t.failureReason).toBe("late failure");
+  });
+
+  it("multiple markReady() calls are idempotent", () => {
+    const t = new StartupTracker();
+    t.markReady();
+    t.markReady();
+    t.markReady();
+    expect(t.state).toBe("ready");
+  });
+});


### PR DESCRIPTION
## Summary

Workstream A2–A8 from the Phase 1 brief — keeper safety hardening that is **program-agnostic** (won't need to be redone after v16). Stacks on top of A1 (#113) in module spirit; this PR does not touch A1's files so will rebase cleanly when A1 merges.

## Per-fix breakdown

| ID | What | Where |
|---|---|---|
| A2 | env-guards rejects \`localhost\` / \`127.0.0.1\` / \`0.0.0.0\` / \`[::1]\` / port \`8899\` when \`NETWORK=mainnet\` | \`src/env-guards.ts\` |
| A3 | Deleted unreachable \"anon == service-role\" equality check (pre-empted by hard-reject above it) | \`src/env-guards.ts\` |
| A4 | Deleted dead per-market \`setInterval\` loop that ran on an empty Map at module load; \`lastSuccessfulCrankTime\`/\`lastOracleUpdateTime\` were never read | \`src/index.ts\` |
| A5 | New \`StartupTracker\`; \`start()\` success → markReady, failure → \`captureAndExit\`; /health hard 503 until ready | \`src/lib/startup-tracker.ts\`, \`src/index.ts\` |
| A6 | \`unhandledRejection\` / \`uncaughtException\` → \`captureException\` + 2s Sentry flush + \`process.exit(1)\`. No silent recovery. | \`src/lib/exit-handlers.ts\`, \`src/index.ts\` |
| A7 | \`KeeperBudget\` circuit breaker — cycle/hour/day spend caps, tx-count cap, rolling success-rate guard. Halt latches; day-cap requires manual \`resume()\` | \`src/lib/budget.ts\` |
| A8 | SOL-balance-low log truncates wallet pubkey to match Discord embed format | \`src/index.ts\` |

## New modules

- \`src/lib/exit-handlers.ts\` (47 LOC) — used by A5+A6
- \`src/lib/startup-tracker.ts\` (40 LOC) — used by A5
- \`src/lib/budget.ts\` (345 LOC) — A7

## Tests added (+54 passing, +3 STRESS-gated, ~720 LOC)

- \`tests/lib/exit-handlers.test.ts\` — 7 cases: log+capture+exit call order, custom flush window, Sentry-failure-swallowing
- \`tests/lib/startup-tracker.test.ts\` — 6 cases: state machine + sticky failure semantics
- \`tests/lib/budget.test.ts\` — 24 unit cases per cap + drop accounting + onHalt hook + env override
- \`tests/lib/budget.property.test.ts\` — 5 fast-check properties × 500 runs (halt latches, isHalted is sticky, cycleSpend invariant, hourSpend bounds, success-rate domain)
- \`tests/lib/budget.stress.test.ts\` — 1k-op concurrency smoke (always-on); 10k-op cases gated behind \`STRESS=true\`
- \`tests/env-guards.test.ts\` — 8 new cases covering mainnet+local-host rejection

## Dependency added

- \`fast-check@^4.8.0\` (devDep) — property-based testing, on the brief's allow-list

## Test plan

- [x] \`pnpm build\` clean (tsc, strict)
- [x] \`pnpm test\`: **225 passed | 6 skipped** (was 171 / 3) — +54 new test cases
- [x] Property tests pass with 500 runs each
- [x] \`STRESS=true pnpm test\` locally: 10k-op stress finishes in < 5s wall, counters consistent, halt latches exactly once
- [ ] Shadow keeper (\`DRY_RUN=true\`) in us-east4 for 24h
- [ ] Promote to live keeper (eu-west4); verify boot + /health 503-then-200 transition + crash handler firing on contrived error

## What this does NOT change

- **KeeperBudget is not wired into the send path yet.** That's Workstream D6 (D-series PR). This PR ships the module + tests only.
- /health internal status logic (starting / ok / degraded / down) is unchanged for the ready path — the new 503 only fires when \`startupTracker\` hasn't marked ready.
- A1's program-id assertion is in #113 and not duplicated here. When #113 merges, this branch rebases cleanly (no overlap with the changed imports section).

## Shadow observation guidance

- Boot logs should show new \"Keeper start() resolved — health endpoint now reports ready\" line on success
- /health returns 503 with \`{ status: \"starting\" }\` during initial discovery, transitions to 200 with full rich body afterward
- Crash handlers should be invisible in normal operation — process still exits 0 on SIGTERM as before
- A halted KeeperBudget would log \`Keeper budget halted — refusing further sends until manual resume()\` at ERROR level; in this PR, \`canSpend\`/\`recordTx\` aren't called from the send path, so this should never fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)