### PR TITLE
fix(keeper): Phase 1 Workstream B' — 17 pure-TS audit bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.2.2",
+    "fast-check": "^4.8.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^4.0.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     dependencies:
       '@percolatorct/sdk':
-        specifier: ^2.0.9
+        specifier: 2.0.9
         version: 2.0.9(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@percolatorct/shared':
         specifier: 1.0.0-beta.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@types/node':
         specifier: ^25.2.2
         version: 25.5.0
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -927,6 +930,10 @@ packages:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
@@ -1134,6 +1141,9 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
@@ -2310,6 +2320,10 @@ snapshots:
 
   eyes@0.1.8: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-stable-stringify@1.0.0: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
@@ -2480,6 +2494,8 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  pure-rand@8.4.0: {}
 
   require-in-the-middle@8.0.1:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,13 @@ const solBalanceCheckInterval = setInterval(async () => {
 }, 60_000);
 solBalanceCheckInterval.unref();
 
+// B7: per-market cooldown so we don't fire a Discord critical every 60 s while
+// an oracle is stuck. The old aggregate alert reset only when the stale set
+// emptied, which never happened during a multi-hour DEX outage — channel got
+// nuked. Track last-alert per slab and re-fire only after STALE_ALERT_COOLDOWN_MS.
+const STALE_ALERT_COOLDOWN_MS = Number(process.env.KEEPER_STALE_ALERT_COOLDOWN_MS ?? 5 * 60_000);
+const lastStaleAlertByMarket = new Map<string, number>();
+
 const staleCheckInterval = setInterval(() => {
   // Skip stale checks during startup grace period (GH#29 — false CRITICAL floods on deploy)
   if (Date.now() - _keeperStartTime < STARTUP_GRACE_MS) return;
@@ -127,10 +134,26 @@ const staleCheckInterval = setInterval(() => {
     }
   }
 
-  // Send alert for 5-min stale markets (includes paused ones)
-  if (alertStale.length > 0) {
+  // Recovered markets should drop their cooldown entry so a fresh staleness
+  // event re-alerts immediately rather than waiting for the cooldown window.
+  const alertSet = new Set(alertStale);
+  for (const market of Array.from(lastStaleAlertByMarket.keys())) {
+    if (!alertSet.has(market)) lastStaleAlertByMarket.delete(market);
+  }
+
+  // B7: per-market cooldown — gather the subset whose cooldown has elapsed.
+  const now = Date.now();
+  const toAlert: string[] = [];
+  for (const market of alertStale) {
+    const last = lastStaleAlertByMarket.get(market) ?? 0;
+    if (now - last >= STALE_ALERT_COOLDOWN_MS) {
+      lastStaleAlertByMarket.set(market, now);
+      toAlert.push(market);
+    }
+  }
+  if (toAlert.length > 0) {
     sendCriticalAlert("Oracle stale for markets", [
-      { name: "Stale Markets", value: alertStale.join(", "), inline: false },
+      { name: "Stale Markets", value: toAlert.join(", "), inline: false },
       { name: "Paused (>10min)", value: stalePausedMarkets.size.toString(), inline: true },
     ]).catch(() => {});
   }
@@ -453,9 +476,10 @@ res.writeHead(401, secureJsonHeaders);
   }
 });
 
-healthServer.listen(healthPort, () => {
-  logger.info("Health endpoint started", { port: healthPort });
-});
+// B13: do NOT bind the health port at module load. start() calls .listen()
+// after services are wired so Railway treats the missing port as unhealthy
+// during boot — without this, Railway flips to "healthy" the moment the
+// server binds (well before the keeper can actually crank anything).
 
 /**
  * Escalating retry delays for startup market discovery.
@@ -533,7 +557,7 @@ async function start() {
     logger.info("No markets found — keeper will idle and retry discovery each cycle. This is normal for fresh mainnet deployments.");
   }
 
-  crankService.start();
+  await crankService.start();
   logger.info("Crank service started");
   liquidationService.start(() => crankService.getMarkets());
   logger.info("Liquidation scanner started");
@@ -546,7 +570,19 @@ async function start() {
     adlService.start(() => crankService.getMarkets());
     logger.info("ADL service started");
   }
-  
+
+  // B13: bind the health port only after every service is wired up. Wrapped in
+  // a Promise so start() awaits the bind callback before resolving — otherwise
+  // a concurrent /health probe could land between this call and start() resolving.
+  await new Promise<void>((resolve, reject) => {
+    healthServer.once("error", reject);
+    healthServer.listen(healthPort, () => {
+      healthServer.off("error", reject);
+      logger.info("Health endpoint started", { port: healthPort });
+      resolve();
+    });
+  });
+
   // Send startup alert
   await sendInfoAlert("Keeper service started", [
     { name: "Markets Tracked", value: markets.length.toString(), inline: true },

--- a/src/lib/alert-aggregator.ts
+++ b/src/lib/alert-aggregator.ts
@@ -1,0 +1,91 @@
+/**
+ * AlertAggregator — buffer high-frequency alerts and flush them as a single
+ * summary so Discord (or any sink) isn't spammed during a cascade.
+ *
+ * Usage: per `add(key)` call we increment that key's bucket. After
+ * `bufferMs` of any-key activity we flush all buckets via `flushFn(key, count)`
+ * and clear them. The timer is anchored to the first `add` since the last
+ * flush — not rolling — so an event 4 s into a 5 s window still flushes 1 s
+ * later, not 5 s later. Bounded memory by `maxBuckets`.
+ */
+
+export interface AlertAggregatorOptions {
+  /** ms between first add and flush. Default 5_000. */
+  bufferMs?: number;
+  /** Cap on distinct keys before forced flush. Default 1_000. */
+  maxBuckets?: number;
+  /** Logger used when flushFn throws — never thrown back to the caller. */
+  onFlushError?: (err: unknown) => void;
+  /** Injectable scheduler for tests. */
+  setTimer?: (cb: () => void, ms: number) => unknown;
+  /** Injectable cancel for tests. */
+  clearTimer?: (handle: unknown) => void;
+}
+
+export type FlushFn = (key: string, count: number) => Promise<void> | void;
+
+export class AlertAggregator {
+  private readonly buckets = new Map<string, number>();
+  private readonly bufferMs: number;
+  private readonly maxBuckets: number;
+  private readonly onFlushError: (err: unknown) => void;
+  private readonly setTimer: (cb: () => void, ms: number) => unknown;
+  private readonly clearTimer: (handle: unknown) => void;
+  private timerHandle: unknown = null;
+
+  constructor(
+    private readonly flushFn: FlushFn,
+    opts: AlertAggregatorOptions = {},
+  ) {
+    this.bufferMs = opts.bufferMs ?? 5_000;
+    this.maxBuckets = opts.maxBuckets ?? 1_000;
+    this.onFlushError = opts.onFlushError ?? (() => {});
+    this.setTimer = opts.setTimer ?? ((cb, ms) => setTimeout(cb, ms));
+    this.clearTimer = opts.clearTimer ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+  }
+
+  add(key: string): void {
+    const prev = this.buckets.get(key) ?? 0;
+    this.buckets.set(key, prev + 1);
+    if (this.buckets.size > this.maxBuckets) {
+      // Cap-bound flush so a runaway producer never grows the Map unboundedly.
+      void this.flush();
+      return;
+    }
+    if (this.timerHandle === null) {
+      this.timerHandle = this.setTimer(() => {
+        void this.flush();
+      }, this.bufferMs);
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.timerHandle !== null) {
+      this.clearTimer(this.timerHandle);
+      this.timerHandle = null;
+    }
+    if (this.buckets.size === 0) return;
+    const snapshot = Array.from(this.buckets.entries());
+    this.buckets.clear();
+    for (const [key, count] of snapshot) {
+      try {
+        await this.flushFn(key, count);
+      } catch (err) {
+        this.onFlushError(err);
+      }
+    }
+  }
+
+  /** Drop pending buckets without flushing (used on shutdown when the sink is also closing). */
+  stop(): void {
+    if (this.timerHandle !== null) {
+      this.clearTimer(this.timerHandle);
+      this.timerHandle = null;
+    }
+    this.buckets.clear();
+  }
+
+  size(): number {
+    return this.buckets.size;
+  }
+}

--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -353,6 +353,12 @@ export class AdlService {
    * Returns number of ExecuteAdl transactions sent (0 if ADL not needed).
    */
   async scanMarket(slabAddress: string, market: DiscoveredMarket): Promise<number> {
+    // B17: stamp lastScanTime on every scan so /status reports activity even
+    // when the trigger conditions are false. Without this the field stays at 0
+    // and looks like the ADL service has never run — operators can't tell
+    // "ADL is off" from "ADL is hung".
+    this._getOrCreateState(slabAddress).lastScanTime = Date.now();
+
     const connection = getConnection();
     const keypair = this._keypair;
     const programId = market.programId;

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -109,7 +109,10 @@ interface MarketCrankState {
  *  resolves so there is no read-modify-write race even under unusual
  *  microtask interleavings.
  */
-async function processBatched<T>(
+// A.15: exported so the per-item counter correctness can be property-tested
+// directly. Module-private would force testing via crankAll() with discovery
+// + filtering wrapper overhead that would mask off-by-ones.
+export async function processBatched<T>(
   items: T[],
   batchSize: number,
   delayMs: number,

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -62,6 +62,12 @@ interface MarketCrankState {
   /** How many times this market has been skipped for 0x4 across rediscoveries */
   skipCount?: number;
   /**
+   * B1: latch so the "5 consecutive failures" Discord alert fires once per
+   * failure-streak instead of only on the exact-5 transition. Cleared on
+   * the next successful crank.
+   */
+  alertedAt5?: boolean;
+  /**
    * PERC-465: Mainnet CA override for price lookups.
    * On devnet Quick Launch markets, collateralMint is a devnet mirror mint with no DEX data.
    * This field stores the original mainnet CA so Jupiter/DexScreener lookups use the right address.
@@ -97,12 +103,17 @@ interface MarketCrankState {
 
 /** Process items in batches with delay between batches.
  *  Each item is wrapped in try/catch so one failure doesn't kill the batch.
- *  BM7: Enhanced error tracking per item. */
+ *
+ *  B2: each closure RETURNS its outcome (boolean ok | thrown) instead of
+ *  mutating outer counters. Sums are computed after every Promise.all
+ *  resolves so there is no read-modify-write race even under unusual
+ *  microtask interleavings.
+ */
 async function processBatched<T>(
   items: T[],
   batchSize: number,
   delayMs: number,
-  fn: (item: T) => Promise<void>,
+  fn: (item: T) => Promise<boolean>,
 ): Promise<{ succeeded: number; failed: number; errors: Map<string, Error> }> {
   const errors = new Map<string, Error>();
   let succeeded = 0;
@@ -110,18 +121,31 @@ async function processBatched<T>(
 
   for (let i = 0; i < items.length; i += batchSize) {
     const batch = items.slice(i, i + batchSize);
-    await Promise.all(batch.map(async (item) => {
-      try {
-        await fn(item);
-        succeeded++;
-      } catch (err) {
+    type ItemOutcome =
+      | { kind: "ok" }
+      | { kind: "no" }
+      | { kind: "threw"; itemKey: string; error: Error };
+    const outcomes: ItemOutcome[] = await Promise.all(
+      batch.map(async (item): Promise<ItemOutcome> => {
+        try {
+          const ok = await fn(item);
+          return ok ? { kind: "ok" } : { kind: "no" };
+        } catch (err) {
+          const itemKey = String(item);
+          const errorObj = err instanceof Error ? err : new Error(String(err));
+          return { kind: "threw", itemKey, error: errorObj };
+        }
+      }),
+    );
+    for (const o of outcomes) {
+      if (o.kind === "ok") succeeded++;
+      else if (o.kind === "no") failed++;
+      else {
         failed++;
-        const itemKey = String(item);
-        const errorObj = err instanceof Error ? err : new Error(String(err));
-        errors.set(itemKey, errorObj);
-        logger.error("Batch item failed", { item: itemKey, error: errorObj.message });
+        errors.set(o.itemKey, o.error);
+        logger.error("Batch item failed", { item: o.itemKey, error: o.error.message });
       }
-    }));
+    }
     if (i + batchSize < items.length) {
       await new Promise((r) => setTimeout(r, delayMs));
     }
@@ -186,8 +210,8 @@ export class CrankService {
 
   async discover(): Promise<DiscoveredMarket[]> {
     // PERC-HOTFIX: If MARKETS_FILTER is set, skip expensive getProgramAccounts discovery.
-    // Instead, fetch each slab account directly via getAccountInfo (1 RPC call per market
-    // instead of ~8 getProgramAccounts calls that trigger 429 rate limits on Helius).
+    // Instead, batch-fetch the slab accounts via getMultipleAccountsInfo on the fallback
+    // RPC — one roundtrip per 100 slabs vs N sequential calls on the primary RPC (B15).
     const marketsFilter = (process.env.MARKETS_FILTER ?? "").trim();
     const allFound: DiscoveredMarket[] = [];
     // Track which program IDs were successfully scanned. Used by the eviction
@@ -197,32 +221,64 @@ export class CrankService {
     if (marketsFilter) {
       const slabAddresses = marketsFilter.split(",").map(s => s.trim()).filter(Boolean);
       logger.info("Using MARKETS_FILTER — skipping getProgramAccounts discovery", { count: slabAddresses.length });
-      const conn = getConnection();
-      for (const addr of slabAddresses) {
+      // B14: parseHeader/parseConfig/parseEngine/parseParams are statically imported at the
+      // top of this file — drop the redundant dynamic import that used to run on every call.
+      // B15: batch via getMultipleAccountsInfo with a per-call timeout on the fallback RPC.
+      const conn = getFallbackConnection();
+      const pubkeys: Array<PublicKey | null> = slabAddresses.map((addr) => {
         try {
-          const pubkey = new PublicKey(addr);
-          const info = await conn.getAccountInfo(pubkey);
+          return new PublicKey(addr);
+        } catch {
+          logger.warn("MARKETS_FILTER: invalid base58 slab address", { slab: addr.slice(0, 8) });
+          return null;
+        }
+      });
+      const FETCH_BATCH = 100;
+      for (let i = 0; i < pubkeys.length; i += FETCH_BATCH) {
+        const batch = pubkeys.slice(i, i + FETCH_BATCH).filter((p): p is PublicKey => p !== null);
+        if (batch.length === 0) continue;
+        let infos: Array<Awaited<ReturnType<typeof conn.getAccountInfo>>>;
+        try {
+          infos = await withTimeout(
+            conn.getMultipleAccountsInfo(batch),
+            RPC_TIMEOUT_MS,
+            `getMultipleAccountsInfo(${batch.length})`,
+          );
+        } catch (err) {
+          logger.warn("MARKETS_FILTER: getMultipleAccountsInfo failed for batch", {
+            batchSize: batch.length,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          continue;
+        }
+        for (let j = 0; j < batch.length; j++) {
+          const pubkey = batch[j]!;
+          const info = infos[j];
           if (!info?.data) {
-            logger.warn("MARKETS_FILTER: slab not found on-chain", { slab: addr.slice(0, 8) });
+            logger.warn("MARKETS_FILTER: slab not found on-chain", { slab: pubkey.toBase58().slice(0, 8) });
             continue;
           }
-          const data = new Uint8Array(info.data);
-          const { parseHeader, parseConfig, parseEngine, parseParams } = await import("@percolatorct/sdk");
-          const header = parseHeader(data);
-          const marketConfig = parseConfig(data);
-          const engine = parseEngine(data);
-          const params = parseParams(data);
-          allFound.push({
-            slabAddress: pubkey,
-            programId: info.owner,
-            header,
-            config: marketConfig,
-            engine,
-            params,
-          });
-          succeededProgramIds.add(info.owner.toBase58());
-        } catch (e) {
-          logger.warn("MARKETS_FILTER: failed to load slab", { slab: addr.slice(0, 8), error: e instanceof Error ? e.message : String(e) });
+          try {
+            const data = new Uint8Array(info.data);
+            const header = parseHeader(data);
+            const marketConfig = parseConfig(data);
+            const engine = parseEngine(data);
+            const params = parseParams(data);
+            allFound.push({
+              slabAddress: pubkey,
+              programId: info.owner,
+              header,
+              config: marketConfig,
+              engine,
+              params,
+            });
+            succeededProgramIds.add(info.owner.toBase58());
+          } catch (e) {
+            logger.warn("MARKETS_FILTER: failed to parse slab", {
+              slab: pubkey.toBase58().slice(0, 8),
+              error: e instanceof Error ? e.message : String(e),
+            });
+          }
         }
       }
       // Fall through to Supabase fetch + this.markets population below
@@ -655,8 +711,12 @@ export class CrankService {
         state.lastCrankTime = Date.now();
         state.successCount++;
         state.consecutiveFailures = 0;
+        state.alertedAt5 = false; // B1: reset alert latch on success
         state.isActive = true;
-        if (state.failureCount > 0) state.failureCount = 0;
+        // B10: do NOT reset failureCount — it is the lifetime counter exposed
+        // by /status, used to compute the long-run error rate. Resetting it on
+        // every success made the rate read 0 forever; only the per-streak
+        // counter (consecutiveFailures) should reset.
         eventBus.publish("crank.success", slabAddress, { signature: sig });
         return true;
       }
@@ -710,8 +770,9 @@ export class CrankService {
       state.lastCrankTime = Date.now();
       state.successCount++;
       state.consecutiveFailures = 0;
+      state.alertedAt5 = false; // B1: reset alert latch on success
       state.isActive = true;
-      if (state.failureCount > 0) state.failureCount = 0;
+      // B10: see HYPERP branch above — preserve lifetime failureCount.
 
       eventBus.publish("crank.success", slabAddress, { signature: sig });
       return true;
@@ -765,8 +826,11 @@ export class CrankService {
         programId: market.programId.toBase58(),
       });
       
-      // Alert on 5+ consecutive failures — fire-and-forget; never let Discord errors crash the crank loop
-      if (state.consecutiveFailures === 5) {
+      // B1: alert when consecutive failures crosses 5 (changed from `=== 5`
+      // so a jump 4 → 6 still fires) and latch `alertedAt5` so we don't
+      // re-alert every cycle while still failing. Latch clears on next success.
+      if (state.consecutiveFailures >= 5 && !state.alertedAt5) {
+        state.alertedAt5 = true;
         sendCriticalAlert("Crank experiencing consecutive failures", [
           { name: "Market", value: slabAddress.slice(0, 12), inline: true },
           { name: "Consecutive Failures", value: state.consecutiveFailures.toString(), inline: true },
@@ -866,10 +930,11 @@ export class CrankService {
       continue;
     }
 
-    if (state.consecutiveFailures > MAX_CONSECUTIVE_FAILURES) {
-      // P0 FIX: Log on first skip so operators know WHY a market stopped cranking.
-      // Previously this was completely silent — the market would die with no trace in logs.
-      if (state.consecutiveFailures === MAX_CONSECUTIVE_FAILURES + 1) {
+    // B1: gate is `>=`, not `>`. The off-by-one previously let MAX-th failure
+    // through (cranks at 10, skips at 11+). Now skips at MAX (10+).
+    if (state.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      // Log on first skip so operators know WHY a market stopped cranking.
+      if (state.consecutiveFailures === MAX_CONSECUTIVE_FAILURES) {
         logger.warn("Market exceeded max consecutive failures — pausing cranks until next rediscovery", {
           slabAddress,
           consecutiveFailures: state.consecutiveFailures,
@@ -911,12 +976,21 @@ export class CrankService {
     // The Solana network de-dupes by signature, so parallel submission is safe.
     const PARALLEL_CONCURRENCY = 10; // Cap concurrency to avoid rate limit storms
 
-    // Process in parallel batches (larger batches, no delay between)
-    const batchResult = await processBatched(toCrank, PARALLEL_CONCURRENCY, 500, async (slabAddress) => {
-      const ok = await this.crankMarket(slabAddress);
-      if (ok) success++;
-      else failed++;
-    });
+    // B16: drop inter-batch delay from 500 ms to 50 ms. At PARALLEL_CONCURRENCY=10
+    // and ~100 markets, the original 500 ms gap added ~4.5 s of pure wait per cycle
+    // and pushed land time past the next interval. The Solana network rate limits
+    // are handled per-RPC, not per-process, so this purely reclaims wasted time.
+    //
+    // B2: closure returns a plain boolean; processBatched sums succeeded/failed
+    // after Promise.all resolves. No outer counter mutation in the closure.
+    const batchResult = await processBatched(
+      toCrank,
+      PARALLEL_CONCURRENCY,
+      50,
+      (slabAddress) => this.crankMarket(slabAddress),
+    );
+    success = batchResult.succeeded;
+    failed = batchResult.failed;
 
     // BM7: Log detailed error summary if any failed
     if (batchResult.failed > 0) {
@@ -1038,23 +1112,25 @@ export class CrankService {
     }
   }
 
-  start(): void {
+  async start(): Promise<void> {
     if (this.timer) return;
     this._isRunning = true;
     logger.info("Crank service starting", { intervalMs: this.intervalMs, inactiveIntervalMs: this.inactiveIntervalMs });
 
-    // Only fire a startup discovery if no markets are already loaded.
-    // index.ts runs discover() before calling start(), so on normal startup markets.size > 0
-    // and we skip this to avoid a redundant burst of getProgramAccounts calls that trigger
-    // 429s on Helius. If start() is called standalone (tests, hot-restart edge case) with
-    // empty markets, we still discover as expected.
+    // B11: await initial discovery so the first crank cycle never races against
+    // the discover() call. index.ts already discovers before calling start() on
+    // normal boot (markets.size > 0), so this path is only hit by tests or
+    // hot-restart edge cases — but when it does run, the interval below must
+    // not start ticking until markets is populated.
     if (this.markets.size === 0) {
       logger.debug("start(): no pre-loaded markets — running initial discovery");
-      this.discover().then(markets => {
+      try {
+        const markets = await this.discover();
         logger.info("Initial discovery complete", { marketCount: markets.length });
-      }).catch(err => {
+      } catch (err) {
         logger.error("Initial discovery failed", { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined });
-      });
+        // Continue — the periodic discovery in the interval will retry.
+      }
     } else {
       logger.debug("start(): markets pre-loaded by caller — skipping redundant startup discover", {
         marketCount: this.markets.size,

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -80,6 +80,24 @@ const PRICE_E6_DIVISOR = 1_000_000n; // Price precision divisor (6 decimals)
 const BPS_MULTIPLIER = 10_000n; // Basis points multiplier (100% = 10000 bps)
 
 /**
+ * A.13: pure helper for margin-ratio-in-bps. scanMarket() and liquidate()
+ * both compute this value; extracting it both unblocks property testing and
+ * prevents drift between the two call sites.
+ *
+ * Semantics (matches the inline code that was duplicated):
+ *  - notional == 0n  → 0n (no position, nothing to ratio)
+ *  - equity   <= 0n  → 0n (B3: underwater = liquidatable; the unreachable
+ *                          `-1` sentinel that lived inside the equity<=0n
+ *                          branch is removed in the same commit)
+ *  - else            → equity * 10_000n / notional (bigint divide truncates)
+ */
+export function computeMarginRatioBps(equity: bigint, notional: bigint): bigint {
+  if (notional === 0n) return 0n;
+  if (equity <= 0n) return 0n;
+  return equity * BPS_MULTIPLIER / notional;
+}
+
+/**
  * Oracle mode for a market.
  * - 'pyth-pinned': oracle_authority == [0;32] && index_feed_id != [0;32]
  *   → staleness enforced on-chain by Pyth CPI
@@ -272,33 +290,12 @@ export class LiquidationService {
           // Use account.pnl directly — it is always populated and accurate.
           const markPnl = account.pnl;
           const equity = account.capital + markPnl;
+          const marginRatioBps = computeMarginRatioBps(equity, notional);
 
-          // B3: If equity <= 0 the account is definitely liquidatable — short-circuit
-          // before the marginRatioBps computation. The bigint divide truncates toward
-          // zero, so `equity * BPS_MULTIPLIER / notional` can round to 0n for tiny
-          // positive equity, which is fine for the liquidatable comparison (the
-          // candidate is collected and the on-chain program reads the canonical
-          // values during execution). Dropped the unreachable `-1` branch — that
-          // ternary always evaluated to 0 inside the `equity <= 0n` arm.
-          if (equity <= 0n) {
-            candidates.push({
-              slabAddress,
-              accountIdx: i,
-              owner: account.owner.toBase58(),
-              positionSize: account.positionSize,
-              capital: account.capital,
-              pnl: markPnl,
-              marginRatio: 0,
-              maintenanceMarginBps,
-            });
-            continue;
-          }
-
-          // multiply by BPS_MULTIPLIER before dividing — keep all precision the
-          // bigint allows before the final truncating divide.
-          const marginRatioBps = equity * BPS_MULTIPLIER / notional;
-
-          // If margin ratio < maintenance margin, this account is liquidatable
+          // If margin ratio < maintenance margin, this account is liquidatable.
+          // The equity<=0n short-circuit lives inside computeMarginRatioBps;
+          // a candidate with marginRatioBps == 0n is collected here just like
+          // any other below-threshold ratio.
           if (marginRatioBps < maintenanceMarginBps) {
             candidates.push({
               slabAddress,
@@ -416,18 +413,21 @@ export class LiquidationService {
         const { price: freshPrice } = resolveMarketPrice(freshCfg, freshMode);
         if (freshPrice > 0n) {
           const notional = absBI(freshAccount.positionSize) * freshPrice / PRICE_E6_DIVISOR;
-          if (notional > 0n) {
-            // v12.17: entryPrice is always 0n (removed from on-chain struct).
-            // Use freshAccount.pnl directly for re-verification.
-            const freshMarkPnl = freshAccount.pnl;
-            const equity = freshAccount.capital + freshMarkPnl;
-            if (equity > 0n) {
-              const marginRatioBps = equity * BPS_MULTIPLIER / notional;
-              if (marginRatioBps >= freshParams.maintenanceMarginBps) {
-                logger.warn("Race condition: account no longer undercollateralized", { accountIndex: accountIdx, slabAddress: slabAddress.toBase58(), marginRatioBps: Number(marginRatioBps) });
-                return null;
-              }
-            }
+          // A.13: shared helper. equity<=0n returns 0n, which is < any
+          // positive maintenanceMarginBps and so correctly proceeds with
+          // liquidation; the previous `if (equity > 0n)` wrapper just
+          // skipped the re-check entirely on underwater equity, missing
+          // the same liquidation case the scanMarket path catches.
+          const freshMarkPnl = freshAccount.pnl;
+          const equity = freshAccount.capital + freshMarkPnl;
+          const marginRatioBps = computeMarginRatioBps(equity, notional);
+          if (
+            notional > 0n &&
+            equity > 0n &&
+            marginRatioBps >= freshParams.maintenanceMarginBps
+          ) {
+            logger.warn("Race condition: account no longer undercollateralized", { accountIndex: accountIdx, slabAddress: slabAddress.toBase58(), marginRatioBps: Number(marginRatioBps) });
+            return null;
           }
         }
       }

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -19,6 +19,7 @@ import {
 import { config, getConnection, loadKeypair, sendWithRetry, sendWithRetryKeeper, pollSignatureStatus, getRecentPriorityFees, checkTransactionSize, eventBus, createLogger, sendWarningAlert, acquireToken, getFallbackConnection, backoffMs, getErrorMessage } from "@percolatorct/shared";
 import { OracleService } from "./oracle.js";
 import { recordAttempt, recordLanded, recordFailed } from "../lib/sender-metrics.js";
+import { AlertAggregator } from "../lib/alert-aggregator.js";
 
 const logger = createLogger("keeper:liquidation");
 
@@ -168,6 +169,26 @@ export class LiquidationService {
   private readonly permanentlySkipped = new Set<string>();
   // Cache keypair at construction — avoids re-parsing from env on every liquidate() call
   private readonly _keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
+  // B4: per-cycle dedup so the same owner is never targeted twice in the same
+  // scan cycle. A user underwater in multiple markets used to get N parallel
+  // liquidates fired; now we attempt one per cycle and let the next cycle pick
+  // up any residual undercollateralization.
+  private _cycleSeenOwners = new Set<string>();
+  // B5: collapse per-liquidation Discord alerts into a single summary alert per
+  // market within a 5 s window — prevents cascade-driven channel flooding.
+  private readonly _liquidationAlertAggregator = new AlertAggregator(
+    async (key, count) => {
+      const market = key.startsWith("liq:") ? key.slice(4) : key;
+      await sendWarningAlert(
+        count === 1 ? "Liquidation executed" : `${count} liquidations executed in market`,
+        [
+          { name: "Market", value: market.slice(0, 16), inline: true },
+          { name: "Count", value: count.toString(), inline: true },
+        ],
+      ).catch(() => {});
+    },
+    { bufferMs: 5_000 },
+  );
 
   constructor(oracleService: OracleService, intervalMs = 60_000) {
     this.oracleService = oracleService;
@@ -252,7 +273,13 @@ export class LiquidationService {
           const markPnl = account.pnl;
           const equity = account.capital + markPnl;
 
-          // H4: If equity <= 0, definitely liquidatable (skip ratio calc)
+          // B3: If equity <= 0 the account is definitely liquidatable — short-circuit
+          // before the marginRatioBps computation. The bigint divide truncates toward
+          // zero, so `equity * BPS_MULTIPLIER / notional` can round to 0n for tiny
+          // positive equity, which is fine for the liquidatable comparison (the
+          // candidate is collected and the on-chain program reads the canonical
+          // values during execution). Dropped the unreachable `-1` branch — that
+          // ternary always evaluated to 0 inside the `equity <= 0n` arm.
           if (equity <= 0n) {
             candidates.push({
               slabAddress,
@@ -261,12 +288,14 @@ export class LiquidationService {
               positionSize: account.positionSize,
               capital: account.capital,
               pnl: markPnl,
-              marginRatio: equity <= 0n ? 0 : -1,
+              marginRatio: 0,
               maintenanceMarginBps,
             });
             continue;
           }
 
+          // multiply by BPS_MULTIPLIER before dividing — keep all precision the
+          // bigint allows before the final truncating divide.
           const marginRatioBps = equity * BPS_MULTIPLIER / notional;
 
           // If margin ratio < maintenance margin, this account is liquidatable
@@ -438,14 +467,10 @@ export class LiquidationService {
         signature: sig,
       });
       logger.info("Account liquidated", { accountIndex: accountIdx, slabAddress: slabAddress.toBase58(), signature: sig });
-      
-      // Send Discord alert for liquidation execution — fire-and-forget; never let Discord errors crash the liquidation loop
-      sendWarningAlert("Liquidation executed", [
-        { name: "Market", value: slabAddress.toBase58().slice(0, 8), inline: true },
-        { name: "Account Index", value: accountIdx.toString(), inline: true },
-        { name: "Signature", value: sig.slice(0, 12), inline: true },
-      ])?.catch(() => {});
-      
+
+      // B5: aggregate per-liquidation Discord alerts into a 5 s summary per market.
+      this._liquidationAlertAggregator.add(`liq:${slabAddress.toBase58()}`);
+
       return sig;
     } catch (err) {
       const errMsg = getErrorMessage(err);
@@ -495,6 +520,10 @@ export class LiquidationService {
     let scanned = 0;
     let candidateCount = 0;
     let liquidated = 0;
+    // B4: fresh per-cycle dedup set — owners targeted in earlier cycles can
+    // be re-targeted next cycle (the previous liquidate may have only chipped
+    // away part of their exposure).
+    this._cycleSeenOwners.clear();
 
     // P2 FIX: Periodically clear permanentlySkipped to allow recovery when SDK is updated.
     // Markets re-add themselves on next parse failure, so this is safe.
@@ -538,8 +567,17 @@ export class LiquidationService {
         const candidates = result.value;
         candidateCount += candidates.length;
 
-        // Liquidations are sequential (each is a transaction)
+        // Liquidations are sequential (each is a transaction).
+        // B4: skip owners already targeted earlier in this scan cycle.
         for (const candidate of candidates) {
+          if (this._cycleSeenOwners.has(candidate.owner)) {
+            logger.debug("Skipping owner already targeted this cycle", {
+              owner: candidate.owner.slice(0, 8),
+              slabAddress: candidate.slabAddress.slice(0, 8),
+            });
+            continue;
+          }
+          this._cycleSeenOwners.add(candidate.owner);
           const sig = await this.liquidate(filteredBatch[j]!.market, candidate.accountIdx);
           if (sig) liquidated++;
         }
@@ -613,6 +651,9 @@ export class LiquidationService {
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
+      // B5: flush any pending aggregated alerts so a SIGTERM during a cascade
+      // doesn't drop the summary.
+      void this._liquidationAlertAggregator.flush();
       logger.info("Liquidation service stopped");
     }
   }

--- a/src/services/monitor.ts
+++ b/src/services/monitor.ts
@@ -29,6 +29,17 @@ import type { MarketCrankState } from "./crank-types.js";
 
 const logger = createLogger("keeper:monitor");
 
+/** B12: Per-RPC-call timeout so one slow node can't stall the whole monitor cycle. */
+const MONITOR_RPC_TIMEOUT_MS = 10_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label}: timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 // How often to run the conservation invariant check (default 5 minutes)
 const INVARIANT_CHECK_INTERVAL_MS = Number(process.env.INVARIANT_CHECK_INTERVAL_MS ?? 5 * 60_000);
 
@@ -150,19 +161,43 @@ export class MonitorService {
     const conn = getConnection();
     const now = Date.now();
 
-    for (const [slabAddress, crankState] of markets) {
-      if (crankState.permanentlySkipped) continue;
-      if (crankState.foreignOracleSkipped) continue;
+    // B12: parallel-fan-out per market with allSettled + per-call timeout.
+    // The previous sequential loop meant one slow node delayed every market's
+    // invariant check; one timeout would also abort the whole pass.
+    const entries = Array.from(markets.entries()).filter(
+      ([_, s]) => !s.permanentlySkipped && !s.foreignOracleSkipped,
+    );
+    await Promise.allSettled(
+      entries.map(([slabAddress, crankState]) =>
+        this._checkOneMarket(slabAddress, crankState, conn, now),
+      ),
+    );
+  }
 
+  private async _checkOneMarket(
+    slabAddress: string,
+    crankState: MarketCrankState,
+    conn: ReturnType<typeof getConnection>,
+    now: number,
+  ): Promise<void> {
+    {
       // ── 6.1: Conservation invariant ───────────────────────────────────────
       try {
-        const data = await fetchSlab(conn, crankState.market.slabAddress);
+        const data = await withTimeout(
+          fetchSlab(conn, crankState.market.slabAddress),
+          MONITOR_RPC_TIMEOUT_MS,
+          `fetchSlab(${slabAddress.slice(0, 8)})`,
+        );
         const engine = parseEngine(data);
         const cfg = parseConfig(data);
 
         // Fetch the actual SPL token balance from the vault token account.
         // parseConfig returns vaultPubkey — the token account that holds collateral.
-        const tokenBalanceResp = await conn.getTokenAccountBalance(cfg.vaultPubkey);
+        const tokenBalanceResp = await withTimeout(
+          conn.getTokenAccountBalance(cfg.vaultPubkey),
+          MONITOR_RPC_TIMEOUT_MS,
+          `getTokenAccountBalance(${slabAddress.slice(0, 8)})`,
+        );
         // amount is a string in the token's raw units (no decimals)
         const vaultTokenBalance = BigInt(tokenBalanceResp.value.amount);
 

--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -59,9 +59,14 @@ export class OracleService {
   private readonly maxTrackedMarkets = 500;
   // BM2: Deduplicate concurrent requests for the same mint
   private inFlightRequests = new Map<string, Promise<bigint | null>>();
-  // Track consecutive single-source fetches to detect degraded cross-validation
-  private _consecutiveSingleSource = 0;
-  private _singleSourceAlertSent = false;
+  // B6: per-mint single-source state. The previous shared counters meant that
+  // any single-source fetch — even on a niche market — moved the same global
+  // counter, so a misbehaving feed for one mint could mute or trigger alerts
+  // for every other market.
+  private _singleSourceState = new Map<
+    string,
+    { consecutive: number; alertSent: boolean }
+  >();
   private static readonly SINGLE_SOURCE_ALERT_THRESHOLD = 10;
   // M-4: Track when an external source (DexScreener or Jupiter) last returned a
   // valid price for each slab. Used to cap the on-chain fallback duration so that
@@ -100,7 +105,12 @@ export class OracleService {
           if ((pair.liquidity?.usd ?? 0) < MIN_LIQUIDITY_USD) return null;
           const p = parseFloat(pair.priceUsd);
           if (!isFinite(p) || p <= 0) return null;
-          return BigInt(Math.round(p * PRICE_E6_MULTIPLIER));
+          // B8: parseFloat + Math.round can produce 0 for sub-1e-7 prices,
+          // which would pass downstream `!== null` checks but represent no
+          // price at all. Reject explicitly.
+          const priceE6 = BigInt(Math.round(p * PRICE_E6_MULTIPLIER));
+          if (priceE6 === 0n) return null;
+          return priceE6;
         }
       }
 
@@ -136,8 +146,17 @@ export class OracleService {
       if ((pair.liquidity?.usd ?? 0) < MIN_LIQUIDITY_USD) return null;
       const parsed = parseFloat(pair.priceUsd);
       if (!isFinite(parsed) || parsed <= 0) return null;
-      return BigInt(Math.round(parsed * PRICE_E6_MULTIPLIER));
-    } catch {
+      // B8: see cache-hit branch above.
+      const priceE6 = BigInt(Math.round(parsed * PRICE_E6_MULTIPLIER));
+      if (priceE6 === 0n) return null;
+      return priceE6;
+    } catch (err) {
+      // B9: log instead of silently swallowing — a sustained DexScreener outage
+      // used to be invisible until cross-source validation alerts fired downstream.
+      logger.warn("fetchDexScreenerPrice failed", {
+        mint,
+        error: err instanceof Error ? err.message : String(err),
+      });
       return null;
     }
   }
@@ -178,8 +197,16 @@ export class OracleService {
       if (!priceStr) return null;
       const parsed = parseFloat(priceStr);
       if (!isFinite(parsed) || parsed <= 0) return null;
-      return BigInt(Math.round(parsed * PRICE_E6_MULTIPLIER));
-    } catch {
+      // B8: explicit zero short-circuit — see fetchDexScreenerPrice for rationale.
+      const priceE6 = BigInt(Math.round(parsed * PRICE_E6_MULTIPLIER));
+      if (priceE6 === 0n) return null;
+      return priceE6;
+    } catch (err) {
+      // B9: log instead of swallowing.
+      logger.warn("fetchJupiterPrice failed", {
+        mint,
+        error: err instanceof Error ? err.message : String(err),
+      });
       return null;
     }
   }
@@ -219,37 +246,47 @@ export class OracleService {
       }
     }
 
-    // Track cross-validation coverage: alert when single-source mode persists
+    // B6: per-mint single-source tracking. Each mint has independent counters
+    // so a degraded feed for one market does not silence (or fire) alerts for
+    // any other.
     const bothAvailable = dexPrice !== null && jupPrice !== null;
+    const mintState = this._singleSourceState.get(mint) ?? {
+      consecutive: 0,
+      alertSent: false,
+    };
     if (bothAvailable) {
-      if (this._consecutiveSingleSource > 0) {
+      if (mintState.consecutive > 0) {
         logger.info("Cross-source validation restored", {
-          previousSingleSourceCount: this._consecutiveSingleSource,
+          mint,
+          previousSingleSourceCount: mintState.consecutive,
         });
       }
-      this._consecutiveSingleSource = 0;
-      this._singleSourceAlertSent = false;
+      mintState.consecutive = 0;
+      mintState.alertSent = false;
     } else if (dexPrice !== null || jupPrice !== null) {
-      this._consecutiveSingleSource++;
+      mintState.consecutive++;
       const degradedSource = dexPrice !== null ? "dexscreener" : "jupiter";
       const downSource = dexPrice !== null ? "jupiter" : "dexscreener";
       if (
-        this._consecutiveSingleSource >= OracleService.SINGLE_SOURCE_ALERT_THRESHOLD &&
-        !this._singleSourceAlertSent
+        mintState.consecutive >= OracleService.SINGLE_SOURCE_ALERT_THRESHOLD &&
+        !mintState.alertSent
       ) {
-        this._singleSourceAlertSent = true;
+        mintState.alertSent = true;
         logger.warn("Cross-source validation degraded — operating on single source", {
-          consecutiveSingleSource: this._consecutiveSingleSource,
+          mint,
+          consecutiveSingleSource: mintState.consecutive,
           activeSource: degradedSource,
           downSource,
         });
         sendWarningAlert("Oracle cross-validation degraded", [
+          { name: "Mint", value: mint.slice(0, 12), inline: true },
           { name: "Active Source", value: degradedSource, inline: true },
           { name: "Down Source", value: downSource, inline: true },
-          { name: "Consecutive", value: String(this._consecutiveSingleSource), inline: true },
+          { name: "Consecutive", value: String(mintState.consecutive), inline: true },
         ])?.catch(() => {});
       }
     }
+    this._singleSourceState.set(mint, mintState);
 
     // Select best available price (DexScreener preferred)
     let priceE6: bigint | null = dexPrice;

--- a/tests/lib/alert-aggregator.test.ts
+++ b/tests/lib/alert-aggregator.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi } from "vitest";
+import { AlertAggregator } from "../../src/lib/alert-aggregator.js";
+
+function makeFakeTimer() {
+  let queued: { cb: () => void; ms: number; cancelled: boolean }[] = [];
+  return {
+    set: vi.fn((cb: () => void, ms: number) => {
+      const entry = { cb, ms, cancelled: false };
+      queued.push(entry);
+      return entry;
+    }),
+    clear: vi.fn((h: unknown) => {
+      const e = h as { cancelled: boolean };
+      e.cancelled = true;
+    }),
+    fireFirst() {
+      const e = queued.shift();
+      if (e && !e.cancelled) e.cb();
+    },
+    queued() {
+      return queued.filter((e) => !e.cancelled);
+    },
+  };
+}
+
+describe("AlertAggregator", () => {
+  it("emits one flush per key after bufferMs", async () => {
+    const flush = vi.fn();
+    const timer = makeFakeTimer();
+    const agg = new AlertAggregator(flush, {
+      bufferMs: 5_000,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+    });
+
+    agg.add("liq:marketA");
+    agg.add("liq:marketA");
+    agg.add("liq:marketA");
+
+    expect(flush).not.toHaveBeenCalled();
+    expect(timer.set).toHaveBeenCalledTimes(1);
+    expect(timer.set).toHaveBeenCalledWith(expect.any(Function), 5_000);
+
+    timer.fireFirst();
+    await Promise.resolve();
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(flush).toHaveBeenCalledWith("liq:marketA", 3);
+  });
+
+  it("aggregates per-key counts across mixed keys", async () => {
+    const flush = vi.fn();
+    const timer = makeFakeTimer();
+    const agg = new AlertAggregator(flush, {
+      bufferMs: 1_000,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+    });
+
+    agg.add("liq:A");
+    agg.add("liq:B");
+    agg.add("liq:A");
+    agg.add("liq:B");
+    agg.add("liq:B");
+
+    timer.fireFirst();
+    await Promise.resolve();
+    expect(flush).toHaveBeenCalledTimes(2);
+    expect(flush).toHaveBeenCalledWith("liq:A", 2);
+    expect(flush).toHaveBeenCalledWith("liq:B", 3);
+  });
+
+  it("does not re-schedule while a flush is pending", () => {
+    const flush = vi.fn();
+    const timer = makeFakeTimer();
+    const agg = new AlertAggregator(flush, {
+      bufferMs: 1_000,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+    });
+
+    agg.add("k1");
+    agg.add("k2");
+    agg.add("k3");
+    expect(timer.set).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules a new timer after a flush", async () => {
+    const flush = vi.fn();
+    const timer = makeFakeTimer();
+    const agg = new AlertAggregator(flush, {
+      bufferMs: 1_000,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+    });
+
+    agg.add("k1");
+    timer.fireFirst();
+    await Promise.resolve();
+    expect(flush).toHaveBeenCalledTimes(1);
+
+    agg.add("k1");
+    expect(timer.set).toHaveBeenCalledTimes(2);
+  });
+
+  it("manual flush() drains and clears the pending timer", async () => {
+    const flush = vi.fn();
+    const timer = makeFakeTimer();
+    const agg = new AlertAggregator(flush, {
+      bufferMs: 60_000,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+    });
+
+    agg.add("k1");
+    await agg.flush();
+
+    expect(flush).toHaveBeenCalledWith("k1", 1);
+    expect(timer.clear).toHaveBeenCalledTimes(1);
+    expect(agg.size()).toBe(0);
+  });
+
+  it("stop() drops pending buckets without flushing", () => {
+    const flush = vi.fn();
+    const timer = makeFakeTimer();
+    const agg = new AlertAggregator(flush, {
+      bufferMs: 5_000,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+    });
+
+    agg.add("k1");
+    agg.stop();
+    expect(flush).not.toHaveBeenCalled();
+    expect(agg.size()).toBe(0);
+    expect(timer.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("maxBuckets triggers an immediate flush instead of unbounded growth", async () => {
+    const flush = vi.fn();
+    const timer = makeFakeTimer();
+    const agg = new AlertAggregator(flush, {
+      bufferMs: 60_000,
+      maxBuckets: 3,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+    });
+
+    agg.add("a");
+    agg.add("b");
+    agg.add("c");
+    agg.add("d"); // crosses cap
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(flush).toHaveBeenCalled();
+    expect(agg.size()).toBeLessThanOrEqual(0);
+  });
+
+  it("flush errors are swallowed and reported via onFlushError", async () => {
+    const onFlushError = vi.fn();
+    const flush = vi.fn().mockRejectedValue(new Error("discord down"));
+    const timer = makeFakeTimer();
+    const agg = new AlertAggregator(flush, {
+      bufferMs: 1_000,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+      onFlushError,
+    });
+
+    agg.add("k");
+    timer.fireFirst();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onFlushError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/services/crank.b-fixes.test.ts
+++ b/tests/services/crank.b-fixes.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Regression tests for Phase 1 Workstream B′ crank.ts fixes.
+ *
+ * - B1: alert at >=5 consecutive failures fires once per streak, resets on success
+ * - B10: lifetime failureCount is never reset on success — only consecutiveFailures
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@solana/web3.js", async () => {
+  const actual = await vi.importActual<typeof import("@solana/web3.js")>("@solana/web3.js");
+  return {
+    ...actual,
+    SYSVAR_CLOCK_PUBKEY: {
+      toBase58: () => "SysvarC1ock11111111111111111111111111111111",
+      equals: () => false,
+    },
+  };
+});
+
+vi.mock("@percolatorct/sdk", () => ({
+  discoverMarkets: vi.fn(),
+  encodeKeeperCrank: vi.fn(() => Buffer.from([1])),
+  encodeUpdateHyperpMark: vi.fn(() => Buffer.from([7])),
+  buildAccountMetas: vi.fn(() => []),
+  buildIx: vi.fn(() => ({})),
+  derivePythPushOraclePDA: vi.fn(() => [
+    { toBase58: () => "Oracle111111111111111111111111111111111" },
+    0,
+  ]),
+  detectDexType: vi.fn(() => "raydium-clmm"),
+  parseDexPool: vi.fn(),
+  parseHeader: vi.fn(),
+  parseConfig: vi.fn(),
+  parseEngine: vi.fn(),
+  parseParams: vi.fn(),
+  fetchSlab: vi.fn(),
+  ACCOUNTS_KEEPER_CRANK: {},
+}));
+
+vi.mock("@percolatorct/shared", () => ({
+  config: {
+    crankIntervalMs: 30000,
+    crankInactiveIntervalMs: 120000,
+    discoveryIntervalMs: 300000,
+    allProgramIds: ["11111111111111111111111111111111"],
+    crankKeypair: "mock-keypair-path",
+  },
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  getConnection: vi.fn(() => ({ getAccountInfo: vi.fn() })),
+  getFallbackConnection: vi.fn(() => ({
+    getProgramAccounts: vi.fn(),
+    getAccountInfo: vi.fn(),
+    getMultipleAccountsInfo: vi.fn(),
+  })),
+  loadKeypair: vi.fn(() => ({
+    publicKey: {
+      toBase58: () => "11111111111111111111111111111111",
+      equals: (o: any) => o?.toBase58?.() === "11111111111111111111111111111111",
+    },
+    secretKey: new Uint8Array(64),
+  })),
+  sendWithRetry: vi.fn(async () => "mock-sig"),
+  sendWithRetryKeeper: vi.fn(),
+  rateLimitedCall: vi.fn((fn) => fn()),
+  sendCriticalAlert: vi.fn().mockResolvedValue(undefined),
+  getSupabase: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        in: vi.fn(() => ({ data: [], error: null })),
+      })),
+    })),
+  })),
+  eventBus: { publish: vi.fn() },
+}));
+
+import { PublicKey } from "@solana/web3.js";
+import { CrankService } from "../../src/services/crank.js";
+import * as shared from "@percolatorct/shared";
+
+function makeMarketState(opts: Partial<{ consecutiveFailures: number; failureCount: number; successCount: number; alertedAt5: boolean }> = {}) {
+  return {
+    market: {
+      slabAddress: new PublicKey("11111111111111111111111111111112"),
+      programId: new PublicKey("11111111111111111111111111111111"),
+      header: {},
+      config: {
+        oracleAuthority: PublicKey.default,
+        indexFeedId: new PublicKey(new Uint8Array(32)),
+        authorityPriceE6: 0n,
+        dexPool: null,
+      },
+      engine: {},
+      params: {},
+    } as any,
+    lastCrankTime: 0,
+    successCount: opts.successCount ?? 0,
+    failureCount: opts.failureCount ?? 0,
+    consecutiveFailures: opts.consecutiveFailures ?? 0,
+    isActive: true,
+    missingDiscoveryCount: 0,
+    alertedAt5: opts.alertedAt5 ?? false,
+  };
+}
+
+describe("crank B-fixes — B1 alert latch", () => {
+  let crank: CrankService;
+  let alertSpy: ReturnType<typeof vi.fn>;
+  const slab = "11111111111111111111111111111112";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    alertSpy = vi.mocked(shared.sendCriticalAlert);
+    const oracleService = {
+      pushPrice: vi.fn(),
+      recordPushTime: vi.fn(),
+    } as any;
+    crank = new CrankService(oracleService);
+    (crank as any).markets.set(slab, makeMarketState());
+  });
+
+  afterEach(() => crank.stop());
+
+  it("does not fire while consecutiveFailures < 5", async () => {
+    vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(new Error("boom"));
+    for (let i = 0; i < 4; i++) await crank.crankMarket(slab);
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+
+  it("fires exactly once when consecutiveFailures crosses 5 (5,6,7,8 → 1 alert)", async () => {
+    vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(new Error("boom"));
+    for (let i = 0; i < 8; i++) await crank.crankMarket(slab);
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect((crank as any).markets.get(slab).alertedAt5).toBe(true);
+  });
+
+  it("still fires when failures jump 4 → 6 (skip 5) — B1 fix vs old `=== 5`", async () => {
+    // Pre-load consecutiveFailures = 5 (simulating jump). The fix uses `>= 5 && !alertedAt5`.
+    const state = (crank as any).markets.get(slab);
+    state.consecutiveFailures = 5;
+    vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(new Error("boom"));
+    await crank.crankMarket(slab); // bumps to 6, should still fire
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("latch resets on success so a second streak can alert again", async () => {
+    vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(new Error("boom"));
+    for (let i = 0; i < 6; i++) await crank.crankMarket(slab);
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+
+    // success path
+    vi.mocked(shared.sendWithRetryKeeper).mockResolvedValueOnce("ok-sig");
+    await crank.crankMarket(slab);
+    expect((crank as any).markets.get(slab).consecutiveFailures).toBe(0);
+    expect((crank as any).markets.get(slab).alertedAt5).toBe(false);
+
+    // second streak should fire again
+    vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(new Error("boom2"));
+    for (let i = 0; i < 6; i++) await crank.crankMarket(slab);
+    expect(alertSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("crank B-fixes — B10 lifetime failureCount preservation", () => {
+  let crank: CrankService;
+  const slab = "11111111111111111111111111111112";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const oracleService = { pushPrice: vi.fn(), recordPushTime: vi.fn() } as any;
+    crank = new CrankService(oracleService);
+    (crank as any).markets.set(slab, makeMarketState({ failureCount: 42, consecutiveFailures: 3 }));
+  });
+
+  afterEach(() => crank.stop());
+
+  it("success resets consecutiveFailures but preserves lifetime failureCount", async () => {
+    vi.mocked(shared.sendWithRetryKeeper).mockResolvedValueOnce("ok-sig");
+    await crank.crankMarket(slab);
+    const state = (crank as any).markets.get(slab);
+    expect(state.consecutiveFailures).toBe(0);
+    // B10: lifetime counter must NOT be reset
+    expect(state.failureCount).toBe(42);
+    expect(state.successCount).toBe(1);
+  });
+});

--- a/tests/services/crank.processBatched.test.ts
+++ b/tests/services/crank.processBatched.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from "vitest";
+import fc from "fast-check";
+
+// Mocks must be set BEFORE the SUT import — crank.ts depends on shared/sdk
+// at module load via loadKeypair / config / etc.
+
+vi.mock("@solana/web3.js", async () => {
+  const actual = await vi.importActual("@solana/web3.js");
+  return {
+    ...actual,
+    SYSVAR_CLOCK_PUBKEY: {
+      toBase58: () => "SysvarC1ock11111111111111111111111111111111",
+      equals: () => false,
+    },
+  };
+});
+
+vi.mock("@percolatorct/sdk", () => ({
+  discoverMarkets: vi.fn(),
+  encodeKeeperCrank: vi.fn(() => Buffer.from([1])),
+  encodeUpdateHyperpMark: vi.fn(() => Buffer.from([2])),
+  buildAccountMetas: vi.fn(() => []),
+  buildIx: vi.fn(() => ({})),
+  derivePythPushOraclePDA: vi.fn(() => [
+    { toBase58: () => "11111111111111111111111111111111" },
+    0,
+  ]),
+  detectDexType: vi.fn(() => "raydium-clmm"),
+  parseDexPool: vi.fn(),
+  fetchSlab: vi.fn(),
+  parseHeader: vi.fn(),
+  parseConfig: vi.fn(),
+  parseEngine: vi.fn(),
+  parseParams: vi.fn(),
+  ACCOUNTS_KEEPER_CRANK: {},
+}));
+
+vi.mock("@percolatorct/shared", () => ({
+  config: {
+    crankIntervalMs: 30_000,
+    crankInactiveIntervalMs: 120_000,
+    discoveryIntervalMs: 300_000,
+    allProgramIds: ["11111111111111111111111111111111"],
+    crankKeypair: "mock-keypair-path",
+  },
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  getConnection: vi.fn(() => ({ getAccountInfo: vi.fn() })),
+  getFallbackConnection: vi.fn(() => ({ getProgramAccounts: vi.fn() })),
+  loadKeypair: vi.fn(() => ({
+    publicKey: { toBase58: () => "11111111111111111111111111111111", equals: () => true },
+    secretKey: new Uint8Array(64),
+  })),
+  sendWithRetry: vi.fn(async () => "sig"),
+  sendWithRetryKeeper: vi.fn(async () => "sig"),
+  rateLimitedCall: vi.fn((fn) => fn()),
+  sendCriticalAlert: vi.fn(),
+  getSupabase: vi.fn(() => ({
+    from: vi.fn(() => ({ select: vi.fn(() => ({ in: vi.fn(() => ({ data: [], error: null })) })) })),
+  })),
+  eventBus: { publish: vi.fn() },
+}));
+
+import { processBatched } from "../../src/services/crank.js";
+
+// A.15: succeeded + failed must always equal the input length, and a thrown
+// error must be counted exactly once (never both as success AND failure).
+describe("processBatched (A.15)", () => {
+  type Outcome = "success" | "fail" | "throw";
+
+  function runWithOutcomes(outcomes: Outcome[]): Promise<{ succeeded: number; failed: number; errors: Map<string, Error> }> {
+    const items = outcomes.map((_, i) => i);
+    return processBatched(items, 5, 0, async (idx) => {
+      const out = outcomes[idx as number]!;
+      if (out === "throw") throw new Error(`thrown by item ${idx}`);
+      return out === "success";
+    });
+  }
+
+  it("succeeded + failed === items.length for a known mix", async () => {
+    const { succeeded, failed } = await runWithOutcomes([
+      "success", "fail", "throw", "success", "fail", "throw", "success", "success",
+    ]);
+    // 4 success, 2 fail, 2 throw → 4 succeeded, 4 failed
+    expect(succeeded + failed).toBe(8);
+    expect(succeeded).toBe(4);
+    expect(failed).toBe(4);
+  });
+
+  it("thrown errors are counted as failed (not as success), exactly once each", async () => {
+    const { succeeded, failed, errors } = await runWithOutcomes(["throw", "throw", "throw"]);
+    expect(succeeded).toBe(0);
+    expect(failed).toBe(3);
+    expect(errors.size).toBe(3);
+  });
+
+  it("empty input → zero counts, zero errors", async () => {
+    const { succeeded, failed, errors } = await runWithOutcomes([]);
+    expect(succeeded).toBe(0);
+    expect(failed).toBe(0);
+    expect(errors.size).toBe(0);
+  });
+
+  it("property: succeeded + failed always equals items.length across random mixes", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(fc.constantFrom<Outcome>("success", "fail", "throw"), {
+          minLength: 0,
+          maxLength: 50,
+        }),
+        async (outcomes) => {
+          const { succeeded, failed } = await runWithOutcomes(outcomes);
+          return succeeded + failed === outcomes.length;
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("property: succeeded matches the count of 'success' outcomes", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(fc.constantFrom<Outcome>("success", "fail", "throw"), {
+          minLength: 0,
+          maxLength: 50,
+        }),
+        async (outcomes) => {
+          const expected = outcomes.filter((o) => o === "success").length;
+          const { succeeded } = await runWithOutcomes(outcomes);
+          return succeeded === expected;
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("property: failed matches the count of 'fail' + 'throw' outcomes (no double-count)", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(fc.constantFrom<Outcome>("success", "fail", "throw"), {
+          minLength: 0,
+          maxLength: 50,
+        }),
+        async (outcomes) => {
+          const expected = outcomes.filter((o) => o === "fail" || o === "throw").length;
+          const { failed } = await runWithOutcomes(outcomes);
+          return failed === expected;
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("property: errors map size equals the number of thrown outcomes", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(fc.constantFrom<Outcome>("success", "fail", "throw"), {
+          minLength: 0,
+          maxLength: 50,
+        }),
+        async (outcomes) => {
+          const expected = outcomes.filter((o) => o === "throw").length;
+          const { errors } = await runWithOutcomes(outcomes);
+          return errors.size === expected;
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -990,21 +990,19 @@ describe('CrankService', () => {
   describe('start and stop', () => {
     it('should start timer and perform initial discovery', async () => {
       vi.mocked(core.discoverMarkets).mockResolvedValue([]);
-      
-      crankService.start();
-      
+
+      // B11: start() is now async — await it so we can verify initial discovery synchronously
+      await crankService.start();
+
       expect(crankService.isRunning).toBe(true);
-      
-      // Wait for initial discovery
-      await new Promise(resolve => setTimeout(resolve, 100));
-      
       expect(core.discoverMarkets).toHaveBeenCalled();
     });
 
-    it('should stop timer', () => {
-      crankService.start();
+    it('should stop timer', async () => {
+      vi.mocked(core.discoverMarkets).mockResolvedValue([]);
+      await crankService.start();
       expect(crankService.isRunning).toBe(true);
-      
+
       crankService.stop();
       expect(crankService.isRunning).toBe(false);
     });

--- a/tests/services/liquidation.property.test.ts
+++ b/tests/services/liquidation.property.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import { computeMarginRatioBps } from "../../src/services/liquidation.js";
+
+// A.13: property tests for computeMarginRatioBps. The B3 fix removed an
+// unreachable `-1` sentinel; these properties pin down the semantics that
+// scanMarket + liquidate both depend on, so the two call sites can't drift.
+
+describe("computeMarginRatioBps (A.13)", () => {
+  it("property: result is non-negative for any (equity, notional) with notional > 0n", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: -(10n ** 30n), max: 10n ** 30n }),
+        fc.bigInt({ min: 1n, max: 10n ** 30n }),
+        (equity, notional) => {
+          return computeMarginRatioBps(equity, notional) >= 0n;
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  it("property: equity == 0n always returns 0n (regardless of notional)", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 0n, max: 10n ** 30n }),
+        (notional) => {
+          return computeMarginRatioBps(0n, notional) === 0n;
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  it("property: notional == 0n always returns 0n (regardless of equity)", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: -(10n ** 30n), max: 10n ** 30n }),
+        (equity) => {
+          return computeMarginRatioBps(equity, 0n) === 0n;
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  it("property: equity < 0n always returns 0n (underwater is treated as liquidatable, not negative)", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: -(10n ** 30n), max: -1n }),
+        fc.bigInt({ min: 1n, max: 10n ** 30n }),
+        (equity, notional) => {
+          return computeMarginRatioBps(equity, notional) === 0n;
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  it("property: monotonic non-decreasing in equity for fixed notional > 0n (when both equity values are positive)", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 1n, max: 10n ** 20n }),
+        fc.bigInt({ min: 1n, max: 10n ** 20n }),
+        fc.bigInt({ min: 1n, max: 10n ** 20n }),
+        (eqA, eqB, notional) => {
+          const lo = eqA < eqB ? eqA : eqB;
+          const hi = eqA < eqB ? eqB : eqA;
+          return computeMarginRatioBps(lo, notional) <= computeMarginRatioBps(hi, notional);
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  it("property: monotonic non-increasing in notional for fixed equity > 0n (more notional = lower ratio)", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 1n, max: 10n ** 20n }),
+        fc.bigInt({ min: 1n, max: 10n ** 20n }),
+        fc.bigInt({ min: 1n, max: 10n ** 20n }),
+        (equity, notA, notB) => {
+          const lo = notA < notB ? notA : notB;
+          const hi = notA < notB ? notB : notA;
+          // Higher notional → lower (or equal) ratio
+          return computeMarginRatioBps(equity, hi) <= computeMarginRatioBps(equity, lo);
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  it("known values: bigint truncation matches the live call sites", () => {
+    expect(computeMarginRatioBps(0n, 100n)).toBe(0n);
+    expect(computeMarginRatioBps(-1n, 100n)).toBe(0n);
+    expect(computeMarginRatioBps(100n, 0n)).toBe(0n);
+    // equity = notional → exactly 1.0× = 10_000 bps
+    expect(computeMarginRatioBps(1000n, 1000n)).toBe(10_000n);
+    // equity = 2× notional → 20_000 bps
+    expect(computeMarginRatioBps(2000n, 1000n)).toBe(20_000n);
+    // equity = 0.05 × notional → 500 bps (matches typical 5% maintenance margin)
+    expect(computeMarginRatioBps(50n, 1000n)).toBe(500n);
+  });
+});

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -662,4 +662,99 @@ describe('LiquidationService', () => {
       expect(core.fetchSlab).not.toHaveBeenCalled();
     });
   });
+
+  // A.14 (MED): per-cycle owner dedup — same underwater owner across N markets
+  // produces ONE liquidate call per cycle, not N. The set resets between
+  // cycles so a residual undercollateralization can be retargeted next time.
+  describe('A.14: scanAndLiquidateAll owner dedup', () => {
+    function makeMarketAt(slabAddr: string) {
+      return {
+        slabAddress: { toBase58: () => slabAddr, equals: () => false },
+        programId: { toBase58: () => 'ProgramId1111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'Mint111111111111111111111111111111111111' },
+          oracleAuthority: mockZeroKey(),
+          indexFeedId: mockNonZeroKey('feed'),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+      };
+    }
+
+    it('liquidates the same owner ONCE when present in two markets in the same cycle', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const sharedOwner = 'OwnerShared111111111111111111111111111111111';
+
+      // Stub scanMarket directly so we can return identical candidates for
+      // both markets without wrestling with parser mocks.
+      const scanSpy = vi.spyOn(svc, 'scanMarket').mockImplementation(
+        async (market: any) =>
+          [
+            {
+              slabAddress: market.slabAddress.toBase58(),
+              accountIdx: 1,
+              owner: sharedOwner,
+              positionSize: 1_000n,
+              capital: 100n,
+              pnl: -50n,
+              marginRatio: 4.0,
+              maintenanceMarginBps: 500n,
+            },
+          ] as any,
+      );
+
+      // Stub liquidate so it just counts calls without exercising the send path.
+      const liquidateSpy = vi
+        .spyOn(svc, 'liquidate')
+        .mockResolvedValue('mock-liq-sig');
+
+      const markets = new Map([
+        ['SlabA1111111111111111111111111111111111111', { market: makeMarketAt('SlabA1111111111111111111111111111111111111') as any }],
+        ['SlabB2222222222222222222222222222222222222', { market: makeMarketAt('SlabB2222222222222222222222222222222222222') as any }],
+      ]);
+
+      const result = await svc.scanAndLiquidateAll(markets);
+
+      // Both markets scanned…
+      expect(scanSpy).toHaveBeenCalledTimes(2);
+      // …but liquidate fired only once thanks to the dedup set.
+      expect(liquidateSpy).toHaveBeenCalledTimes(1);
+      expect(result.candidates).toBe(2);
+      expect(result.liquidated).toBe(1);
+    });
+
+    it('permits the same owner to be liquidated again on the NEXT cycle', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const sharedOwner = 'OwnerShared222222222222222222222222222222222';
+
+      const scanSpy = vi.spyOn(svc, 'scanMarket').mockImplementation(
+        async (market: any) =>
+          [
+            {
+              slabAddress: market.slabAddress.toBase58(),
+              accountIdx: 1,
+              owner: sharedOwner,
+              positionSize: 1_000n,
+              capital: 100n,
+              pnl: -50n,
+              marginRatio: 4.0,
+              maintenanceMarginBps: 500n,
+            },
+          ] as any,
+      );
+      const liquidateSpy = vi.spyOn(svc, 'liquidate').mockResolvedValue('mock-liq-sig');
+
+      const markets = new Map([
+        ['SlabC3333333333333333333333333333333333333', { market: makeMarketAt('SlabC3333333333333333333333333333333333333') as any }],
+      ]);
+
+      await svc.scanAndLiquidateAll(markets);
+      await svc.scanAndLiquidateAll(markets);
+
+      // Two cycles, two liquidates — the dedup set is per-cycle, not lifetime.
+      expect(liquidateSpy).toHaveBeenCalledTimes(2);
+      // sanity: scanMarket also called twice (once per cycle)
+      expect(scanSpy).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/tests/services/oracle.b-fixes.test.ts
+++ b/tests/services/oracle.b-fixes.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression tests for Phase 1 Workstream B′ oracle.ts fixes.
+ *
+ * - B6: single-source state is per-mint; a degraded feed for mint A must not
+ *   trigger or silence alerts for mint B
+ * - B8: parseFloat → BigInt conversions that round to 0n short-circuit to null
+ * - B9: DexScreener / Jupiter fetch errors are logged (not silently swallowed)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+
+global.fetch = vi.fn();
+
+// vi.mock factory is hoisted above plain top-level `const` declarations and
+// would TDZ-crash if it tried to capture them — vi.hoisted lifts the spies
+// alongside the mocks so both run in the right order.
+const hoisted = vi.hoisted(() => ({
+  loggerWarn: vi.fn(),
+  sendWarningAlert: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@percolatorct/sdk", () => ({
+  encodePushOraclePrice: vi.fn(() => Buffer.from([1])),
+  buildAccountMetas: vi.fn(() => []),
+  buildIx: vi.fn(() => ({})),
+  ACCOUNTS_PUSH_ORACLE_PRICE: {},
+}));
+
+vi.mock("@percolatorct/shared", () => ({
+  config: {
+    programId: "11111111111111111111111111111111",
+    crankKeypair: "mock-keypair-path",
+  },
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: hoisted.loggerWarn,
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  getConnection: vi.fn(() => ({ getAccountInfo: vi.fn() })),
+  loadKeypair: vi.fn(() => ({
+    publicKey: new PublicKey("11111111111111111111111111111111"),
+    secretKey: new Uint8Array(64),
+  })),
+  sendWithRetry: vi.fn(async () => "mock-sig"),
+  eventBus: { publish: vi.fn() },
+  getErrorMessage: vi.fn((err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+  ),
+  sendWarningAlert: hoisted.sendWarningAlert,
+}));
+
+const loggerWarn = hoisted.loggerWarn;
+const sendWarningAlert = hoisted.sendWarningAlert;
+
+import { OracleService } from "../../src/services/oracle.js";
+
+function mockDexResponse(priceUsd: string, liquidityUsd = 100_000) {
+  vi.mocked(fetch).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      pairs: [{ priceUsd, liquidity: { usd: liquidityUsd } }],
+    }),
+  } as any);
+}
+
+function mockJupResponse(price: string | null, mint: string) {
+  vi.mocked(fetch).mockResolvedValueOnce({
+    ok: true,
+    json: async () =>
+      price === null
+        ? { data: {} }
+        : { data: { [mint]: { price } } },
+  } as any);
+}
+
+describe("oracle B-fixes — B8 priceE6===0n short-circuit", () => {
+  let svc: OracleService;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svc = new OracleService();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("DexScreener: rejects sub-precision prices that would round to 0n", async () => {
+    mockDexResponse("0.0000001"); // 0.0000001 * 1e6 = 0.1 → rounds to 0
+    const p = await svc.fetchDexScreenerPrice("MINT_B8_1");
+    expect(p).toBeNull();
+  });
+
+  it("DexScreener: cached-hit branch also rejects 0n prices", async () => {
+    // first call fills cache (sub-precision)
+    mockDexResponse("0.0000004");
+    const first = await svc.fetchDexScreenerPrice("MINT_B8_2");
+    expect(first).toBeNull();
+
+    // second call hits cache → also returns null (not a 0n bigint)
+    const second = await svc.fetchDexScreenerPrice("MINT_B8_2");
+    expect(second).toBeNull();
+  });
+
+  it("Jupiter: rejects sub-precision prices that would round to 0n", async () => {
+    mockJupResponse("0.0000003", "MINT_B8_3");
+    const p = await svc.fetchJupiterPrice("MINT_B8_3");
+    expect(p).toBeNull();
+  });
+
+  it("DexScreener: still returns the price for legit values", async () => {
+    mockDexResponse("0.5"); // 500_000
+    const p = await svc.fetchDexScreenerPrice("MINT_B8_4");
+    expect(p).toBe(500_000n);
+  });
+});
+
+describe("oracle B-fixes — B9 fetch error logging", () => {
+  let svc: OracleService;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svc = new OracleService();
+  });
+
+  it("logs DexScreener fetch failures via logger.warn", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("ECONNRESET"));
+    await svc.fetchDexScreenerPrice("MINT_B9_1");
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "fetchDexScreenerPrice failed",
+      expect.objectContaining({ mint: "MINT_B9_1", error: "ECONNRESET" }),
+    );
+  });
+
+  it("logs Jupiter fetch failures via logger.warn", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("HTTP/2 stream reset"));
+    await svc.fetchJupiterPrice("MINT_B9_2");
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "fetchJupiterPrice failed",
+      expect.objectContaining({ mint: "MINT_B9_2", error: "HTTP/2 stream reset" }),
+    );
+  });
+});
+
+describe("oracle B-fixes — B6 per-mint single-source state", () => {
+  let svc: OracleService;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svc = new OracleService();
+  });
+
+  // We bypass the fetch path here: the module-level DexScreener cache + mock-queue
+  // ordering makes fetch-based test scaffolding brittle. Spying on the public
+  // methods exercises the single-source state machine deterministically.
+  function makeSvcWith(getDex: (mint: string) => bigint | null, getJup: (mint: string) => bigint | null) {
+    const s = new OracleService();
+    vi.spyOn(s, "fetchDexScreenerPrice").mockImplementation(async (mint: string) => getDex(mint));
+    vi.spyOn(s, "fetchJupiterPrice").mockImplementation(async (mint: string) => getJup(mint));
+    return s;
+  }
+
+  it("alert for mint A's degraded feed does not silence alerts for mint B", async () => {
+    const s = makeSvcWith(
+      () => 1_000_000n,
+      (mint) => (mint === "MINT_A_B6" ? null : null), // jupiter always down in this test
+    );
+
+    // 10 single-source iterations for MINT_A
+    for (let i = 0; i < 10; i++) await s.fetchPrice("MINT_A_B6", "slab-A");
+    expect(sendWarningAlert).toHaveBeenCalledTimes(1);
+    expect(sendWarningAlert.mock.calls[0]?.[1]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Mint", value: expect.stringContaining("MINT_A_B6") }),
+      ]),
+    );
+
+    // 10 more single-source iterations for MINT_B should fire its OWN alert
+    sendWarningAlert.mockClear();
+    for (let i = 0; i < 10; i++) await s.fetchPrice("MINT_B_B6", "slab-B");
+    expect(sendWarningAlert).toHaveBeenCalledTimes(1);
+    expect(sendWarningAlert.mock.calls[0]?.[1]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Mint", value: expect.stringContaining("MINT_B_B6") }),
+      ]),
+    );
+  });
+
+  it("recovery on mint A does not reset counters for mint B", async () => {
+    let mintAJupReturns: bigint | null = null; // jupiter down for X by default
+    const s = makeSvcWith(
+      () => 1_000_000n,
+      (mint) => (mint === "MINT_X" ? mintAJupReturns : null),
+    );
+
+    // 5 single-source for mint A (jup down) and 5 for mint B (jup down)
+    for (let i = 0; i < 5; i++) await s.fetchPrice("MINT_X", "slab-x");
+    for (let i = 0; i < 5; i++) await s.fetchPrice("MINT_Y", "slab-y");
+    expect(sendWarningAlert).toHaveBeenCalledTimes(0);
+
+    // Recover mint A by flipping the jup mock
+    mintAJupReturns = 1_000_000n;
+    await s.fetchPrice("MINT_X", "slab-x");
+
+    // 5 more single-source for mint B → its consecutive hits 10 → alert fires for mint B
+    for (let i = 0; i < 5; i++) await s.fetchPrice("MINT_Y", "slab-y");
+    expect(sendWarningAlert).toHaveBeenCalledTimes(1);
+    expect(sendWarningAlert.mock.calls[0]?.[1]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Mint", value: expect.stringContaining("MINT_Y") }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Workstream B′ from the Phase 1 brief — 17 audit-found bugs that are pure JS/TS issues (no program coupling, no instruction-tag/account-layout assumptions, no v16 dependence). Stacks alongside A1 (#113) and A2-A8 (#114); does not touch their files.

## Per-fix breakdown

| ID | File | What |
|---|---|---|
| B1 | crank.ts | Alert gate \`>\` → \`>=\`; per-streak \`alertedAt5\` latch so a 4→6 jump still fires and we don't re-alert each cycle |
| B2 | crank.ts | \`processBatched\` closure returns boolean; counters summed after \`Promise.all\` |
| B3 | liquidation.ts | Removed unreachable \`-1\` branch in equity-≤0 ternary; documented bigint truncation |
| B4 | liquidation.ts | Per-cycle \`Set<owner>\` dedup; no double-liquidate of the same user under cross-margin |
| B5 | liquidation.ts | Discord alert per liquidation → buffered 5s window via new \`AlertAggregator\` |
| B6 | oracle.ts | Single-source state per-mint (was shared \`_consecutiveSingleSource\`); one bad feed no longer silences alerts for unrelated markets |
| B7 | index.ts | Per-market stale-oracle alert cooldown (5 min); was firing every 60 s during a multi-hour outage |
| B8 | oracle.ts | Explicit \`priceE6 === 0n → null\` after \`BigInt(Math.round(...))\` — sub-1e-7 prices no longer pass \`!== null\` checks |
| B9 | oracle.ts | Bare \`catch {}\` on DexScreener / Jupiter fetches → \`logger.warn\` |
| B10 | crank.ts | Stop resetting lifetime \`failureCount\` on success — only \`consecutiveFailures\` resets |
| B11 | crank.ts | \`start()\` is async + \`await\`s initial \`discover()\` before scheduling the interval |
| B12 | monitor.ts | Serial market loop → \`Promise.allSettled\` with per-call \`withTimeout(10s)\` |
| B13 | index.ts | \`healthServer.listen()\` moved inside \`start()\` — Railway sees missing port as unhealthy during boot |
| B14 | crank.ts | Deleted redundant dynamic \`import(\"@percolatorct/sdk\")\` in the MARKETS_FILTER hot loop |
| B15 | crank.ts | MARKETS_FILTER: \`getMultipleAccountsInfo\` batches of 100 on fallback RPC with per-call timeout, replacing N sequential \`getAccountInfo\` on primary |
| B16 | crank.ts | Inter-batch delay 500 ms → 50 ms (saves ~4.5 s per cycle at 10×100 markets) |
| B17 | adl.ts | \`lastScanTime\` stamped on every \`scanMarket\` — observability hygiene |

## New module

- \`src/lib/alert-aggregator.ts\` (~90 LOC) — per-key bucket + delayed flush, bounded by \`maxBuckets\` cap, injectable timer for tests.

## Tests added (+21 passing)

- \`tests/lib/alert-aggregator.test.ts\` — 8 cases: scheduling, per-key aggregation, manual flush, stop semantics, cap-bound flush, swallowed flush errors.
- \`tests/services/crank.b-fixes.test.ts\` — 5 cases: B1 alert latch (no-fire <5, once at >=5, jump 4→6 fires, latch resets on success, second streak re-alerts); B10 lifetime preservation.
- \`tests/services/oracle.b-fixes.test.ts\` — 8 cases: B8 zero-round short-circuit (dex + cache hit + jup + legit value); B9 logger.warn on fetch failures; B6 per-mint isolation (degraded mint A doesn't silence mint B; recovery on mint A doesn't reset mint B's counter).
- \`tests/services/crank.test.ts\` modified — existing start() test now awaits the new async signature.

Total: ~480 LOC of new tests across 4 files.

## Test plan

- [x] \`pnpm build\` clean (tsc strict)
- [x] \`pnpm test\`: **192 passed | 3 skipped** (was 171 / 3) — +21 new test cases
- [ ] Shadow keeper (\`DRY_RUN=true\`) in us-east4 for 24h: should see new aggregated liquidation alerts (count > 1 only during cascades), see no per-cycle stale-oracle alert spam, see crank cycle complete in less wall-clock under load (B16)
- [ ] Promote eu-west4 primary; verify
  - \`/status\` shows non-zero \`failureCount\` after first error (B10)
  - During a contrived cascade, exactly one Discord alert per market per 5s window (B5)
  - Healthcheck transitions from down → healthy only after initial discovery completes (B13)

## Why this is not coupled to v16 / v12.19

Every fix here is a JS/TS bug, an internal state-machine cleanup, or a refactor of how the keeper talks to RPC / Discord / its own loggers. Nothing depends on instruction tags, account byte offsets, error codes, reward semantics, or any program-internal logic. When v16 replaces v12.19, this code is unchanged.

## Conflicts to expect on merge

- \`src/index.ts\` overlaps with A2-A8 (#114) in: imports area, the SOL-balance-low log block, the start() rejection handler, the /health route, the crash handlers. Most are different lines but the import block will need a manual merge. Easy: keep both new imports.
- \`src/env-guards.ts\`: no overlap (B' doesn't touch it).
- New modules: \`src/lib/alert-aggregator.ts\` (B') and \`src/lib/{boot-assertions,budget,exit-handlers,startup-tracker}.ts\` (A) don't overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-market oracle staleness alert cooldown to reduce alert frequency.
  * Alert batching for liquidation notifications to minimize spam.

* **Bug Fixes**
  * Oracle single-source degradation tracking now isolated per mint.
  * Price precision validation for external feeds (DexScreener, Jupiter).
  * Improved market monitoring performance via parallel checks with per-call timeouts.

* **Improvements**
  * Enhanced error logging for external price fetch failures.
  * Crank service startup reliability and market discovery optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-keeper/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->