### PR TITLE
feat(keeper): Phase 1 Workstream D — send path upgrade (priority fee + CU sim + blockhash cache + budget wiring)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,13 +32,30 @@ KEEPER_HEALTH_PORT=8081
 # RPC_URL=https://mainnet.helius-rpc.com/?api-key=YOUR_KEY
 # PROGRAM_ID=GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24
 
-# Helius Sender (Phase 1 performance upgrade — opt-in)
-# Requires SOLANA_RPC_URL to be a Helius mainnet endpoint.
+# Helius Sender (Phase 1 performance upgrade)
+# Default: USE_HELIUS_SENDER=true on mainnet (NETWORK=mainnet). Set false to opt out.
+# Requires RPC_URL to be a Helius mainnet endpoint with an api-key query param.
 # When true, sendWithRetryKeeper routes via https://sender.helius-rpc.com/fast
 # with skipPreflight + Jito tip + program-specific priority fee estimate.
-# USE_HELIUS_SENDER=true
+# On mainnet (NETWORK=mainnet), USE_HELIUS_SENDER should always be true for
+# competitive landing rates — devnet uses standard RPC regardless of this flag.
+USE_HELIUS_SENDER=true
 # HELIUS_PRIORITY_LEVEL=High       # Min | Low | Medium | High | VeryHigh
 # JITO_TIP_LAMPORTS=200000         # 0.0002 SOL minimum for dual-routing
+
+# Dynamic priority fees (Workstream D2)
+# KEEPER_PRIORITY_FEE_CACHE_MS=5000              # Cache TTL per account-key set
+# KEEPER_PRIORITY_FEE_PERCENTILE_LIQUIDATION=75  # p75 for liquidation txs
+# KEEPER_PRIORITY_FEE_PERCENTILE_CRANK=50        # p50 for crank txs
+# KEEPER_PRIORITY_FEE_PERCENTILE_ORACLE=25       # p25 for oracle txs
+
+# CU simulation (Workstream D3)
+# KEEPER_CU_SIMULATE_MARGIN=1.10     # 10% headroom above simulated CU
+# KEEPER_CU_FALLBACK_LIMIT=1400000   # CU limit used if simulation fails
+
+# Blockhash cache (Workstream D5)
+# KEEPER_BLOCKHASH_CACHE_MS=2000          # Background refresh interval
+# KEEPER_BLOCKHASH_MAX_SLOTS_REUSE=60     # Max slots before forced re-fetch (~24s)
 
 # Enhanced WebSocket (Phase 2 — indexer real-time streaming)
 # HELIUS_ATLAS_WS_URL=wss://atlas-mainnet.helius-rpc.com?api-key=YOUR_KEY

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.2.2",
+    "fast-check": "^4.8.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^4.0.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     dependencies:
       '@percolatorct/sdk':
-        specifier: ^2.0.9
+        specifier: 2.0.9
         version: 2.0.9(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@percolatorct/shared':
         specifier: 1.0.0-beta.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@types/node':
         specifier: ^25.2.2
         version: 25.5.0
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -927,6 +930,10 @@ packages:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
@@ -1134,6 +1141,9 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
@@ -2310,6 +2320,10 @@ snapshots:
 
   eyes@0.1.8: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-stable-stringify@1.0.0: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
@@ -2480,6 +2494,8 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  pure-rand@8.4.0: {}
 
   require-in-the-middle@8.0.1:
     dependencies:

--- a/src/lib/blockhash-cache.ts
+++ b/src/lib/blockhash-cache.ts
@@ -1,0 +1,118 @@
+import type { Connection } from "@solana/web3.js";
+import { createLogger } from "@percolatorct/shared";
+
+const logger = createLogger("keeper:blockhash-cache");
+
+const DEFAULT_REFRESH_MS = 2_000;
+const DEFAULT_MAX_SLOTS_REUSE = 60;
+
+interface CachedBlockhash {
+  blockhash: string;
+  lastValidBlockHeight: number;
+  fetchedAt: number;
+  slot: number;
+}
+
+export class BlockhashCache {
+  private readonly _connection: Connection;
+  private readonly _refreshMs: number;
+  private readonly _maxSlotsReuse: number;
+  private _cached: CachedBlockhash | null = null;
+  private _timer: ReturnType<typeof setInterval> | null = null;
+  private _fetchPromise: Promise<void> | null = null;
+
+  constructor(
+    connection: Connection,
+    opts?: { refreshMs?: number; maxSlotsReuse?: number },
+  ) {
+    this._connection = connection;
+    this._refreshMs =
+      opts?.refreshMs ??
+      parseInt(process.env.KEEPER_BLOCKHASH_CACHE_MS ?? String(DEFAULT_REFRESH_MS), 10);
+    this._maxSlotsReuse =
+      opts?.maxSlotsReuse ??
+      parseInt(process.env.KEEPER_BLOCKHASH_MAX_SLOTS_REUSE ?? String(DEFAULT_MAX_SLOTS_REUSE), 10);
+  }
+
+  start(): void {
+    if (this._timer) return;
+    this._timer = setInterval(() => {
+      this._refresh().catch((err) => {
+        logger.warn("Blockhash cache background refresh failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, this._refreshMs);
+  }
+
+  stop(): void {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  get(): { blockhash: string; lastValidBlockHeight: number } {
+    const now = Date.now();
+    if (this._cached && this._isStillValid(this._cached, now)) {
+      return {
+        blockhash: this._cached.blockhash,
+        lastValidBlockHeight: this._cached.lastValidBlockHeight,
+      };
+    }
+    // Cached value is absent or too old — must fetch synchronously.
+    // We do NOT await here; callers must await get() in async contexts.
+    // For sync callers we throw to force them to use the async path.
+    // In practice every keeper send path is async, so we expose a sync API
+    // that throws on cache miss to make the contract explicit.
+    throw new Error(
+      "BlockhashCache: no valid cached blockhash — call await getAsync() or ensure start() is running",
+    );
+  }
+
+  async getAsync(): Promise<{ blockhash: string; lastValidBlockHeight: number }> {
+    const now = Date.now();
+    if (this._cached && this._isStillValid(this._cached, now)) {
+      return {
+        blockhash: this._cached.blockhash,
+        lastValidBlockHeight: this._cached.lastValidBlockHeight,
+      };
+    }
+    await this._refresh();
+    return {
+      blockhash: this._cached!.blockhash,
+      lastValidBlockHeight: this._cached!.lastValidBlockHeight,
+    };
+  }
+
+  private _isStillValid(cached: CachedBlockhash, nowMs: number): boolean {
+    const ageMs = nowMs - cached.fetchedAt;
+    const ageSlots = ageMs / 400;
+    return ageSlots <= this._maxSlotsReuse;
+  }
+
+  private async _refresh(): Promise<void> {
+    if (this._fetchPromise) {
+      return this._fetchPromise;
+    }
+    this._fetchPromise = this._doFetch().finally(() => {
+      this._fetchPromise = null;
+    });
+    return this._fetchPromise;
+  }
+
+  private async _doFetch(): Promise<void> {
+    const result = await this._connection.getLatestBlockhash({ commitment: "processed" });
+    const slot = await this._connection.getSlot("processed");
+    this._cached = {
+      blockhash: result.blockhash,
+      lastValidBlockHeight: result.lastValidBlockHeight,
+      fetchedAt: Date.now(),
+      slot,
+    };
+    logger.debug("Blockhash cache refreshed", {
+      blockhash: result.blockhash.slice(0, 8),
+      lastValidBlockHeight: result.lastValidBlockHeight,
+    });
+  }
+}

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -1,0 +1,345 @@
+/**
+ * KeeperBudget — circuit breaker for keeper send-path spending.
+ *
+ * Why this exists: the keeper signs transactions against a wallet with real
+ * funds. A misconfigured priority fee, a stuck retry loop, or a malicious
+ * input can drain that wallet faster than ops can notice. The budget caps
+ * lamport spend per cycle / hour / day and tx count per cycle, plus a
+ * rolling-window success-rate guard that catches "we're sending but nothing
+ * lands". On breach, the budget halts: every subsequent canSpend() returns
+ * false until an operator manually resume()s. Day-cap breaches especially
+ * never auto-recover — that's a real signal something is wrong.
+ *
+ * Concurrency: every public method is synchronous. Under Node's single-
+ * threaded event loop, no two calls can interleave between their reads and
+ * writes, so the internal counters cannot drift even under thousands of
+ * concurrent canSpend() / recordTx() callers.
+ */
+
+import { createLogger } from "@percolatorct/shared";
+
+const logger = createLogger("keeper:budget");
+
+export type TxType = "crank" | "liquidation" | "oracle";
+export type TxResult = "success" | "fail" | "drop";
+
+export interface KeeperBudgetConfig {
+  /** Per cycle cap in lamports (default 50_000_000 = 0.05 SOL). */
+  maxSolPerCycle: number;
+  /** Rolling 1-hour cap in lamports (default 500_000_000 = 0.5 SOL). */
+  maxSolPerHour: number;
+  /** Rolling 24-hour cap in lamports (default 3_000_000_000 = 3 SOL). Manual-resume-only on breach. */
+  maxSolPerDay: number;
+  /** Cap on tx attempts per cycle (default 60). */
+  maxTxPerCycle: number;
+  /** Window length in ms over which success rate is computed (default 60_000). */
+  txSuccessRateWindow: number;
+  /** Floor for success rate within the window (default 0.70). */
+  txSuccessRateThreshold: number;
+  /** Minimum samples before the success-rate guard activates (default 10). */
+  txSuccessRateMinSamples: number;
+}
+
+export interface BudgetStats {
+  cycleSpend: number;
+  hourSpend: number;
+  daySpend: number;
+  cycleTxCount: number;
+  txSuccessRate: number | null;
+  txWindowSize: number;
+  halted: boolean;
+  haltReason?: string;
+  haltKind?: HaltKind;
+  config: KeeperBudgetConfig;
+}
+
+export type HaltKind =
+  | "cycle-spend-cap"
+  | "hour-spend-cap"
+  | "day-spend-cap"
+  | "cycle-tx-count-cap"
+  | "tx-success-rate"
+  | "operator";
+
+export interface KeeperBudgetDeps {
+  now?: () => number;
+  env?: NodeJS.ProcessEnv;
+  onHalt?: (kind: HaltKind, reason: string) => void;
+}
+
+interface SpendEvent {
+  ts: number;
+  lamports: number;
+}
+
+interface TxRecord {
+  ts: number;
+  success: boolean;
+}
+
+const DEFAULTS: KeeperBudgetConfig = {
+  maxSolPerCycle: 50_000_000,
+  maxSolPerHour: 500_000_000,
+  maxSolPerDay: 3_000_000_000,
+  maxTxPerCycle: 60,
+  txSuccessRateWindow: 60_000,
+  txSuccessRateThreshold: 0.7,
+  txSuccessRateMinSamples: 10,
+};
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
+
+const INT_ENV_KEYS: Array<[keyof KeeperBudgetConfig, string]> = [
+  ["maxSolPerCycle", "KEEPER_MAX_SOL_PER_CYCLE"],
+  ["maxSolPerHour", "KEEPER_MAX_SOL_PER_HOUR"],
+  ["maxSolPerDay", "KEEPER_MAX_SOL_PER_DAY"],
+  ["maxTxPerCycle", "KEEPER_MAX_TX_PER_CYCLE"],
+  ["txSuccessRateWindow", "KEEPER_TX_SUCCESS_RATE_WINDOW_MS"],
+  ["txSuccessRateMinSamples", "KEEPER_TX_SUCCESS_RATE_MIN_SAMPLES"],
+];
+
+function parseEnvOverrides(env: NodeJS.ProcessEnv): Partial<KeeperBudgetConfig> {
+  const result: Partial<KeeperBudgetConfig> = {};
+  for (const [key, envName] of INT_ENV_KEYS) {
+    const raw = env[envName];
+    if (raw === undefined || raw === "") continue;
+    const n = Number(raw);
+    if (Number.isFinite(n) && n > 0 && Number.isInteger(n)) {
+      (result as Record<string, number>)[key] = n;
+    }
+  }
+  const rateRaw = env.KEEPER_TX_SUCCESS_RATE_THRESHOLD;
+  if (rateRaw !== undefined && rateRaw !== "") {
+    const n = Number(rateRaw);
+    if (Number.isFinite(n) && n >= 0 && n <= 1) {
+      result.txSuccessRateThreshold = n;
+    }
+  }
+  return result;
+}
+
+export class KeeperBudget {
+  readonly config: KeeperBudgetConfig;
+  private readonly _now: () => number;
+  private readonly _onHalt: ((kind: HaltKind, reason: string) => void) | undefined;
+
+  private _cycleSpend = 0;
+  private _cycleTxCount = 0;
+  private readonly _hourEvents: SpendEvent[] = [];
+  private _hourSpendSum = 0;
+  private readonly _dayEvents: SpendEvent[] = [];
+  private _daySpendSum = 0;
+  private readonly _txWindow: TxRecord[] = [];
+  private _txWindowSuccesses = 0;
+  private _txWindowFailures = 0;
+
+  private _isHalted = false;
+  private _haltKind: HaltKind | undefined;
+  private _haltReason: string | undefined;
+
+  constructor(config: Partial<KeeperBudgetConfig> = {}, deps: KeeperBudgetDeps = {}) {
+    const envOverrides = parseEnvOverrides(deps.env ?? process.env);
+    this.config = { ...DEFAULTS, ...envOverrides, ...config };
+    this._now = deps.now ?? (() => Date.now());
+    this._onHalt = deps.onHalt;
+  }
+
+  /**
+   * Pre-flight check: would sending a tx that costs `lamports` lamports breach
+   * any cap? Returns false on breach AND latches the halt so subsequent calls
+   * also return false until resume() is called.
+   *
+   * txType is currently advisory (logged on breach); planned use is to attribute
+   * Prometheus halt counters per tx category.
+   */
+  canSpend(lamports: number, txType: TxType): boolean {
+    if (this._isHalted) return false;
+
+    const nowMs = this._now();
+    this._pruneOld(nowMs);
+
+    if (this._cycleSpend + lamports > this.config.maxSolPerCycle) {
+      this._halt(
+        "cycle-spend-cap",
+        `proposed cycle spend ${this._cycleSpend + lamports} > cap ${this.config.maxSolPerCycle} (txType=${txType})`,
+      );
+      return false;
+    }
+    if (this._hourSpendSum + lamports > this.config.maxSolPerHour) {
+      this._halt(
+        "hour-spend-cap",
+        `proposed hour spend ${this._hourSpendSum + lamports} > cap ${this.config.maxSolPerHour} (txType=${txType})`,
+      );
+      return false;
+    }
+    if (this._daySpendSum + lamports > this.config.maxSolPerDay) {
+      this._halt(
+        "day-spend-cap",
+        `proposed day spend ${this._daySpendSum + lamports} > cap ${this.config.maxSolPerDay} (txType=${txType})`,
+      );
+      return false;
+    }
+    if (this._cycleTxCount + 1 > this.config.maxTxPerCycle) {
+      this._halt(
+        "cycle-tx-count-cap",
+        `proposed cycle tx count ${this._cycleTxCount + 1} > cap ${this.config.maxTxPerCycle} (txType=${txType})`,
+      );
+      return false;
+    }
+
+    const rate = this._computeSuccessRate();
+    if (rate !== null && rate < this.config.txSuccessRateThreshold) {
+      this._halt(
+        "tx-success-rate",
+        `tx success rate ${rate.toFixed(3)} < threshold ${this.config.txSuccessRateThreshold} over ${this._txWindow.length} samples (txType=${txType})`,
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Record a settled tx. Called regardless of halt state — accounts for
+   * in-flight txs that settle after the budget has already tripped.
+   *
+   * - 'success' / 'fail': lamports are added to spend trackers (fees pay on
+   *   failed txs that landed in a block).
+   * - 'drop': lamports are NOT added (we never reached the chain). Still
+   *   counts toward cycleTxCount as an attempt.
+   */
+  recordTx(lamports: number, txType: string, result: TxResult): void {
+    if (lamports < 0 || !Number.isFinite(lamports)) return;
+    const nowMs = this._now();
+    this._cycleTxCount++;
+
+    if (result !== "drop") {
+      this._cycleSpend += lamports;
+      this._hourEvents.push({ ts: nowMs, lamports });
+      this._hourSpendSum += lamports;
+      this._dayEvents.push({ ts: nowMs, lamports });
+      this._daySpendSum += lamports;
+      const success = result === "success";
+      this._txWindow.push({ ts: nowMs, success });
+      if (success) this._txWindowSuccesses++;
+      else this._txWindowFailures++;
+    }
+
+    this._pruneOld(nowMs);
+
+    if (process.env.KEEPER_BUDGET_DEBUG === "true") {
+      logger.debug("recordTx", {
+        txType,
+        result,
+        lamports,
+        cycleSpend: this._cycleSpend,
+        hourSpend: this._hourSpendSum,
+        daySpend: this._daySpendSum,
+      });
+    }
+  }
+
+  /**
+   * Reset per-cycle counters at the top of a new cycle. Does NOT clear halt
+   * state — that requires resume().
+   */
+  beginCycle(): void {
+    this._cycleSpend = 0;
+    this._cycleTxCount = 0;
+  }
+
+  getStats(): BudgetStats {
+    this._pruneOld(this._now());
+    return {
+      cycleSpend: this._cycleSpend,
+      hourSpend: this._hourSpendSum,
+      daySpend: this._daySpendSum,
+      cycleTxCount: this._cycleTxCount,
+      txSuccessRate: this._computeSuccessRate(),
+      txWindowSize: this._txWindow.length,
+      halted: this._isHalted,
+      haltReason: this._haltReason,
+      haltKind: this._haltKind,
+      config: { ...this.config },
+    };
+  }
+
+  isHalted(): boolean {
+    return this._isHalted;
+  }
+
+  get haltReason(): string | undefined {
+    return this._haltReason;
+  }
+
+  get haltKind(): HaltKind | undefined {
+    return this._haltKind;
+  }
+
+  /**
+   * Clear halt state. Logs the operator name so the audit trail records who
+   * authorized the resume. Pass a recognizable identifier (e.g. on-call
+   * pager handle) so the alert thread can reference it.
+   */
+  resume(operator: string): void {
+    if (!this._isHalted) return;
+    logger.warn("Keeper budget resumed", {
+      operator,
+      previousHaltKind: this._haltKind,
+      previousHaltReason: this._haltReason,
+    });
+    this._isHalted = false;
+    this._haltKind = undefined;
+    this._haltReason = undefined;
+  }
+
+  /**
+   * Operator-initiated halt. Useful for cordoning the keeper before a
+   * deploy or in response to an external incident.
+   */
+  haltManually(reason: string): void {
+    this._halt("operator", reason);
+  }
+
+  private _halt(kind: HaltKind, reason: string): void {
+    if (this._isHalted) return;
+    this._isHalted = true;
+    this._haltKind = kind;
+    this._haltReason = reason;
+    logger.error("Keeper budget halted — refusing further sends until manual resume()", {
+      kind,
+      reason,
+    });
+    try {
+      this._onHalt?.(kind, reason);
+    } catch (err) {
+      logger.warn("onHalt hook threw — ignoring", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private _pruneOld(nowMs: number): void {
+    const hourCutoff = nowMs - HOUR_MS;
+    while (this._hourEvents.length > 0 && this._hourEvents[0]!.ts < hourCutoff) {
+      this._hourSpendSum -= this._hourEvents.shift()!.lamports;
+    }
+    const dayCutoff = nowMs - DAY_MS;
+    while (this._dayEvents.length > 0 && this._dayEvents[0]!.ts < dayCutoff) {
+      this._daySpendSum -= this._dayEvents.shift()!.lamports;
+    }
+    const windowCutoff = nowMs - this.config.txSuccessRateWindow;
+    while (this._txWindow.length > 0 && this._txWindow[0]!.ts < windowCutoff) {
+      const evicted = this._txWindow.shift()!;
+      if (evicted.success) this._txWindowSuccesses--;
+      else this._txWindowFailures--;
+    }
+  }
+
+  private _computeSuccessRate(): number | null {
+    const total = this._txWindow.length;
+    if (total < this.config.txSuccessRateMinSamples) return null;
+    return this._txWindowSuccesses / total;
+  }
+}

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -20,7 +20,7 @@ import { createLogger } from "@percolatorct/shared";
 
 const logger = createLogger("keeper:budget");
 
-export type TxType = "crank" | "liquidation" | "oracle";
+export type TxType = "crank" | "liquidation" | "oracle" | "adl";
 export type TxResult = "success" | "fail" | "drop";
 
 export interface KeeperBudgetConfig {

--- a/src/lib/cu-estimator.ts
+++ b/src/lib/cu-estimator.ts
@@ -1,0 +1,66 @@
+import {
+  TransactionMessage,
+  VersionedTransaction,
+  TransactionInstruction,
+  Keypair,
+  PublicKey,
+} from "@solana/web3.js";
+import type { Connection } from "@solana/web3.js";
+import { createLogger } from "@percolatorct/shared";
+
+const logger = createLogger("keeper:cu-estimator");
+
+const DEFAULT_MARGIN = 1.1;
+const DEFAULT_FALLBACK_CU = 1_400_000;
+
+export class CuEstimator {
+  private readonly _margin: number;
+  private readonly _fallback: number;
+
+  constructor(opts?: { margin?: number; fallback?: number }) {
+    this._margin =
+      opts?.margin ??
+      parseFloat(process.env.KEEPER_CU_SIMULATE_MARGIN ?? String(DEFAULT_MARGIN));
+    this._fallback =
+      opts?.fallback ??
+      parseInt(process.env.KEEPER_CU_FALLBACK_LIMIT ?? String(DEFAULT_FALLBACK_CU), 10);
+  }
+
+  async estimate(
+    connection: Connection,
+    instructions: TransactionInstruction[],
+    signers: Keypair[],
+  ): Promise<number> {
+    try {
+      const feePayer = signers[0]?.publicKey ?? PublicKey.default;
+      // Use a throwaway blockhash — replaceRecentBlockhash=true will overwrite it.
+      const msg = new TransactionMessage({
+        payerKey: feePayer,
+        recentBlockhash: "11111111111111111111111111111112",
+        instructions,
+      }).compileToV0Message();
+      const tx = new VersionedTransaction(msg);
+
+      const sim = await connection.simulateTransaction(tx, {
+        replaceRecentBlockhash: true,
+        sigVerify: false,
+      });
+
+      const consumed = sim.value.unitsConsumed;
+      if (typeof consumed !== "number" || consumed <= 0) {
+        logger.warn("Simulation returned no unitsConsumed — using fallback CU limit", {
+          err: sim.value.err,
+          logs: sim.value.logs?.slice(0, 3),
+        });
+        return this._fallback;
+      }
+
+      return Math.ceil(consumed * this._margin);
+    } catch (err) {
+      logger.warn("CU simulation failed — using fallback CU limit", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return this._fallback;
+    }
+  }
+}

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -1,0 +1,119 @@
+import type { Connection, TransactionInstruction, Keypair } from "@solana/web3.js";
+import { sendWithRetryKeeper, createLogger } from "@percolatorct/shared";
+import type { KeeperSendOptions } from "@percolatorct/shared";
+import { KeeperBudget } from "./budget.js";
+import type { TxType, TxResult } from "./budget.js";
+import { HeliusPriorityFeeEstimator } from "./priority-fee.js";
+import type { PriorityFeeEstimator, PriorityFeeTier } from "./priority-fee.js";
+import { CuEstimator } from "./cu-estimator.js";
+
+const logger = createLogger("keeper:send");
+
+const BASE_FEE_LAMPORTS = 5_000;
+
+const TIER_MAP: Record<TxType, PriorityFeeTier> = {
+  crank: "crank",
+  liquidation: "liquidation",
+  oracle: "oracle",
+};
+
+// Lazy singletons — instantiated on first use so mocks applied in test setup take effect.
+let _priorityFeeEstimator: PriorityFeeEstimator | null = null;
+let _cuEstimator: CuEstimator | null = null;
+
+function getPriorityFeeEstimator(): PriorityFeeEstimator {
+  if (!_priorityFeeEstimator) _priorityFeeEstimator = new HeliusPriorityFeeEstimator();
+  return _priorityFeeEstimator;
+}
+
+function getCuEstimator(): CuEstimator {
+  if (!_cuEstimator) _cuEstimator = new CuEstimator();
+  return _cuEstimator;
+}
+
+export const sharedBudget = new KeeperBudget();
+
+function isMainnetSender(): boolean {
+  return (
+    process.env.NETWORK === "mainnet" &&
+    process.env.USE_HELIUS_SENDER === "true"
+  );
+}
+
+/**
+ * Estimate total lamport cost of a transaction.
+ * priority_fee_microlamports * CU / 1_000_000 + base_fee + jito_tip.
+ */
+async function estimateCost(
+  connection: Connection,
+  instructions: TransactionInstruction[],
+  signers: Keypair[],
+  txType: TxType,
+): Promise<number> {
+  const accountKeys = instructions
+    .flatMap((ix) => ix.keys.map((k) => k.pubkey.toBase58()))
+    .filter((v, i, a) => a.indexOf(v) === i);
+
+  const [microLamports, cu] = await Promise.all([
+    getPriorityFeeEstimator().estimate(accountKeys, TIER_MAP[txType]),
+    getCuEstimator().estimate(connection, instructions, signers),
+  ]);
+
+  const priorityFee = Math.ceil((microLamports * cu) / 1_000_000);
+  const jitoTip = process.env.USE_HELIUS_SENDER === "true"
+    ? parseInt(process.env.JITO_TIP_LAMPORTS ?? "200000", 10)
+    : 0;
+
+  return BASE_FEE_LAMPORTS + priorityFee + jitoTip;
+}
+
+export interface KeeperSendResult {
+  signature: string;
+  estimatedCost: number;
+}
+
+/**
+ * Send a keeper transaction with budget gate, priority-fee estimation, and CU simulation.
+ *
+ * Returns null if the budget is exhausted (budget.canSpend returned false) — caller
+ * should skip without treating this as a send failure.
+ */
+export async function keeperSend(
+  connection: Connection,
+  instructions: TransactionInstruction[],
+  signers: Keypair[],
+  txType: TxType,
+  budget: KeeperBudget,
+  maxRetries = 3,
+  keeperOpts?: KeeperSendOptions,
+): Promise<KeeperSendResult | null> {
+  const estimatedCost = await estimateCost(connection, instructions, signers, txType);
+
+  if (!budget.canSpend(estimatedCost, txType)) {
+    logger.warn("Budget gate: refusing send — budget exhausted or halted", {
+      txType,
+      estimatedCost,
+      stats: budget.getStats(),
+    });
+    return null;
+  }
+
+  const opts: KeeperSendOptions = {
+    ...keeperOpts,
+    // Saves ~20-50ms on mainnet when Helius Sender runs its own preflight downstream.
+    ...(isMainnetSender() ? { skipPreflight: true } : {}),
+  };
+
+  let result: TxResult = "fail";
+  let signature = "";
+  try {
+    signature = await sendWithRetryKeeper(connection, instructions, signers, maxRetries, opts);
+    result = "success";
+    return { signature, estimatedCost };
+  } catch (err) {
+    result = "fail";
+    throw err;
+  } finally {
+    budget.recordTx(estimatedCost, txType, result);
+  }
+}

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { Connection, TransactionInstruction, Keypair } from "@solana/web3.js";
 import { sendWithRetryKeeper, createLogger } from "@percolatorct/shared";
 import type { KeeperSendOptions } from "@percolatorct/shared";
@@ -9,13 +10,29 @@ import { CuEstimator } from "./cu-estimator.js";
 
 const logger = createLogger("keeper:send");
 
-const BASE_FEE_LAMPORTS = 5_000;
+export const BASE_FEE_LAMPORTS = 5_000;
 
 const TIER_MAP: Record<TxType, PriorityFeeTier> = {
   crank: "crank",
   liquidation: "liquidation",
   oracle: "oracle",
+  adl: "adl",
 };
+
+/**
+ * Pure lamport-cost formula, factored out so property tests can exercise it
+ * without the fetch/simulate stubs around the public keeperSend API.
+ *
+ * Cost = base + ceil(microLamports * cu / 1_000_000) + jitoTip.
+ */
+export function estimateLamportCost(
+  microLamports: number,
+  cu: number,
+  jitoTip: number,
+): number {
+  const priorityFee = Math.ceil((microLamports * cu) / 1_000_000);
+  return BASE_FEE_LAMPORTS + priorityFee + jitoTip;
+}
 
 // Lazy singletons — instantiated on first use so mocks applied in test setup take effect.
 let _priorityFeeEstimator: PriorityFeeEstimator | null = null;
@@ -59,12 +76,11 @@ async function estimateCost(
     getCuEstimator().estimate(connection, instructions, signers),
   ]);
 
-  const priorityFee = Math.ceil((microLamports * cu) / 1_000_000);
   const jitoTip = process.env.USE_HELIUS_SENDER === "true"
     ? parseInt(process.env.JITO_TIP_LAMPORTS ?? "200000", 10)
     : 0;
 
-  return BASE_FEE_LAMPORTS + priorityFee + jitoTip;
+  return estimateLamportCost(microLamports, cu, jitoTip);
 }
 
 export interface KeeperSendResult {
@@ -96,6 +112,35 @@ export async function keeperSend(
       stats: budget.getStats(),
     });
     return null;
+  }
+
+  // A.10 (HIGH): DRY_RUN intercepts before the real send. The shadow-keeper
+  // harness compares would-have-fired decisions against the live keeper's
+  // tx history; that comparison needs the full ix payload + accounts +
+  // estimated cost recorded against the same budget so runaway-fire is also
+  // detectable in dry runs. Logged at info so the harness can ingest it.
+  if (process.env.DRY_RUN === "true") {
+    const signature = `dry_run_${randomUUID()}`;
+    const accountKeys = instructions.flatMap((ix) =>
+      ix.keys.map((k) => k.pubkey.toBase58()),
+    );
+    logger.info("DRY_RUN: intercepted send", {
+      txType,
+      signature,
+      estimatedCost,
+      instructions: instructions.map((ix) => ({
+        programId: ix.programId.toBase58(),
+        accountKeys: ix.keys.map((k) => ({
+          pubkey: k.pubkey.toBase58(),
+          isSigner: k.isSigner,
+          isWritable: k.isWritable,
+        })),
+        dataBase64: Buffer.from(ix.data).toString("base64"),
+      })),
+      uniqueAccounts: Array.from(new Set(accountKeys)),
+    });
+    budget.recordTx(estimatedCost, txType, "success");
+    return { signature, estimatedCost };
   }
 
   const opts: KeeperSendOptions = {

--- a/src/lib/priority-fee.ts
+++ b/src/lib/priority-fee.ts
@@ -2,14 +2,15 @@ import { createLogger } from "@percolatorct/shared";
 
 const logger = createLogger("keeper:priority-fee");
 
-export type PriorityFeeTier = "crank" | "liquidation" | "oracle";
+export type PriorityFeeTier = "crank" | "liquidation" | "oracle" | "adl";
 
 const FALLBACK_MICROLAMPORTS = 1_000;
 const DEFAULT_CACHE_MS = 5_000;
 
-/** Default percentiles per tier (overridable via env). */
+/** Default percentiles per tier (overridable via env). ADL is liquidation-priority. */
 const DEFAULT_PERCENTILES: Record<PriorityFeeTier, number> = {
   liquidation: 75,
+  adl: 75,
   crank: 50,
   oracle: 25,
 };
@@ -41,6 +42,7 @@ function hashKeys(keys: string[]): string {
 function resolvePercentile(tier: PriorityFeeTier): number {
   const envMap: Record<PriorityFeeTier, string> = {
     liquidation: "KEEPER_PRIORITY_FEE_PERCENTILE_LIQUIDATION",
+    adl: "KEEPER_PRIORITY_FEE_PERCENTILE_ADL",
     crank: "KEEPER_PRIORITY_FEE_PERCENTILE_CRANK",
     oracle: "KEEPER_PRIORITY_FEE_PERCENTILE_ORACLE",
   };

--- a/src/lib/priority-fee.ts
+++ b/src/lib/priority-fee.ts
@@ -1,0 +1,132 @@
+import { createLogger } from "@percolatorct/shared";
+
+const logger = createLogger("keeper:priority-fee");
+
+export type PriorityFeeTier = "crank" | "liquidation" | "oracle";
+
+const FALLBACK_MICROLAMPORTS = 1_000;
+const DEFAULT_CACHE_MS = 5_000;
+
+/** Default percentiles per tier (overridable via env). */
+const DEFAULT_PERCENTILES: Record<PriorityFeeTier, number> = {
+  liquidation: 75,
+  crank: 50,
+  oracle: 25,
+};
+
+export interface PriorityFeeEstimator {
+  estimate(accountKeys: string[], tier: PriorityFeeTier): Promise<number>;
+}
+
+interface HeliusResponse {
+  result?: {
+    priorityFeeLevels?: {
+      min?: number;
+      low?: number;
+      medium?: number;
+      high?: number;
+      veryHigh?: number;
+      unsafeMax?: number;
+      [key: string]: number | undefined;
+    };
+    priorityFeeEstimate?: number;
+  };
+}
+
+/** Stable hash of an account-key set for cache keying. */
+function hashKeys(keys: string[]): string {
+  return [...keys].sort().join(",");
+}
+
+function resolvePercentile(tier: PriorityFeeTier): number {
+  const envMap: Record<PriorityFeeTier, string> = {
+    liquidation: "KEEPER_PRIORITY_FEE_PERCENTILE_LIQUIDATION",
+    crank: "KEEPER_PRIORITY_FEE_PERCENTILE_CRANK",
+    oracle: "KEEPER_PRIORITY_FEE_PERCENTILE_ORACLE",
+  };
+  const raw = process.env[envMap[tier]];
+  if (raw) {
+    const n = parseInt(raw, 10);
+    if (Number.isFinite(n) && n >= 0 && n <= 100) return n;
+  }
+  return DEFAULT_PERCENTILES[tier];
+}
+
+/** Map a numeric percentile to the Helius API priority level string. */
+function percentileToLevel(p: number): string {
+  if (p >= 95) return "veryHigh";
+  if (p >= 75) return "high";
+  if (p >= 50) return "medium";
+  if (p >= 25) return "low";
+  return "min";
+}
+
+export class HeliusPriorityFeeEstimator implements PriorityFeeEstimator {
+  private readonly _rpcUrl: string;
+  private readonly _cacheMs: number;
+  private readonly _cache = new Map<string, { value: number; expiresAt: number }>();
+
+  constructor(rpcUrl?: string, opts?: { cacheMs?: number }) {
+    this._rpcUrl = rpcUrl ?? process.env.HELIUS_RPC_URL ?? process.env.RPC_URL ?? "";
+    this._cacheMs =
+      opts?.cacheMs ??
+      parseInt(process.env.KEEPER_PRIORITY_FEE_CACHE_MS ?? String(DEFAULT_CACHE_MS), 10);
+  }
+
+  async estimate(accountKeys: string[], tier: PriorityFeeTier): Promise<number> {
+    const cacheKey = `${tier}:${hashKeys(accountKeys)}`;
+    const cached = this._cache.get(cacheKey);
+    if (cached && Date.now() < cached.expiresAt) {
+      return cached.value;
+    }
+
+    const percentile = resolvePercentile(tier);
+    const level = percentileToLevel(percentile);
+
+    try {
+      const response = await fetch(this._rpcUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "getPriorityFeeEstimate",
+          params: [
+            {
+              accountKeys,
+              options: {
+                includeAllPriorityFeeLevels: true,
+                priorityLevel: level,
+              },
+            },
+          ],
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as HeliusResponse;
+      const levels = data.result?.priorityFeeLevels;
+      const fee =
+        levels?.[level] ??
+        data.result?.priorityFeeEstimate;
+
+      if (typeof fee !== "number" || fee < 0) {
+        throw new Error(`Unexpected fee value from Helius: ${JSON.stringify(fee)}`);
+      }
+
+      const value = Math.round(fee);
+      this._cache.set(cacheKey, { value, expiresAt: Date.now() + this._cacheMs });
+      return value;
+    } catch (err) {
+      logger.warn("Priority fee estimation failed — using fallback", {
+        tier,
+        error: err instanceof Error ? err.message : String(err),
+        fallback: FALLBACK_MICROLAMPORTS,
+      });
+      return FALLBACK_MICROLAMPORTS;
+    }
+  }
+}

--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -47,13 +47,13 @@ import {
 import {
   getConnection,
   loadKeypair,
-  sendWithRetryKeeper,
   createLogger,
   sendWarningAlert,
   sendCriticalAlert,
 } from "@percolatorct/shared";
 import type { MarketCrankState } from "./crank-types.js";
 import { recordAttempt, recordLanded, recordFailed } from "../lib/sender-metrics.js";
+import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
 
 const logger = createLogger("keeper:adl");
 
@@ -465,7 +465,27 @@ export class AdlService {
         recordAttempt();
         let sig: string;
         try {
-          sig = await sendWithRetryKeeper(connection, [ix], [keypair]);
+          // A.9: route ADL through the budget+priority-fee+CU pipeline. ADL
+          // was the only send-path that bypassed KeeperBudget; the cap that
+          // protects the keeper wallet from a runaway crank or liquidation
+          // loop did nothing for ADL until this fix.
+          const result = await keeperSend(
+            connection,
+            [ix],
+            [keypair],
+            "adl",
+            sharedBudget,
+          );
+          if (!result) {
+            logger.warn("ADL: budget gate refused send — skipping target", {
+              slabAddress,
+              targetIdx: pos.idx,
+              stats: sharedBudget.getStats(),
+            });
+            recordFailed();
+            break;
+          }
+          sig = result.signature;
           const __tip = process.env.USE_HELIUS_SENDER === "true"
             ? parseInt(process.env.JITO_TIP_LAMPORTS ?? "200000", 10)
             : 0;

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -18,9 +18,10 @@ import {
   type DiscoveredMarket,
   type DexType,
 } from "@percolatorct/sdk";
-import { config, getConnection, getFallbackConnection, loadKeypair, sendWithRetryKeeper, eventBus, createLogger, sendCriticalAlert, getSupabase } from "@percolatorct/shared";
+import { config, getConnection, getFallbackConnection, loadKeypair, eventBus, createLogger, sendCriticalAlert, getSupabase } from "@percolatorct/shared";
 import { OracleService } from "./oracle.js";
 import { recordAttempt, recordLanded, recordFailed } from "../lib/sender-metrics.js";
+import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
 
 const logger = createLogger("keeper:crank");
 
@@ -643,7 +644,12 @@ export class CrankService {
         recordAttempt();
         let sig: string;
         try {
-          sig = await sendWithRetryKeeper(connection, instructions, [keypair], 3, KEEPER_SEND_OPTS);
+          const sendResult = await keeperSend(connection, instructions, [keypair], "crank", sharedBudget, 3, KEEPER_SEND_OPTS);
+          if (!sendResult) {
+            recordFailed();
+            return false;
+          }
+          sig = sendResult.signature;
           const __tip = process.env.USE_HELIUS_SENDER === "true"
             ? parseInt(process.env.JITO_TIP_LAMPORTS ?? "200000", 10)
             : 0;
@@ -694,7 +700,12 @@ export class CrankService {
       recordAttempt();
       let sig: string;
       try {
-        sig = await sendWithRetryKeeper(connection, instructions, [keypair], 3, KEEPER_SEND_OPTS);
+        const sendResult = await keeperSend(connection, instructions, [keypair], "crank", sharedBudget, 3, KEEPER_SEND_OPTS);
+        if (!sendResult) {
+          recordFailed();
+          return false;
+        }
+        sig = sendResult.signature;
         const __tip = process.env.USE_HELIUS_SENDER === "true"
           ? parseInt(process.env.JITO_TIP_LAMPORTS ?? "200000", 10)
           : 0;

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -16,9 +16,10 @@ import {
   derivePythPushOraclePDA,
   type DiscoveredMarket,
 } from "@percolatorct/sdk";
-import { config, getConnection, loadKeypair, sendWithRetry, sendWithRetryKeeper, pollSignatureStatus, getRecentPriorityFees, checkTransactionSize, eventBus, createLogger, sendWarningAlert, acquireToken, getFallbackConnection, backoffMs, getErrorMessage } from "@percolatorct/shared";
+import { config, getConnection, loadKeypair, sendWithRetry, pollSignatureStatus, getRecentPriorityFees, checkTransactionSize, eventBus, createLogger, sendWarningAlert, acquireToken, getFallbackConnection, backoffMs, getErrorMessage } from "@percolatorct/shared";
 import { OracleService } from "./oracle.js";
 import { recordAttempt, recordLanded, recordFailed } from "../lib/sender-metrics.js";
+import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
 
 const logger = createLogger("keeper:liquidation");
 
@@ -412,7 +413,12 @@ export class LiquidationService {
       recordAttempt();
       let sig: string;
       try {
-        sig = await sendWithRetryKeeper(connection, instructions, [keypair], 3);
+        const sendResult = await keeperSend(connection, instructions, [keypair], "liquidation", sharedBudget, 3);
+        if (!sendResult) {
+          recordFailed();
+          return null;
+        }
+        sig = sendResult.signature;
         const __tip = process.env.USE_HELIUS_SENDER === "true"
           ? parseInt(process.env.JITO_TIP_LAMPORTS ?? "200000", 10)
           : 0;

--- a/tests/lib/blockhash-cache.test.ts
+++ b/tests/lib/blockhash-cache.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { BlockhashCache } from "../../src/lib/blockhash-cache.js";
+
+function makeConnection(overrides: Partial<{
+  getLatestBlockhash: () => Promise<{ blockhash: string; lastValidBlockHeight: number }>;
+  getSlot: () => Promise<number>;
+}> = {}) {
+  return {
+    getLatestBlockhash: vi.fn(async () => ({
+      blockhash: "mockblockhash11111111111111111111111111",
+      lastValidBlockHeight: 999_999,
+    })),
+    getSlot: vi.fn(async () => 100),
+    ...overrides,
+  } as any;
+}
+
+describe("BlockhashCache", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("getAsync fetches on first call and returns the cached value", async () => {
+    const conn = makeConnection();
+    const cache = new BlockhashCache(conn, { refreshMs: 2_000, maxSlotsReuse: 60 });
+
+    const result = await cache.getAsync();
+
+    expect(result.blockhash).toBe("mockblockhash11111111111111111111111111");
+    expect(result.lastValidBlockHeight).toBe(999_999);
+    expect(conn.getLatestBlockhash).toHaveBeenCalledTimes(1);
+  });
+
+  it("get() throws if cache is empty", () => {
+    const conn = makeConnection();
+    const cache = new BlockhashCache(conn, { refreshMs: 2_000, maxSlotsReuse: 60 });
+
+    expect(() => cache.get()).toThrow("BlockhashCache");
+  });
+
+  it("get() returns cached value after getAsync populates it", async () => {
+    const conn = makeConnection();
+    const cache = new BlockhashCache(conn, { refreshMs: 2_000, maxSlotsReuse: 60 });
+
+    await cache.getAsync();
+    const result = cache.get();
+
+    expect(result.blockhash).toBe("mockblockhash11111111111111111111111111");
+    expect(conn.getLatestBlockhash).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent getAsync calls into a single RPC fetch", async () => {
+    const conn = makeConnection();
+    const cache = new BlockhashCache(conn, { refreshMs: 2_000, maxSlotsReuse: 60 });
+
+    const [r1, r2, r3] = await Promise.all([
+      cache.getAsync(),
+      cache.getAsync(),
+      cache.getAsync(),
+    ]);
+
+    expect(conn.getLatestBlockhash).toHaveBeenCalledTimes(1);
+    expect(r1.blockhash).toBe(r2.blockhash);
+    expect(r2.blockhash).toBe(r3.blockhash);
+  });
+
+  it("re-fetches after maxSlotsReuse window elapses", async () => {
+    vi.useFakeTimers();
+    const conn = makeConnection();
+    const cache = new BlockhashCache(conn, { refreshMs: 2_000, maxSlotsReuse: 1 });
+
+    await cache.getAsync();
+    expect(conn.getLatestBlockhash).toHaveBeenCalledTimes(1);
+
+    // Advance by 1 slot = 400ms + 1ms to exceed the 1-slot reuse window
+    vi.advanceTimersByTime(401);
+
+    await cache.getAsync();
+    expect(conn.getLatestBlockhash).toHaveBeenCalledTimes(2);
+  });
+
+  it("start/stop controls background refresh timer", async () => {
+    vi.useFakeTimers();
+    const conn = makeConnection();
+    const cache = new BlockhashCache(conn, { refreshMs: 500, maxSlotsReuse: 60 });
+
+    cache.start();
+    await vi.advanceTimersByTimeAsync(1_600);
+
+    // ~3 interval ticks have fired (0ms start is not a tick, but 500ms, 1000ms, 1500ms are)
+    expect(conn.getLatestBlockhash).toBeGreaterThanOrEqual !== undefined;
+    const callCount = conn.getLatestBlockhash.mock.calls.length;
+    expect(callCount).toBeGreaterThanOrEqual(3);
+
+    cache.stop();
+    const countAfterStop = conn.getLatestBlockhash.mock.calls.length;
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    // No new calls after stop()
+    expect(conn.getLatestBlockhash.mock.calls.length).toBe(countAfterStop);
+  });
+
+  it("start() is idempotent — second call does not create a second timer", async () => {
+    vi.useFakeTimers();
+    const conn = makeConnection();
+    const cache = new BlockhashCache(conn, { refreshMs: 500, maxSlotsReuse: 60 });
+
+    cache.start();
+    cache.start();
+    await vi.advanceTimersByTimeAsync(600);
+
+    // Only one timer running → at most one refresh in 600ms window
+    expect(conn.getLatestBlockhash.mock.calls.length).toBeLessThanOrEqual(1);
+
+    cache.stop();
+  });
+
+  it("reads KEEPER_BLOCKHASH_CACHE_MS and KEEPER_BLOCKHASH_MAX_SLOTS_REUSE from env", () => {
+    const origCache = process.env.KEEPER_BLOCKHASH_CACHE_MS;
+    const origSlots = process.env.KEEPER_BLOCKHASH_MAX_SLOTS_REUSE;
+    process.env.KEEPER_BLOCKHASH_CACHE_MS = "1234";
+    process.env.KEEPER_BLOCKHASH_MAX_SLOTS_REUSE = "30";
+    try {
+      const conn = makeConnection();
+      const cache = new BlockhashCache(conn);
+      // Internal fields — cast to access for testing
+      expect((cache as any)._refreshMs).toBe(1234);
+      expect((cache as any)._maxSlotsReuse).toBe(30);
+    } finally {
+      if (origCache === undefined) delete process.env.KEEPER_BLOCKHASH_CACHE_MS;
+      else process.env.KEEPER_BLOCKHASH_CACHE_MS = origCache;
+      if (origSlots === undefined) delete process.env.KEEPER_BLOCKHASH_MAX_SLOTS_REUSE;
+      else process.env.KEEPER_BLOCKHASH_MAX_SLOTS_REUSE = origSlots;
+    }
+  });
+});

--- a/tests/lib/blockhash-cache.test.ts
+++ b/tests/lib/blockhash-cache.test.ts
@@ -125,6 +125,27 @@ describe("BlockhashCache", () => {
     cache.stop();
   });
 
+  // A.11 (MED): the existing 3-caller coalesce test proves the lock works
+  // for trivial concurrency; the brief specified 1k. Catches regressions
+  // where someone "optimizes" away the in-flight promise share.
+  it.skipIf(!process.env.STRESS)(
+    "A.11 STRESS: 1000 concurrent getAsync() calls produce a single RPC fetch",
+    { timeout: 15_000 },
+    async () => {
+      const conn = makeConnection();
+      const cache = new BlockhashCache(conn, { refreshMs: 60_000, maxSlotsReuse: 60 });
+
+      const results = await Promise.all(
+        Array.from({ length: 1000 }, () => cache.getAsync()),
+      );
+
+      expect(conn.getLatestBlockhash).toHaveBeenCalledTimes(1);
+      // Every caller saw the same blockhash.
+      const uniq = new Set(results.map((r) => r.blockhash));
+      expect(uniq.size).toBe(1);
+    },
+  );
+
   it("reads KEEPER_BLOCKHASH_CACHE_MS and KEEPER_BLOCKHASH_MAX_SLOTS_REUSE from env", () => {
     const origCache = process.env.KEEPER_BLOCKHASH_CACHE_MS;
     const origSlots = process.env.KEEPER_BLOCKHASH_MAX_SLOTS_REUSE;

--- a/tests/lib/cu-estimator.test.ts
+++ b/tests/lib/cu-estimator.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import fc from "fast-check";
 
 vi.mock("@percolatorct/shared", () => ({
   createLogger: vi.fn(() => ({
@@ -120,5 +121,57 @@ describe("CuEstimator", () => {
         sigVerify: false,
       }),
     );
+  });
+
+  // A.12: properties protect the CU-margin math. If the estimator ever returns
+  // a value below `consumed`, the CU limit on-chain would be too tight and
+  // the tx would land with InsufficientComputeUnits.
+  describe("A.12: property tests", () => {
+    it("property: result >= consumed for any consumed > 0 and margin >= 1.0", () => {
+      fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 1_400_000 }),
+          fc.double({ min: 1.0, max: 3.0, noNaN: true }),
+          async (consumed, margin) => {
+            const conn = makeConnection(consumed);
+            const estimator = new CuEstimator({ margin, fallback: 1_400_000 });
+            const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+            return result >= consumed;
+          },
+        ),
+        { numRuns: 200 },
+      );
+    });
+
+    it("property: for consumed == 0, always returns the configured fallback", () => {
+      fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 1_400_000 }),
+          fc.double({ min: 1.0, max: 3.0, noNaN: true }),
+          async (fallback, margin) => {
+            const conn = makeConnection(0);
+            const estimator = new CuEstimator({ margin, fallback });
+            const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+            return result === fallback;
+          },
+        ),
+        { numRuns: 200 },
+      );
+    });
+
+    it("property: result >= 1 for any consumed >= 1 (no zero/negative)", () => {
+      fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 1_400_000 }),
+          async (consumed) => {
+            const conn = makeConnection(consumed);
+            const estimator = new CuEstimator({ margin: 1.1, fallback: 1_400_000 });
+            const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+            return result >= 1;
+          },
+        ),
+        { numRuns: 200 },
+      );
+    });
   });
 });

--- a/tests/lib/cu-estimator.test.ts
+++ b/tests/lib/cu-estimator.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { CuEstimator } from "../../src/lib/cu-estimator.js";
+import { Keypair, PublicKey, TransactionInstruction } from "@solana/web3.js";
+
+function makeDummyIx(): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: PublicKey.default,
+    keys: [],
+    data: Buffer.from([]),
+  });
+}
+
+function makeConnection(unitsConsumed: number | undefined, err: string | null = null) {
+  return {
+    simulateTransaction: vi.fn(async () => ({
+      value: {
+        err,
+        logs: [],
+        unitsConsumed,
+      },
+    })),
+  } as any;
+}
+
+describe("CuEstimator", () => {
+  it("returns ceil(unitsConsumed * margin) on success", async () => {
+    const conn = makeConnection(100_000);
+    const estimator = new CuEstimator({ margin: 1.1, fallback: 1_400_000 });
+
+    const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+
+    expect(result).toBe(Math.ceil(100_000 * 1.1));
+  });
+
+  it("returns fallback when unitsConsumed is 0", async () => {
+    const conn = makeConnection(0);
+    const estimator = new CuEstimator({ margin: 1.1, fallback: 1_400_000 });
+
+    const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+
+    expect(result).toBe(1_400_000);
+  });
+
+  it("returns fallback when unitsConsumed is undefined", async () => {
+    const conn = makeConnection(undefined);
+    const estimator = new CuEstimator({ margin: 1.1, fallback: 500_000 });
+
+    const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+
+    expect(result).toBe(500_000);
+  });
+
+  it("returns fallback when simulateTransaction throws", async () => {
+    const conn = {
+      simulateTransaction: vi.fn(async () => {
+        throw new Error("RPC error");
+      }),
+    } as any;
+    const estimator = new CuEstimator({ margin: 1.1, fallback: 1_400_000 });
+
+    const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+
+    expect(result).toBe(1_400_000);
+  });
+
+  it("reads KEEPER_CU_SIMULATE_MARGIN and KEEPER_CU_FALLBACK_LIMIT from env", async () => {
+    const origMargin = process.env.KEEPER_CU_SIMULATE_MARGIN;
+    const origFallback = process.env.KEEPER_CU_FALLBACK_LIMIT;
+    process.env.KEEPER_CU_SIMULATE_MARGIN = "1.25";
+    process.env.KEEPER_CU_FALLBACK_LIMIT = "800000";
+    try {
+      const conn = makeConnection(200_000);
+      const estimator = new CuEstimator();
+      const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+      expect(result).toBe(Math.ceil(200_000 * 1.25));
+    } finally {
+      if (origMargin === undefined) delete process.env.KEEPER_CU_SIMULATE_MARGIN;
+      else process.env.KEEPER_CU_SIMULATE_MARGIN = origMargin;
+      if (origFallback === undefined) delete process.env.KEEPER_CU_FALLBACK_LIMIT;
+      else process.env.KEEPER_CU_FALLBACK_LIMIT = origFallback;
+    }
+  });
+
+  it("uses fallback from env when simulation fails", async () => {
+    const origFallback = process.env.KEEPER_CU_FALLBACK_LIMIT;
+    process.env.KEEPER_CU_FALLBACK_LIMIT = "750000";
+    try {
+      const conn = {
+        simulateTransaction: vi.fn(async () => { throw new Error("net"); }),
+      } as any;
+      const estimator = new CuEstimator();
+      const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+      expect(result).toBe(750_000);
+    } finally {
+      if (origFallback === undefined) delete process.env.KEEPER_CU_FALLBACK_LIMIT;
+      else process.env.KEEPER_CU_FALLBACK_LIMIT = origFallback;
+    }
+  });
+
+  it("passes replaceRecentBlockhash:true and sigVerify:false to simulateTransaction", async () => {
+    const conn = makeConnection(50_000);
+    const estimator = new CuEstimator({ margin: 1.0, fallback: 1_400_000 });
+
+    await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+
+    expect(conn.simulateTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        replaceRecentBlockhash: true,
+        sigVerify: false,
+      }),
+    );
+  });
+});

--- a/tests/lib/keeper-send.test.ts
+++ b/tests/lib/keeper-send.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  sendWithRetryKeeper: vi.fn(async () => "mock-signature"),
+}));
+
+vi.mock("../../src/lib/priority-fee.js", () => {
+  class HeliusPriorityFeeEstimator {
+    estimate = vi.fn(async () => 1_000);
+  }
+  return { HeliusPriorityFeeEstimator };
+});
+
+vi.mock("../../src/lib/cu-estimator.js", () => {
+  class CuEstimator {
+    estimate = vi.fn(async () => 200_000);
+  }
+  return { CuEstimator };
+});
+
+import * as shared from "@percolatorct/shared";
+import { keeperSend } from "../../src/lib/keeper-send.js";
+import { KeeperBudget } from "../../src/lib/budget.js";
+import { Keypair, TransactionInstruction, PublicKey } from "@solana/web3.js";
+
+function makeDummyIx(): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: PublicKey.default,
+    keys: [],
+    data: Buffer.from([]),
+  });
+}
+
+function makeConnection() {
+  return {
+    simulateTransaction: vi.fn(async () => ({ value: { unitsConsumed: 200_000, err: null, logs: [] } })),
+  } as any;
+}
+
+describe("keeperSend", () => {
+  let budget: KeeperBudget;
+  let connection: ReturnType<typeof makeConnection>;
+  let keypair: Keypair;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000, maxTxPerCycle: 100 });
+    connection = makeConnection();
+    keypair = Keypair.generate();
+    process.env.NETWORK = "devnet";
+    process.env.USE_HELIUS_SENDER = "false";
+  });
+
+  it("returns a signature result on successful send", async () => {
+    const result = await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+
+    expect(result).not.toBeNull();
+    expect(result!.signature).toBe("mock-signature");
+    expect(typeof result!.estimatedCost).toBe("number");
+  });
+
+  it("calls sendWithRetryKeeper from shared", async () => {
+    await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+
+    expect(shared.sendWithRetryKeeper).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when budget is halted", async () => {
+    budget.haltManually("test halt");
+
+    const result = await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+
+    expect(result).toBeNull();
+    expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+  });
+
+  it("records success in budget on successful send", async () => {
+    await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+
+    const stats = budget.getStats();
+    expect(stats.cycleTxCount).toBe(1);
+    // spend recorded: estimatedCost > 0
+    expect(stats.cycleSpend).toBeGreaterThan(0);
+  });
+
+  it("records fail in budget when send throws", async () => {
+    vi.mocked(shared.sendWithRetryKeeper).mockRejectedValueOnce(new Error("RPC error"));
+
+    await expect(
+      keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget),
+    ).rejects.toThrow("RPC error");
+
+    const stats = budget.getStats();
+    expect(stats.cycleTxCount).toBe(1);
+    // failed txs still consume lamports (fees paid on-chain if landed)
+    expect(stats.cycleSpend).toBeGreaterThan(0);
+  });
+
+  it("passes maxRetries to sendWithRetryKeeper", async () => {
+    await keeperSend(connection, [makeDummyIx()], [keypair], "liquidation", budget, 5);
+
+    expect(shared.sendWithRetryKeeper).toHaveBeenCalledWith(
+      connection,
+      expect.any(Array),
+      expect.any(Array),
+      5,
+      expect.anything(),
+    );
+  });
+
+  it("merges keeperOpts with skipPreflight on mainnet+heliusSender", async () => {
+    process.env.NETWORK = "mainnet";
+    process.env.USE_HELIUS_SENDER = "true";
+
+    await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget, 3, {
+      multiRpcBroadcast: true,
+    });
+
+    expect(shared.sendWithRetryKeeper).toHaveBeenCalledWith(
+      connection,
+      expect.any(Array),
+      expect.any(Array),
+      3,
+      expect.objectContaining({ skipPreflight: true, multiRpcBroadcast: true }),
+    );
+
+    delete process.env.NETWORK;
+    delete process.env.USE_HELIUS_SENDER;
+  });
+
+  it("does NOT force skipPreflight on devnet", async () => {
+    process.env.NETWORK = "devnet";
+    process.env.USE_HELIUS_SENDER = "false";
+
+    await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget, 3, {
+      skipPreflight: false,
+    });
+
+    const callArgs = vi.mocked(shared.sendWithRetryKeeper).mock.calls[0];
+    // opts is the 5th arg — skipPreflight should remain false (devnet)
+    expect(callArgs![4]).toEqual(expect.objectContaining({ skipPreflight: false }));
+  });
+});

--- a/tests/lib/keeper-send.test.ts
+++ b/tests/lib/keeper-send.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@percolatorct/shared", () => ({
   createLogger: vi.fn(() => ({
@@ -145,5 +145,77 @@ describe("keeperSend", () => {
     const callArgs = vi.mocked(shared.sendWithRetryKeeper).mock.calls[0];
     // opts is the 5th arg — skipPreflight should remain false (devnet)
     expect(callArgs![4]).toEqual(expect.objectContaining({ skipPreflight: false }));
+  });
+
+  // A.10 (HIGH): DRY_RUN must intercept the actual sendTransaction. Without
+  // this, shadow-keeper deployments would still hit mainnet RPC and could
+  // accidentally land real transactions through retry/network blips.
+  describe("A.10: DRY_RUN intercept", () => {
+    let originalDryRun: string | undefined;
+    beforeEach(() => {
+      originalDryRun = process.env.DRY_RUN;
+      process.env.DRY_RUN = "true";
+    });
+    afterEach(() => {
+      if (originalDryRun === undefined) delete process.env.DRY_RUN;
+      else process.env.DRY_RUN = originalDryRun;
+    });
+
+    it("returns a synthetic dry_run_ signature instead of calling the sender", async () => {
+      const result = await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+      expect(result).not.toBeNull();
+      expect(result!.signature).toMatch(/^dry_run_[0-9a-f-]{36}$/);
+      expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+    });
+
+    it("records the would-have-spent estimate to the budget", async () => {
+      const before = budget.getStats();
+      const result = await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+      const after = budget.getStats();
+      expect(after.cycleTxCount).toBe(before.cycleTxCount + 1);
+      expect(after.cycleSpend).toBe(before.cycleSpend + result!.estimatedCost);
+    });
+
+    it("returns null when budget is halted, even in DRY_RUN", async () => {
+      budget.haltManually("dry-run halt test");
+      const result = await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+      expect(result).toBeNull();
+      expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+    });
+
+    it("each call returns a unique synthetic signature", async () => {
+      const sigs = await Promise.all([
+        keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget),
+        keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget),
+        keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget),
+      ]);
+      const uniq = new Set(sigs.map((r) => r!.signature));
+      expect(uniq.size).toBe(3);
+    });
+
+    it.skipIf(!process.env.STRESS)(
+      "STRESS: 1000 concurrent DRY_RUN sends — zero real RPC traffic, all unique sigs",
+      { timeout: 30_000 },
+      async () => {
+        // A wider budget so the 1k sends don't hit cycle caps.
+        const wideBudget = new (await import("../../src/lib/budget.js")).KeeperBudget({
+          maxSolPerCycle: Number.MAX_SAFE_INTEGER,
+          maxSolPerHour: Number.MAX_SAFE_INTEGER,
+          maxSolPerDay: Number.MAX_SAFE_INTEGER,
+          maxTxPerCycle: 10_000,
+          txSuccessRateThreshold: 0,
+          txSuccessRateMinSamples: 1_000_000,
+        });
+        const N = 1000;
+        const sigs = await Promise.all(
+          Array.from({ length: N }, () =>
+            keeperSend(connection, [makeDummyIx()], [keypair], "crank", wideBudget),
+          ),
+        );
+        const uniq = new Set(sigs.map((r) => r!.signature));
+        expect(uniq.size).toBe(N);
+        expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+      },
+    );
   });
 });

--- a/tests/lib/priority-fee.property.test.ts
+++ b/tests/lib/priority-fee.property.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import { estimateLamportCost, BASE_FEE_LAMPORTS } from "../../src/lib/keeper-send.js";
+
+// A.12: property tests for the keeper send-path cost formula.
+// Formula: cost = BASE_FEE_LAMPORTS + ceil(microLamports * cu / 1_000_000) + jitoTip.
+//
+// These properties protect the budget cap math against silent regressions in
+// the priority-fee + CU + tip composition that drives every keeper send.
+
+describe("estimateLamportCost (A.12)", () => {
+  it("property: cost is always >= BASE_FEE_LAMPORTS for any non-negative inputs", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 1_000_000_000 }),
+        fc.integer({ min: 0, max: 10_000_000 }),
+        fc.integer({ min: 0, max: 1_000_000 }),
+        (microLamports, cu, jitoTip) => {
+          return estimateLamportCost(microLamports, cu, jitoTip) >= BASE_FEE_LAMPORTS;
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  it("property: cost is monotonically non-decreasing in cu (for fixed microLamports + tip)", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 1_000_000 }),
+        fc.integer({ min: 0, max: 1_000_000 }),
+        fc.integer({ min: 0, max: 5_000_000 }),
+        fc.integer({ min: 0, max: 5_000_000 }),
+        (microLamports, jitoTip, cuA, cuB) => {
+          const lo = Math.min(cuA, cuB);
+          const hi = Math.max(cuA, cuB);
+          return (
+            estimateLamportCost(microLamports, lo, jitoTip) <=
+            estimateLamportCost(microLamports, hi, jitoTip)
+          );
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  it("property: cost is monotonically non-decreasing in microLamports (for fixed cu + tip)", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 5_000_000 }),
+        fc.integer({ min: 0, max: 1_000_000 }),
+        fc.integer({ min: 0, max: 1_000_000 }),
+        fc.integer({ min: 0, max: 1_000_000 }),
+        (cu, jitoTip, microA, microB) => {
+          const lo = Math.min(microA, microB);
+          const hi = Math.max(microA, microB);
+          return (
+            estimateLamportCost(lo, cu, jitoTip) <= estimateLamportCost(hi, cu, jitoTip)
+          );
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  it("property: cost == BASE + jitoTip when microLamports == 0", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 5_000_000 }),
+        fc.integer({ min: 0, max: 1_000_000 }),
+        (cu, jitoTip) => {
+          return estimateLamportCost(0, cu, jitoTip) === BASE_FEE_LAMPORTS + jitoTip;
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  it("property: cost == BASE + jitoTip when cu == 0", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 1_000_000_000 }),
+        fc.integer({ min: 0, max: 1_000_000 }),
+        (microLamports, jitoTip) => {
+          return estimateLamportCost(microLamports, 0, jitoTip) === BASE_FEE_LAMPORTS + jitoTip;
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  it("known value: ceil rounding is correct", () => {
+    // 1 microLamport * 999_999 CU = 0.999999 lamports → ceil → 1
+    expect(estimateLamportCost(1, 999_999, 0)).toBe(BASE_FEE_LAMPORTS + 1);
+    // 1 microLamport * 1_000_000 CU = 1 lamport
+    expect(estimateLamportCost(1, 1_000_000, 0)).toBe(BASE_FEE_LAMPORTS + 1);
+    // 1 microLamport * 1_000_001 CU = 1.000001 lamports → ceil → 2
+    expect(estimateLamportCost(1, 1_000_001, 0)).toBe(BASE_FEE_LAMPORTS + 2);
+  });
+});

--- a/tests/lib/priority-fee.test.ts
+++ b/tests/lib/priority-fee.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { HeliusPriorityFeeEstimator } from "../../src/lib/priority-fee.js";
+import type { PriorityFeeTier } from "../../src/lib/priority-fee.js";
+
+function mockFetch(response: object, ok = true, status = 200) {
+  return vi.fn(async () => ({
+    ok,
+    status,
+    statusText: ok ? "OK" : "Internal Server Error",
+    json: async () => response,
+  })) as unknown as typeof fetch;
+}
+
+const HELIUS_SUCCESS_RESPONSE = {
+  result: {
+    priorityFeeLevels: {
+      min: 100,
+      low: 500,
+      medium: 1_000,
+      high: 5_000,
+      veryHigh: 10_000,
+    },
+  },
+};
+
+describe("HeliusPriorityFeeEstimator", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it("returns p50 (medium) fee for crank tier", async () => {
+    global.fetch = mockFetch(HELIUS_SUCCESS_RESPONSE);
+    const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", { cacheMs: 0 });
+
+    const result = await estimator.estimate(["acc1", "acc2"], "crank");
+
+    expect(result).toBe(1_000); // medium = p50
+  });
+
+  it("returns p75 (high) fee for liquidation tier", async () => {
+    global.fetch = mockFetch(HELIUS_SUCCESS_RESPONSE);
+    const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", { cacheMs: 0 });
+
+    const result = await estimator.estimate(["acc1"], "liquidation");
+
+    expect(result).toBe(5_000); // high = p75
+  });
+
+  it("returns p25 (low) fee for oracle tier", async () => {
+    global.fetch = mockFetch(HELIUS_SUCCESS_RESPONSE);
+    const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", { cacheMs: 0 });
+
+    const result = await estimator.estimate(["acc1"], "oracle");
+
+    expect(result).toBe(500); // low = p25
+  });
+
+  it("returns fallback (1000) when fetch throws", async () => {
+    global.fetch = vi.fn(async () => { throw new Error("network error"); }) as any;
+    const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", { cacheMs: 0 });
+
+    const result = await estimator.estimate(["acc1"], "crank");
+
+    expect(result).toBe(1_000); // fallback
+  });
+
+  it("returns fallback when response is not ok", async () => {
+    global.fetch = mockFetch({}, false, 500);
+    const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", { cacheMs: 0 });
+
+    const result = await estimator.estimate(["acc1"], "crank");
+
+    expect(result).toBe(1_000);
+  });
+
+  it("returns fallback when response has malformed priorityFeeLevels", async () => {
+    global.fetch = mockFetch({ result: { priorityFeeLevels: null } });
+    const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", { cacheMs: 0 });
+
+    const result = await estimator.estimate(["acc1"], "crank");
+
+    expect(result).toBe(1_000);
+  });
+
+  it("caches results for cacheMs duration and returns cached value without additional fetch", async () => {
+    vi.useFakeTimers();
+    const fetchFn = mockFetch(HELIUS_SUCCESS_RESPONSE);
+    global.fetch = fetchFn;
+    const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", { cacheMs: 5_000 });
+
+    await estimator.estimate(["acc1"], "crank");
+    await estimator.estimate(["acc1"], "crank");
+
+    // Only one real fetch call — second was served from cache
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after cache expires", async () => {
+    vi.useFakeTimers();
+    const fetchFn = mockFetch(HELIUS_SUCCESS_RESPONSE);
+    global.fetch = fetchFn;
+    const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", { cacheMs: 1_000 });
+
+    await estimator.estimate(["acc1"], "crank");
+    vi.advanceTimersByTime(1_001);
+    await estimator.estimate(["acc1"], "crank");
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("different account-key sets have separate cache entries", async () => {
+    const fetchFn = mockFetch(HELIUS_SUCCESS_RESPONSE);
+    global.fetch = fetchFn;
+    const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", { cacheMs: 60_000 });
+
+    await estimator.estimate(["acc1"], "crank");
+    await estimator.estimate(["acc2"], "crank");
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("different tiers have separate cache entries for same account keys", async () => {
+    const fetchFn = mockFetch(HELIUS_SUCCESS_RESPONSE);
+    global.fetch = fetchFn;
+    const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", { cacheMs: 60_000 });
+
+    await estimator.estimate(["acc1"], "crank");
+    await estimator.estimate(["acc1"], "liquidation");
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("reads percentile overrides from env", async () => {
+    const origEnv = process.env.KEEPER_PRIORITY_FEE_PERCENTILE_CRANK;
+    // Override crank to p95 (veryHigh)
+    process.env.KEEPER_PRIORITY_FEE_PERCENTILE_CRANK = "95";
+    try {
+      global.fetch = mockFetch(HELIUS_SUCCESS_RESPONSE);
+      const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", { cacheMs: 0 });
+
+      const result = await estimator.estimate(["acc1"], "crank");
+
+      expect(result).toBe(10_000); // veryHigh = p95
+    } finally {
+      if (origEnv === undefined) delete process.env.KEEPER_PRIORITY_FEE_PERCENTILE_CRANK;
+      else process.env.KEEPER_PRIORITY_FEE_PERCENTILE_CRANK = origEnv;
+    }
+  });
+});

--- a/tests/services/adl.test.ts
+++ b/tests/services/adl.test.ts
@@ -414,4 +414,53 @@ describe("AdlService", () => {
       expect(marketStats?.consecutiveErrors).toBeGreaterThan(0);
     });
   });
+
+  // A.9 (HIGH): ADL no longer bypasses KeeperBudget. The two behaviours
+  // that the budget should now guard:
+  //   1. budget halt blocks ADL from sending
+  //   2. successful ADL records to the budget (so cap math sees ADL spend)
+  describe("A.9: ADL through KeeperBudget + keeperSend", () => {
+    beforeEach(() => {
+      service = new AdlService();
+    });
+
+    it("does NOT send when sharedBudget is halted", async () => {
+      const { sharedBudget } = await import("../../src/lib/keeper-send.js");
+      sharedBudget.haltManually("A.9 test halt");
+
+      try {
+        vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+        vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 1_000_000n }) as any);
+        vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
+        vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+          makeAccounts([{ idx: 0, pnl: 600_000n, capital: 500_000n, positionSize: 100n }]) as any,
+        );
+
+        await service.scanMarket(slabAddress, makeMarket() as any);
+
+        expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+      } finally {
+        sharedBudget.resume("a9-test-cleanup");
+      }
+    });
+
+    it("records a successful ADL tx to sharedBudget (cycleTxCount and cycleSpend both grow)", async () => {
+      const { sharedBudget } = await import("../../src/lib/keeper-send.js");
+      sharedBudget.resume("a9-pre-test"); // ensure not halted from a prior test
+      const before = sharedBudget.getStats();
+
+      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+      vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 1_000_000n }) as any);
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
+      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+        makeAccounts([{ idx: 0, pnl: 600_000n, capital: 500_000n, positionSize: 100n }]) as any,
+      );
+
+      await service.scanMarket(slabAddress, makeMarket() as any);
+
+      const after = sharedBudget.getStats();
+      expect(after.cycleTxCount).toBe(before.cycleTxCount + 1);
+      expect(after.cycleSpend).toBeGreaterThan(before.cycleSpend);
+    });
+  });
 });

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -71,10 +71,19 @@ vi.mock('@percolatorct/shared', () => ({
   },
 }));
 
+vi.mock('../../src/lib/keeper-send.js', async () => {
+  const { KeeperBudget } = await vi.importActual<typeof import('../../src/lib/budget.js')>('../../src/lib/budget.js');
+  return {
+    keeperSend: vi.fn(async () => ({ signature: 'mock-keeper-sig-' + Date.now(), estimatedCost: 5000 })),
+    sharedBudget: new KeeperBudget(),
+  };
+});
+
 import { PublicKey } from '@solana/web3.js';
 import { CrankService } from '../../src/services/crank.js';
 import * as core from '@percolatorct/sdk';
 import * as shared from '@percolatorct/shared';
+import * as keeperSendModule from '../../src/lib/keeper-send.js';
 
 describe('CrankService', () => {
   let crankService: CrankService;
@@ -211,7 +220,7 @@ describe('CrankService', () => {
       const result = await crankService.crankMarket(slabAddress);
 
       expect(result).toBe(true);
-      expect(shared.sendWithRetryKeeper).toHaveBeenCalled();
+      expect(keeperSendModule.keeperSend).toHaveBeenCalled();
       
       const state = crankService.getMarkets().get(slabAddress);
       expect(state?.successCount).toBe(1);
@@ -236,7 +245,7 @@ describe('CrankService', () => {
       vi.mocked(core.discoverMarkets).mockResolvedValue([mockMarket] as any);
       await crankService.discover();
 
-      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(new Error('Transaction failed'));
+      vi.mocked(keeperSendModule.keeperSend).mockRejectedValue(new Error('Transaction failed'));
 
       const result = await crankService.crankMarket(slabAddress);
 
@@ -272,14 +281,14 @@ describe('CrankService', () => {
       vi.setSystemTime(startTime);
 
       // One successful crank to set lastCrankTime
-      vi.mocked(shared.sendWithRetryKeeper).mockResolvedValue('initial-success');
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'initial-success', estimatedCost: 5000 } as any);
       await crankService.crankMarket(slabAddress);
       const stateAfterSuccess = crankService.getMarkets().get(slabAddress)!;
       expect(stateAfterSuccess.isActive).toBe(true);
       expect(stateAfterSuccess.lastCrankTime).toBeCloseTo(startTime, -2);
 
       // Now fail 10 consecutive times → market becomes inactive
-      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(new Error('Transaction failed'));
+      vi.mocked(keeperSendModule.keeperSend).mockRejectedValue(new Error('Transaction failed'));
       for (let i = 0; i < 10; i++) {
         await crankService.crankMarket(slabAddress);
       }
@@ -326,7 +335,7 @@ describe('CrankService', () => {
       vi.mocked(core.discoverMarkets).mockResolvedValue([mockMarket] as any);
       await crankService.discover();
 
-      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(new Error('Transaction failed'));
+      vi.mocked(keeperSendModule.keeperSend).mockRejectedValue(new Error('Transaction failed'));
 
       // Fail 10 times
       for (let i = 0; i < 10; i++) {
@@ -363,7 +372,7 @@ describe('CrankService', () => {
       };
 
       vi.mocked(core.discoverMarkets).mockResolvedValue([mockMarket] as any);
-      vi.mocked(shared.sendWithRetryKeeper).mockResolvedValue('sig-raydium');
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'sig-raydium', estimatedCost: 5000 } as any);
       await crankService.discover();
 
       expect(await crankService.crankMarket(slabAddress)).toBe(true);
@@ -371,11 +380,13 @@ describe('CrankService', () => {
 
       expect(connection.getAccountInfo).toHaveBeenCalledTimes(1);
       expect(core.detectDexType).toHaveBeenCalledTimes(1);
-      expect(shared.sendWithRetryKeeper).toHaveBeenCalledTimes(2);
-      expect(shared.sendWithRetryKeeper).toHaveBeenLastCalledWith(
+      expect(keeperSendModule.keeperSend).toHaveBeenCalledTimes(2);
+      expect(keeperSendModule.keeperSend).toHaveBeenLastCalledWith(
         connection,
         expect.any(Array),
         expect.any(Array),
+        'crank',
+        expect.anything(),
         3,
         expect.objectContaining({
           skipPreflight: true,
@@ -405,7 +416,7 @@ describe('CrankService', () => {
       await crankService.discover();
 
       // Simulate 0x4 error → permanently skipped
-      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(
+      vi.mocked(keeperSendModule.keeperSend).mockRejectedValue(
         new Error('failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x4')
       );
       await crankService.crankMarket(slabAddress);
@@ -440,7 +451,7 @@ describe('CrankService', () => {
       await crankService.discover();
 
       // Simulate 0x4 error
-      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(
+      vi.mocked(keeperSendModule.keeperSend).mockRejectedValue(
         new Error('custom program error: 0x4')
       );
       await crankService.crankMarket(slabAddress);
@@ -477,7 +488,7 @@ describe('CrankService', () => {
       await crankService.discover();
 
       // Simulate multiple 0x4 errors
-      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(
+      vi.mocked(keeperSendModule.keeperSend).mockRejectedValue(
         new Error('custom program error: 0x4')
       );
       await crankService.crankMarket(slabAddress);
@@ -550,7 +561,7 @@ describe('CrankService', () => {
 
       expect(result).toBe(false);
       // Should NOT have submitted a transaction
-      expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+      expect(keeperSendModule.keeperSend).not.toHaveBeenCalled();
 
       const state = crankService.getMarkets().get(slabAddress)!;
       expect(state.foreignOracleSkipped).toBe(true);
@@ -617,11 +628,11 @@ describe('CrankService', () => {
       vi.mocked(core.discoverMarkets).mockResolvedValue([mockMarket] as any);
       await crankService.discover();
 
-      vi.mocked(shared.sendWithRetryKeeper).mockResolvedValue('sig-own-oracle');
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'sig-own-oracle', estimatedCost: 5000 } as any);
       const result = await crankService.crankMarket(slabAddress);
 
       expect(result).toBe(true);
-      expect(shared.sendWithRetryKeeper).toHaveBeenCalled();
+      expect(keeperSendModule.keeperSend).toHaveBeenCalled();
 
       const state = crankService.getMarkets().get(slabAddress)!;
       expect(state.foreignOracleSkipped).toBeUndefined();
@@ -663,7 +674,7 @@ describe('CrankService', () => {
       await localCrank.discover();
 
       mockOracleService.fetchPrice = vi.fn().mockResolvedValue({ priceE6: BigInt(50_000_000), source: 'dexscreener', timestamp: Date.now() });
-      vi.mocked(shared.sendWithRetryKeeper).mockResolvedValue('sig-push-time');
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'sig-push-time', estimatedCost: 5000 } as any);
 
       try {
         const result = await localCrank.crankMarket(slabAddress);
@@ -722,7 +733,7 @@ describe('CrankService', () => {
       const foreignState = crankService.getMarkets().get(slabForeign)!;
       foreignState.foreignOracleSkipped = true;
 
-      vi.mocked(shared.sendWithRetryKeeper).mockResolvedValue('sig-normal');
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'sig-normal', estimatedCost: 5000 } as any);
       const result = await crankService.crankAll();
 
       // Normal market cranked; foreign oracle market skipped → skipped >= 1
@@ -785,7 +796,7 @@ describe('CrankService', () => {
       // Now simulate discover() resetting the flag (as it does on each cycle)
       foreignState.foreignOracleSkipped = false;
 
-      vi.mocked(shared.sendWithRetryKeeper).mockResolvedValue('sig-norm2');
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'sig-norm2', estimatedCost: 5000 } as any);
       const result = await crankService.crankAll();
 
       // The foreign oracle market should be SKIPPED, not failed
@@ -804,7 +815,7 @@ describe('CrankService', () => {
       // Regression: Small/256-slot Hyperp markets (indexFeedId=all-zeros, authorityPriceE6=0)
       // where fetchPrice returns null cause OracleInvalid (0xc) if cranked.
       // They must be skipped, not failed.
-      vi.mocked(shared.sendWithRetryKeeper).mockResolvedValue('mock-sig');
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'mock-sig', estimatedCost: 5000 } as any);
 
       const slabHyperp = 'HyperpZero1111111111111111111111111111111';
       const slabNormal = 'Normal111111111111111111111111111111111';
@@ -890,7 +901,7 @@ describe('CrankService', () => {
     });
 
     it('PERC-1254: should crank Hyperp market once fetchPrice returns a valid price', async () => {
-      vi.mocked(shared.sendWithRetryKeeper).mockResolvedValue('mock-sig');
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'mock-sig', estimatedCost: 5000 } as any);
 
       const slabHyperp = 'HyperpWithPrice111111111111111111111111';
       const ZERO_BYTES = new Uint8Array(32);

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -121,10 +121,19 @@ vi.mock('@percolatorct/shared', () => ({
   }),
 }));
 
+vi.mock('../../src/lib/keeper-send.js', async () => {
+  const { KeeperBudget } = await vi.importActual<typeof import('../../src/lib/budget.js')>('../../src/lib/budget.js');
+  return {
+    keeperSend: vi.fn(async () => ({ signature: 'mock-keeper-signature', estimatedCost: 5000 })),
+    sharedBudget: new KeeperBudget(),
+  };
+});
+
 import { PublicKey, ComputeBudgetProgram } from '@solana/web3.js';
 import { LiquidationService } from '../../src/services/liquidation.js';
 import * as core from '@percolatorct/sdk';
 import * as shared from '@percolatorct/shared';
+import * as keeperSendModule from '../../src/lib/keeper-send.js';
 
 // Zero key (all zeros) - used for Pyth-pinned oracleAuthority and Hyperp indexFeedId
 const ZERO_KEY = (() => {
@@ -502,8 +511,8 @@ describe('LiquidationService', () => {
         header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
       };
 
-      // Simulate 0x4 error from sendWithRetryKeeper
-      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValueOnce(
+      // Simulate 0x4 error from keeperSend
+      vi.mocked(keeperSendModule.keeperSend).mockRejectedValueOnce(
         new Error('Transaction simulation failed: custom program error: 0x4'),
       );
       vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(1024));
@@ -553,7 +562,7 @@ describe('LiquidationService', () => {
         header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
       };
 
-      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValueOnce(
+      vi.mocked(keeperSendModule.keeperSend).mockRejectedValueOnce(
         new Error('custom program error: 0x4'),
       );
       vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(1024));
@@ -581,7 +590,7 @@ describe('LiquidationService', () => {
       expect(svc.getStatus().permanentlySkippedCount).toBe(1);
 
       // Now run scanAndLiquidateAll — the corrupt market should be skipped entirely
-      vi.mocked(shared.sendWithRetryKeeper).mockClear();
+      vi.mocked(keeperSendModule.keeperSend).mockClear();
       vi.mocked(core.fetchSlab).mockClear();
       const markets = new Map([
         [corruptAddr, { market: mockMarket as any }],
@@ -590,7 +599,7 @@ describe('LiquidationService', () => {
 
       // scanMarket should NOT have been called (filtered before batch)
       // so no send should have been attempted
-      expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+      expect(keeperSendModule.keeperSend).not.toHaveBeenCalled();
       expect(result.scanned).toBe(0);
     });
 


### PR DESCRIPTION
## Summary

Workstream D from the Phase 1 brief — send-path modernization. Four new modules + integration into `CrankService.crankMarket()` and `LiquidationService.liquidate()`, wiring the KeeperBudget circuit breaker (from #114) into the send path. Includes a manual copy of `src/lib/budget.ts` so this PR stands on its own; the copy is byte-identical to A2-A8 (`git diff` returns no output) — merge order between #114 and this PR doesn't matter.

## New modules

| Module | LOC | Purpose |
|---|---|---|
| `src/lib/priority-fee.ts` | 132 | `HeliusPriorityFeeEstimator.estimate(accountKeys, tier)`. Calls Helius `getPriorityFeeEstimate` RPC with the account-key set. Reads p75 for liquidations, p50 for cranks, p25 for oracle pushes (all env-overridable). 5s cache per account-key set hash. Falls back to 1000 µLAMP baseline on RPC failure, logs the fallback as warn. |
| `src/lib/cu-estimator.ts` | 66 | `CuEstimator.estimate(connection, instructions, signers)`. Calls `simulateTransaction({ replaceRecentBlockhash: true, sigVerify: false })`, reads `unitsConsumed`, returns `Math.ceil(unitsConsumed * marginMultiplier)` (default 1.10, env-override `KEEPER_CU_SIMULATE_MARGIN`). Falls back to `KEEPER_CU_FALLBACK_LIMIT` (default 1_400_000) on sim error. |
| `src/lib/blockhash-cache.ts` | 118 | `BlockhashCache(connection, opts).start()/stop()/get()/getAsync()`. Refreshes every 2s at `commitment: processed`. Never reuses beyond 60 slots. `get()` throws on cache miss; `getAsync()` fetches synchronously when needed. Caller-managed singleton. |
| `src/lib/keeper-send.ts` | 119 | Thin wrapper around shared's `sendWithRetryKeeper`. Estimates cost (priority fee × CU + Jito tip + base fee), gates on `budget.canSpend(...)`, calls shared sender, on settle calls `budget.recordTx(actualCost, txType, result)`. |

**Production total: ~435 LOC** (over the ~300 target due to thorough env-override handling and cache coalescing — explicit choice, not bloat).

## Integration

- `CrankService.crankMarket()` and `LiquidationService.liquidate()` now route through `keeperSend(...)` instead of calling `sendWithRetryKeeper` directly. A shared `KeeperBudget` instance is constructed at module load with env defaults.
- `.env.example` documents the new priority-fee / CU / blockhash env vars and notes `USE_HELIUS_SENDER=true` as the recommended mainnet default (D1).
- On mainnet (`NETWORK=mainnet` AND `USE_HELIUS_SENDER=true`), the wrapper sets `skipPreflight: true` (D4) — saves ~20-50ms; the Sender's downstream RPCs run preflight separately.

## Tests added (+34 passing, ~585 LOC + ~130 LOC of existing-test updates)

- `tests/lib/blockhash-cache.test.ts` — 146 LOC. Refresh timing, max-slot reuse, sync `get()` throw vs `getAsync()` fetch, lifecycle.
- `tests/lib/cu-estimator.test.ts` — 124 LOC. Margin math, fallback on sim error, env-override of multiplier + fallback limit.
- `tests/lib/priority-fee.test.ts` — 166 LOC. Tier→percentile mapping, env-override of percentiles, 5s cache, fallback on RPC fail.
- `tests/lib/keeper-send.test.ts` — 149 LOC. Budget canSpend gate, recordTx on success/fail/drop, cost estimation flow.
- Updates to `tests/services/crank.test.ts` (49 LOC) and `tests/services/liquidation.test.ts` (19 LOC) to mock the keeperSend wrapper.

## Test plan

- [x] `pnpm build` clean (tsc strict)
- [x] `pnpm test`: **205 passed | 3 skipped** (was 171 / 3 baseline on main) — +34 new test cases
- [ ] Integration: real Helius `getPriorityFeeEstimate` call on devnet — verify percentile selection per tier and that fallback fires on a malformed mock response
- [ ] Stress: 1k concurrent `blockhashCache.getAsync()` calls — verify single RPC roundtrip (no thundering herd)
- [ ] End-to-end devnet send via `keeperSend` — verify `skipPreflight: true` honored on mainnet config, verify budget halts when caps tripped
- [ ] Shadow keeper (`DRY_RUN=true`) us-east4 for 24h — confirm budget metrics show cycle/hour/day spend tracking real activity; confirm no spurious halts under normal load

## D5 BlockhashCache — partial delivery

The `BlockhashCache` module is **complete and tested** but **not wired into the active send path** because `@percolatorct/shared`'s `sendWithRetryKeeper` controls its own blockhash fetch internally, and the brief's constraint #1 prohibits modifying the shared package. The cache is ready to use in any caller that directly invokes `connection.getLatestBlockhash`; activating it on the send path requires either:
1. A follow-up to shared exposing `KeeperSendOptions.blockhash` so the wrapper can inject the cached value, OR
2. Bypassing `sendWithRetryKeeper` for keeper-managed builds — out of scope here

Until then, blockhash fetching frequency is unchanged from baseline. The cache adds zero RPC load and zero risk; it's a parking spot for the integration once shared cooperates.

## Dependencies added

None. Uses existing `@solana/web3.js`, `node:fetch`, and the in-repo `budget.ts` from A7.

## Env vars

```
USE_HELIUS_SENDER=true                              # mainnet default — already supported by shared
KEEPER_PRIORITY_FEE_PERCENTILE_LIQUIDATION=75
KEEPER_PRIORITY_FEE_PERCENTILE_CRANK=50
KEEPER_PRIORITY_FEE_PERCENTILE_ORACLE=25
KEEPER_PRIORITY_FEE_CACHE_MS=5000
KEEPER_CU_SIMULATE_MARGIN=1.10
KEEPER_CU_FALLBACK_LIMIT=1400000
KEEPER_BLOCKHASH_CACHE_MS=2000
KEEPER_BLOCKHASH_MAX_SLOTS_REUSE=60
```

`HELIUS_RPC_URL` and/or `RPC_URL` must be set for the priority-fee estimator to call Helius's `getPriorityFeeEstimate`. The estimator constructs lazily on first call; verify the env is wired in Railway before promoting to mainnet.

## Merge ordering vs A2-A8 (#114)

This PR contains a byte-identical copy of `src/lib/budget.ts` (the A7 module from #114). `git diff origin/feat/keeper-phase1-a-safety-rest..origin/feat/keeper-phase1-d-send-path-upgrade -- src/lib/budget.ts` returns empty. Either merge order works:

- If #114 merges first → main has `budget.ts` + the rest of A's modules. This PR rebases trivially; the `budget.ts` "addition" becomes a no-op.
- If this PR merges first → main has `budget.ts` (only). #114 rebases trivially; the rest of A's modules (exit-handlers, startup-tracker, env-guards changes, index.ts wiring) are not in conflict.

## Why this is not coupled to v16 / v12.19

Pure infrastructure plumbing around the send path. No knowledge of instruction tags, account layouts, or program error codes. Works identically against today's v12.19 and any future engine version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transaction blockhash caching with automatic refresh to optimize Solana transaction preparation.
  * Introduced compute unit estimation for more accurate transaction fee calculations.
  * Added dynamic priority fee estimation with Helius support for improved transaction prioritization.
  * Implemented keeper budget system to gate and track transaction spending across transaction types.

* **Configuration**
  * Helius Sender fast routing now enabled by default with tunable priority fee and compute unit settings.

* **Tests**
  * Added comprehensive test coverage for blockhash caching, compute unit estimation, and priority fee logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-keeper/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->