### PR TITLE
feat(keeper): Phase 1.5 Workstream G — Alchemy secondary RPC + read/write split

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,3 +81,21 @@ USE_HELIUS_SENDER=true
 # KEEPER_LEADER_LOCK_TTL_MS=30000
 # KEEPER_LEADER_LOCK_RENEW_MS=10000
 # KEEPER_STANDBY_POLL_MS=5000
+
+# RPC pool (Alchemy secondary) — Workstream G
+# Helius stays primary for reads and the sole write path. Alchemy is health-checked
+# failover: reads fall back to Alchemy when Helius P99 > 2s, slot lag > 50, or
+# 5+ consecutive health-check failures. LaserStream (WebSocket) stays on Helius.
+# getProgramAccounts always routes to Alchemy by default (heavy method, spares Helius).
+#
+# Required when RPC_POOL_ENABLED=true:
+# ALCHEMY_RPC_URL=https://solana-mainnet.g.alchemy.com/v2/YOUR_KEY
+# ALCHEMY_API_KEY=                    # informational; the key is embedded in ALCHEMY_RPC_URL
+#
+# RPC_POOL_ENABLED=true               # false = always Helius (current behaviour pre-G)
+# RPC_HEALTH_CHECK_INTERVAL_MS=5000   # how often to probe both providers
+# RPC_UNHEALTHY_P99_MS=2000           # P99 > this → Helius unhealthy
+# RPC_UNHEALTHY_SLOT_LAG=50           # |slot lag| > this → unhealthy
+# RPC_UNHEALTHY_CONSECUTIVE_FAILS=5   # consecutive probe failures → unhealthy
+# RPC_RECOVERY_WINDOW_MS=60000        # must hold clean for this long before re-promoting Helius
+# RPC_FORCE_ALCHEMY_GPA=true          # always route getProgramAccounts to Alchemy

--- a/src/config/rpc.ts
+++ b/src/config/rpc.ts
@@ -1,0 +1,75 @@
+/**
+ * RPC provider configuration and routing rules for the keeper RPC pool.
+ *
+ * Parsed once at startup. ALCHEMY_RPC_URL and ALCHEMY_API_KEY are validated
+ * only when RPC_POOL_ENABLED=true — this avoids breaking keeper boots that
+ * have not yet configured Alchemy.
+ */
+
+function parseBoolEnv(env: NodeJS.ProcessEnv, key: string, defaultVal: boolean): boolean {
+  const raw = env[key];
+  if (raw === undefined || raw === "") return defaultVal;
+  return raw.trim().toLowerCase() === "true";
+}
+
+function parseIntEnv(env: NodeJS.ProcessEnv, key: string, defaultVal: number): number {
+  const raw = env[key];
+  if (raw === undefined || raw === "") return defaultVal;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) return defaultVal;
+  return n;
+}
+
+export interface RpcProviderConfig {
+  url: string;
+  name: "helius" | "alchemy";
+}
+
+export interface RpcPoolConfig {
+  enabled: boolean;
+  helius: RpcProviderConfig;
+  alchemy: RpcProviderConfig;
+  healthCheckIntervalMs: number;
+  unhealthyP99Ms: number;
+  unhealthySlotLag: number;
+  unhealthyConsecutiveFails: number;
+  recoveryWindowMs: number;
+  forceAlchemyGpa: boolean;
+}
+
+export function parseRpcPoolConfig(env: NodeJS.ProcessEnv = process.env): RpcPoolConfig {
+  const enabled = parseBoolEnv(env, "RPC_POOL_ENABLED", true);
+
+  const heliusUrl = env.SOLANA_RPC_URL ?? env.RPC_URL ?? "";
+
+  if (enabled) {
+    const alchemyUrl = env.ALCHEMY_RPC_URL?.trim() ?? "";
+    if (!alchemyUrl) {
+      throw new Error(
+        "RPC_POOL_ENABLED=true requires ALCHEMY_RPC_URL to be set. " +
+          "Set ALCHEMY_RPC_URL to your Alchemy endpoint or set RPC_POOL_ENABLED=false.",
+      );
+    }
+    // Alchemy URL must be https unless ALLOW_INSECURE_RPC=true.
+    if (!alchemyUrl.startsWith("https://") && env.ALLOW_INSECURE_RPC !== "true") {
+      throw new Error(
+        `ALCHEMY_RPC_URL must use https:// (got ${alchemyUrl.slice(0, 30)}...). ` +
+          "Set ALLOW_INSECURE_RPC=true to override for local development.",
+      );
+    }
+  }
+
+  const alchemyUrl = env.ALCHEMY_RPC_URL?.trim() ?? "";
+
+  return {
+    enabled,
+    helius: { url: heliusUrl, name: "helius" },
+    alchemy: { url: alchemyUrl, name: "alchemy" },
+    healthCheckIntervalMs: parseIntEnv(env, "RPC_HEALTH_CHECK_INTERVAL_MS", 5_000),
+    unhealthyP99Ms: parseIntEnv(env, "RPC_UNHEALTHY_P99_MS", 2_000),
+    unhealthySlotLag: parseIntEnv(env, "RPC_UNHEALTHY_SLOT_LAG", 50),
+    unhealthyConsecutiveFails: parseIntEnv(env, "RPC_UNHEALTHY_CONSECUTIVE_FAILS", 5),
+    recoveryWindowMs: parseIntEnv(env, "RPC_RECOVERY_WINDOW_MS", 60_000),
+    forceAlchemyGpa: parseBoolEnv(env, "RPC_FORCE_ALCHEMY_GPA", true),
+  };
+}

--- a/src/config/rpc.ts
+++ b/src/config/rpc.ts
@@ -38,7 +38,7 @@ export interface RpcPoolConfig {
 }
 
 export function parseRpcPoolConfig(env: NodeJS.ProcessEnv = process.env): RpcPoolConfig {
-  const enabled = parseBoolEnv(env, "RPC_POOL_ENABLED", true);
+  const enabled = parseBoolEnv(env, "RPC_POOL_ENABLED", false);
 
   const heliusUrl = env.SOLANA_RPC_URL ?? env.RPC_URL ?? "";
 

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -121,6 +121,48 @@ export const simulateCuUsed = new Histogram({
   registers: [registry],
 });
 
+// ── RPC pool metrics (Workstream G) ──────────────────────────────────────
+
+export const rpcRequestTotal = new Counter({
+  name: "keeper_rpc_request_total",
+  help: "Total RPC requests routed by the pool, partitioned by provider, method, and result",
+  labelNames: ["provider", "method", "result"] as const,
+  registers: [registry],
+});
+
+export const rpcLatencyP50 = new Gauge({
+  name: "keeper_rpc_latency_ms",
+  help: "Rolling P50/P99 latency in ms for each RPC provider, updated on every health-check tick",
+  labelNames: ["provider", "percentile"] as const,
+  registers: [registry],
+});
+
+// P99 exported separately for direct set calls — the gauge name uses a label
+// dimension "percentile" shared with rpcLatencyP50. Both resolve to the same
+// registered gauge; callers set the "p50" / "p99" label value.
+export const rpcLatencyP99 = rpcLatencyP50;
+
+export const rpcProviderHealthy = new Gauge({
+  name: "keeper_rpc_provider_healthy",
+  help: "1 if the RPC provider is healthy, 0 if unhealthy",
+  labelNames: ["provider"] as const,
+  registers: [registry],
+});
+
+export const rpcFailoverTotal = new Counter({
+  name: "keeper_rpc_failover_total",
+  help: "Total RPC failover events, partitioned by from-provider, to-provider, and reason",
+  labelNames: ["from", "to", "reason"] as const,
+  registers: [registry],
+});
+
+export const rpcSlotLag = new Gauge({
+  name: "keeper_rpc_slot_lag",
+  help: "Slot lag for each provider vs the other provider (positive = behind, negative = ahead)",
+  labelNames: ["provider"] as const,
+  registers: [registry],
+});
+
 export function registerDefaultMetrics(): void {
   collectDefaultMetrics({ register: registry, prefix: "nodejs_" });
 }

--- a/src/lib/rpc-health.ts
+++ b/src/lib/rpc-health.ts
@@ -146,7 +146,7 @@ export class RpcProviderHealth {
     if (!this._isHealthy) {
       // Check if we meet recovery criteria.
       const recoveryP99Ok = p99 === null || p99 < this.config.recoveryP99Ms;
-      const recoveryLagOk = slotLag === null || Math.abs(slotLag) < this.config.recoverySlotLag;
+      const recoveryLagOk = slotLag !== null && Math.abs(slotLag) < this.config.recoverySlotLag;
       const recoveryFailsOk = this._consecutiveFails === 0;
 
       if (recoveryP99Ok && recoveryLagOk && recoveryFailsOk) {

--- a/src/lib/rpc-health.ts
+++ b/src/lib/rpc-health.ts
@@ -1,0 +1,228 @@
+/**
+ * Per-provider latency tracker for the RPC pool.
+ *
+ * Maintains a rolling 60-second window of (timestamp, latencyMs) samples.
+ * P50/P99 are computed from sorted samples on every tick rather than
+ * maintained incrementally — the window is small (<720 samples at 5s health
+ * checks) so sort cost is negligible vs accuracy guarantees.
+ *
+ * Slot lag is tracked separately: each provider records the last slot it
+ * observed from getSlot(). The lag is the difference between that provider's
+ * last slot and the other provider's last slot (negative = this provider is
+ * ahead). Health threshold uses absolute value.
+ */
+
+import { createLogger } from "@percolatorct/shared";
+
+const logger = createLogger("keeper:rpc-health");
+
+export interface LatencySample {
+  ts: number;
+  latencyMs: number;
+}
+
+export interface HealthSnapshot {
+  p50Ms: number | null;
+  p99Ms: number | null;
+  consecutiveFails: number;
+  lastSeenSlot: number | null;
+  isHealthy: boolean;
+  unhealthyReason?: string;
+}
+
+export interface RpcHealthConfig {
+  /** Rolling window length in ms (default 60_000). */
+  windowMs: number;
+  /** P99 threshold above which provider is unhealthy (default 2000). */
+  unhealthyP99Ms: number;
+  /** Slot lag threshold (absolute value) above which provider is unhealthy (default 50). */
+  unhealthySlotLag: number;
+  /** Consecutive failed health checks before marking unhealthy (default 5). */
+  unhealthyConsecutiveFails: number;
+  /** Recovery window: must have P99 < recoveryP99Ms AND slot lag < recoverySlotLag AND 0 consecutive fails for this duration before marking healthy. */
+  recoveryWindowMs: number;
+  /** P99 threshold for recovery (default 1000ms). */
+  recoveryP99Ms: number;
+  /** Slot lag threshold for recovery (default 10). */
+  recoverySlotLag: number;
+}
+
+const HEALTH_DEFAULTS: RpcHealthConfig = {
+  windowMs: 60_000,
+  unhealthyP99Ms: 2_000,
+  unhealthySlotLag: 50,
+  unhealthyConsecutiveFails: 5,
+  recoveryWindowMs: 60_000,
+  recoveryP99Ms: 1_000,
+  recoverySlotLag: 10,
+};
+
+export class RpcProviderHealth {
+  readonly config: RpcHealthConfig;
+  private readonly _name: string;
+  private readonly _now: () => number;
+
+  private _samples: LatencySample[] = [];
+  private _consecutiveFails = 0;
+  private _lastSeenSlot: number | null = null;
+  private _isHealthy = true;
+  private _unhealthyReason: string | undefined = undefined;
+
+  // Recovery tracking: when did we first enter a clean recovery window?
+  private _recoveryStartMs: number | null = null;
+
+  constructor(name: string, config: Partial<RpcHealthConfig> = {}, now?: () => number) {
+    this._name = name;
+    this.config = { ...HEALTH_DEFAULTS, ...config };
+    this._now = now ?? (() => Date.now());
+  }
+
+  /** Record a successful latency sample. Resets consecutive-fail counter. */
+  recordSuccess(latencyMs: number): void {
+    const ts = this._now();
+    this._samples.push({ ts, latencyMs });
+    this._consecutiveFails = 0;
+    this._pruneWindow(ts);
+  }
+
+  /** Record a failed call. Increments consecutive-fail counter. */
+  recordFailure(): void {
+    this._consecutiveFails++;
+    this._samples = []; // clear latency data — stale samples are misleading on fail streaks
+  }
+
+  /** Record the last slot seen from this provider's getSlot(). */
+  recordSlot(slot: number): void {
+    this._lastSeenSlot = slot;
+  }
+
+  get lastSeenSlot(): number | null {
+    return this._lastSeenSlot;
+  }
+
+  get consecutiveFails(): number {
+    return this._consecutiveFails;
+  }
+
+  get isHealthy(): boolean {
+    return this._isHealthy;
+  }
+
+  /**
+   * Evaluate health given the other provider's last seen slot.
+   * Returns true if the provider transitions from unhealthy→healthy (for logging).
+   */
+  evaluate(otherLastSeenSlot: number | null): boolean {
+    const nowMs = this._now();
+    this._pruneWindow(nowMs);
+
+    const p99 = this._computePercentile(99);
+    const slotLag = this._computeSlotLag(otherLastSeenSlot);
+
+    // Determine the unhealthy reason if any condition is breached.
+    const p99Breach = p99 !== null && p99 > this.config.unhealthyP99Ms;
+    const lagBreach = slotLag !== null && Math.abs(slotLag) > this.config.unhealthySlotLag;
+    const failBreach = this._consecutiveFails >= this.config.unhealthyConsecutiveFails;
+
+    const anyBreach = p99Breach || lagBreach || failBreach;
+
+    if (anyBreach) {
+      const reasons: string[] = [];
+      if (p99Breach) reasons.push(`P99=${p99!.toFixed(0)}ms > ${this.config.unhealthyP99Ms}ms`);
+      if (lagBreach) reasons.push(`slotLag=${slotLag} > ±${this.config.unhealthySlotLag}`);
+      if (failBreach) reasons.push(`consecutiveFails=${this._consecutiveFails} >= ${this.config.unhealthyConsecutiveFails}`);
+      const reason = reasons.join("; ");
+
+      if (this._isHealthy) {
+        logger.warn("RPC provider became unhealthy", { provider: this._name, reason });
+      }
+      this._isHealthy = false;
+      this._unhealthyReason = reason;
+      this._recoveryStartMs = null; // reset recovery clock on any new breach
+      return false;
+    }
+
+    // No breach: check recovery.
+    if (!this._isHealthy) {
+      // Check if we meet recovery criteria.
+      const recoveryP99Ok = p99 === null || p99 < this.config.recoveryP99Ms;
+      const recoveryLagOk = slotLag === null || Math.abs(slotLag) < this.config.recoverySlotLag;
+      const recoveryFailsOk = this._consecutiveFails === 0;
+
+      if (recoveryP99Ok && recoveryLagOk && recoveryFailsOk) {
+        if (this._recoveryStartMs === null) {
+          // Start the recovery clock.
+          this._recoveryStartMs = nowMs;
+        }
+        const elapsed = nowMs - this._recoveryStartMs;
+        if (elapsed >= this.config.recoveryWindowMs) {
+          this._isHealthy = true;
+          this._unhealthyReason = undefined;
+          this._recoveryStartMs = null;
+          logger.warn("RPC provider recovered", { provider: this._name });
+          return true;
+        }
+        // Still in recovery window — stay unhealthy.
+      } else {
+        // Recovery criteria not fully met; reset recovery clock.
+        this._recoveryStartMs = null;
+      }
+      return false;
+    }
+
+    // Was already healthy.
+    return false;
+  }
+
+  snapshot(): HealthSnapshot {
+    return {
+      p50Ms: this._computePercentile(50),
+      p99Ms: this._computePercentile(99),
+      consecutiveFails: this._consecutiveFails,
+      lastSeenSlot: this._lastSeenSlot,
+      isHealthy: this._isHealthy,
+      unhealthyReason: this._unhealthyReason,
+    };
+  }
+
+  computeP50(): number | null {
+    return this._computePercentile(50);
+  }
+
+  computeP99(): number | null {
+    return this._computePercentile(99);
+  }
+
+  computeSlotLag(otherLastSeenSlot: number | null): number | null {
+    return this._computeSlotLag(otherLastSeenSlot);
+  }
+
+  private _pruneWindow(nowMs: number): void {
+    const cutoff = nowMs - this.config.windowMs;
+    // Find first non-expired index without allocating intermediate arrays.
+    let firstValid = 0;
+    while (firstValid < this._samples.length && this._samples[firstValid]!.ts < cutoff) {
+      firstValid++;
+    }
+    if (firstValid > 0) {
+      this._samples = this._samples.slice(firstValid);
+    }
+  }
+
+  private _computePercentile(pct: number): number | null {
+    if (this._samples.length === 0) return null;
+    const sorted = this._samples.map((s) => s.latencyMs).sort((a, b) => a - b);
+    // Nearest-rank method: ceil(pct/100 * n) - 1.
+    const idx = Math.min(
+      Math.ceil((pct / 100) * sorted.length) - 1,
+      sorted.length - 1,
+    );
+    return sorted[idx]!;
+  }
+
+  private _computeSlotLag(otherLastSeenSlot: number | null): number | null {
+    if (this._lastSeenSlot === null || otherLastSeenSlot === null) return null;
+    // Positive = this provider is behind; negative = this provider is ahead.
+    return otherLastSeenSlot - this._lastSeenSlot;
+  }
+}

--- a/src/lib/rpc-pool.ts
+++ b/src/lib/rpc-pool.ts
@@ -1,0 +1,377 @@
+/**
+ * RpcPool — provider redundancy layer for keeper read operations.
+ *
+ * Wraps two @solana/web3.js Connection instances (Helius primary, Alchemy
+ * secondary). Read calls route to Helius while it is healthy; Alchemy only
+ * when Helius is unhealthy. Writes always go to the caller's Helius Connection
+ * (unaffected by this pool — keeperSend is write-path and stays untouched).
+ *
+ * Design choices:
+ * - No racing/fan-out: one provider is chosen per call; the other is idle.
+ * - getProgramAccounts always routes to Alchemy when RPC_FORCE_ALCHEMY_GPA=true
+ *   because it is a heavy method that puts significant load on Helius primary.
+ * - Fail-safe: both providers unhealthy → reads still go to Helius (degraded
+ *   primary beats zero primary).
+ * - start() launches the health-check timer; stop() clears it. This lets tests
+ *   control lifecycle without relying on global timers.
+ */
+
+import { Connection } from "@solana/web3.js";
+import type {
+  PublicKey,
+  AccountInfo,
+  ParsedAccountData,
+  SignatureStatus,
+  BlockhashWithExpiryBlockHeight,
+  GetProgramAccountsFilter,
+} from "@solana/web3.js";
+import { createLogger } from "@percolatorct/shared";
+import { RpcProviderHealth } from "./rpc-health.js";
+import {
+  rpcRequestTotal,
+  rpcLatencyP50,
+  rpcLatencyP99,
+  rpcProviderHealthy,
+  rpcFailoverTotal,
+  rpcSlotLag,
+} from "./metrics.js";
+import type { RpcPoolConfig } from "../config/rpc.js";
+import { parseRpcPoolConfig } from "../config/rpc.js";
+
+const logger = createLogger("keeper:rpc-pool");
+
+export type ProviderName = "helius" | "alchemy";
+
+export interface RpcPoolDeps {
+  config?: RpcPoolConfig;
+  now?: () => number;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Thin read-method interface exposed by the pool. Mirrors the subset of
+ * Connection methods that the keeper uses for reads. Callers cast to this
+ * interface rather than the full Connection type, making the pool's contract
+ * explicit without subclassing Connection.
+ */
+export interface RpcReadInterface {
+  getSlot(commitment?: string): Promise<number>;
+  getAccountInfo(pubkey: PublicKey): Promise<AccountInfo<Buffer> | null>;
+  getMultipleAccountsInfo(pubkeys: PublicKey[]): Promise<Array<AccountInfo<Buffer> | null>>;
+  getSignatureStatuses(
+    signatures: string[],
+  ): Promise<{ value: Array<SignatureStatus | null> }>;
+  getProgramAccounts(
+    programId: PublicKey,
+    filters?: GetProgramAccountsFilter[],
+  ): Promise<Array<{ pubkey: PublicKey; account: AccountInfo<Buffer | ParsedAccountData> }>>;
+  getLatestBlockhash(commitment?: string): Promise<BlockhashWithExpiryBlockHeight>;
+}
+
+export class RpcPool {
+  private readonly _config: RpcPoolConfig;
+  private readonly _helius: Connection;
+  private readonly _alchemy: Connection;
+  private readonly _heliusHealth: RpcProviderHealth;
+  private readonly _alchemyHealth: RpcProviderHealth;
+  private readonly _now: () => number;
+
+  private _timer: ReturnType<typeof setInterval> | null = null;
+  private _failoverCount = 0;
+
+  // Tracks the active provider for reads to detect transitions.
+  private _activeProvider: ProviderName = "helius";
+
+  constructor(
+    helius: Connection,
+    alchemy: Connection,
+    deps: RpcPoolDeps = {},
+  ) {
+    this._helius = helius;
+    this._alchemy = alchemy;
+    this._now = deps.now ?? (() => Date.now());
+
+    const cfg = deps.config ?? parseRpcPoolConfig(deps.env ?? process.env);
+    this._config = cfg;
+
+    const healthCfg = {
+      windowMs: 60_000,
+      unhealthyP99Ms: cfg.unhealthyP99Ms,
+      unhealthySlotLag: cfg.unhealthySlotLag,
+      unhealthyConsecutiveFails: cfg.unhealthyConsecutiveFails,
+      recoveryWindowMs: cfg.recoveryWindowMs,
+      // Recovery thresholds from spec: P99 < 1000ms AND slot lag < 10.
+      recoveryP99Ms: 1_000,
+      recoverySlotLag: 10,
+    };
+
+    this._heliusHealth = new RpcProviderHealth("helius", healthCfg, this._now);
+    this._alchemyHealth = new RpcProviderHealth("alchemy", healthCfg, this._now);
+
+    // Initialise Prometheus gauges to healthy (1).
+    rpcProviderHealthy.set({ provider: "helius" }, 1);
+    rpcProviderHealthy.set({ provider: "alchemy" }, 1);
+  }
+
+  /** Launch background health-check timer. Safe to call multiple times (no-op after first). */
+  start(): void {
+    if (this._timer !== null) return;
+    if (!this._config.enabled) {
+      logger.warn("RPC pool disabled — always routing reads to Helius");
+      return;
+    }
+    this._timer = setInterval(() => {
+      void this._healthTick();
+    }, this._config.healthCheckIntervalMs);
+    // Allow Node.js to exit even if the timer is still running.
+    if (this._timer.unref) this._timer.unref();
+    logger.warn("RPC pool started", {
+      helius: this._config.helius.url.slice(0, 40),
+      alchemy: this._config.alchemy.url.slice(0, 40),
+      healthCheckIntervalMs: this._config.healthCheckIntervalMs,
+    });
+  }
+
+  /** Stop the health-check timer. */
+  stop(): void {
+    if (this._timer !== null) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  /**
+   * Route a read method to the appropriate provider.
+   * Returns the provider name chosen — useful for callers that need to log provenance.
+   */
+  pickProvider(method: string): ProviderName {
+    if (!this._config.enabled) return "helius";
+
+    // getProgramAccounts is heavy; always Alchemy when the override is set.
+    if (method === "getProgramAccounts" && this._config.forceAlchemyGpa) {
+      return "alchemy";
+    }
+
+    const heliusOk = this._heliusHealth.isHealthy;
+    const alchemyOk = this._alchemyHealth.isHealthy;
+
+    if (heliusOk) return "helius";
+    if (alchemyOk) return "alchemy";
+
+    // Fail-safe: both unhealthy → degrade to Helius.
+    return "helius";
+  }
+
+  private _connectionFor(provider: ProviderName): Connection {
+    return provider === "helius" ? this._helius : this._alchemy;
+  }
+
+  /** Execute a read on the routed provider, recording metrics. */
+  private async _read<T>(
+    method: string,
+    fn: (conn: Connection) => Promise<T>,
+  ): Promise<T> {
+    const provider = this.pickProvider(method);
+    const conn = this._connectionFor(provider);
+    const start = this._now();
+
+    try {
+      const result = await fn(conn);
+      const latencyMs = this._now() - start;
+      rpcRequestTotal.inc({ provider, method, result: "ok" });
+
+      // Record latency sample in the health tracker for non-GPA methods
+      // (GPA is always Alchemy — recording its latency to Alchemy's tracker is correct).
+      if (provider === "helius") {
+        this._heliusHealth.recordSuccess(latencyMs);
+      } else {
+        this._alchemyHealth.recordSuccess(latencyMs);
+      }
+
+      return result;
+    } catch (err) {
+      const latencyMs = this._now() - start;
+      const isTimeout = latencyMs > this._config.unhealthyP99Ms;
+      rpcRequestTotal.inc({ provider, method, result: isTimeout ? "timeout" : "fail" });
+
+      if (provider === "helius") {
+        this._heliusHealth.recordFailure();
+      } else {
+        this._alchemyHealth.recordFailure();
+      }
+
+      throw err;
+    }
+  }
+
+  // ── Public read interface ─────────────────────────────────────────────────
+
+  async getSlot(commitment?: string): Promise<number> {
+    return this._read("getSlot", (c) =>
+      commitment ? c.getSlot(commitment as Parameters<Connection["getSlot"]>[0]) : c.getSlot(),
+    );
+  }
+
+  async getAccountInfo(pubkey: PublicKey): Promise<AccountInfo<Buffer> | null> {
+    return this._read("getAccountInfo", (c) => c.getAccountInfo(pubkey));
+  }
+
+  async getMultipleAccountsInfo(
+    pubkeys: PublicKey[],
+  ): Promise<Array<AccountInfo<Buffer> | null>> {
+    return this._read("getMultipleAccountsInfo", (c) => c.getMultipleAccountsInfo(pubkeys));
+  }
+
+  async getSignatureStatuses(
+    signatures: string[],
+  ): Promise<{ value: Array<SignatureStatus | null> }> {
+    return this._read("getSignatureStatuses", (c) => c.getSignatureStatuses(signatures));
+  }
+
+  async getProgramAccounts(
+    programId: PublicKey,
+    filters?: GetProgramAccountsFilter[],
+  ): Promise<Array<{ pubkey: PublicKey; account: AccountInfo<Buffer | ParsedAccountData> }>> {
+    const result = await this._read("getProgramAccounts", (c) =>
+      filters ? c.getProgramAccounts(programId, { filters }) : c.getProgramAccounts(programId),
+    );
+    // The web3.js return type is readonly; callers expect a mutable array, so spread a copy.
+    return [...result];
+  }
+
+  async getLatestBlockhash(
+    commitment?: string,
+  ): Promise<BlockhashWithExpiryBlockHeight> {
+    return this._read("getLatestBlockhash", (c) =>
+      commitment
+        ? c.getLatestBlockhash(commitment as Parameters<Connection["getLatestBlockhash"]>[0])
+        : c.getLatestBlockhash(),
+    );
+  }
+
+  /**
+   * Write passthrough — always Helius Connection, never pooled.
+   * Exposed on the pool object so callers can get the write Connection
+   * without importing a separate module. Writes are unaffected by health state.
+   */
+  get writeConnection(): Connection {
+    return this._helius;
+  }
+
+  /** Expose health snapshots for metrics + tests. */
+  get heliusHealth(): RpcProviderHealth {
+    return this._heliusHealth;
+  }
+
+  get alchemyHealth(): RpcProviderHealth {
+    return this._alchemyHealth;
+  }
+
+  get failoverCount(): number {
+    return this._failoverCount;
+  }
+
+  // ── Health-check tick ─────────────────────────────────────────────────────
+
+  private async _healthTick(): Promise<void> {
+    await Promise.all([
+      this._probeProvider("helius"),
+      this._probeProvider("alchemy"),
+    ]);
+
+    const heliusSlot = this._heliusHealth.lastSeenSlot;
+    const alchemySlot = this._alchemyHealth.lastSeenSlot;
+
+    // Evaluate health (passing the other provider's slot for lag computation).
+    const heliusBecameHealthy = this._heliusHealth.evaluate(alchemySlot);
+    const alchemyBecameHealthy = this._alchemyHealth.evaluate(heliusSlot);
+
+    // Update Prometheus health gauges.
+    rpcProviderHealthy.set({ provider: "helius" }, this._heliusHealth.isHealthy ? 1 : 0);
+    rpcProviderHealthy.set({ provider: "alchemy" }, this._alchemyHealth.isHealthy ? 1 : 0);
+
+    // Update latency gauges.
+    this._updateLatencyGauges("helius", this._heliusHealth);
+    this._updateLatencyGauges("alchemy", this._alchemyHealth);
+
+    // Update slot-lag gauges.
+    const heliusLag = this._heliusHealth.computeSlotLag(alchemySlot);
+    const alchemyLag = this._alchemyHealth.computeSlotLag(heliusSlot);
+    if (heliusLag !== null) rpcSlotLag.set({ provider: "helius" }, heliusLag);
+    if (alchemyLag !== null) rpcSlotLag.set({ provider: "alchemy" }, alchemyLag);
+
+    // Detect failover transitions.
+    const newActive = this.pickProvider("_tick");
+    if (newActive !== this._activeProvider) {
+      const reason = this._heliusHealth.isHealthy ? "helius-recovered" : "helius-unhealthy";
+      rpcFailoverTotal.inc({ from: this._activeProvider, to: newActive, reason });
+      this._failoverCount++;
+      logger.warn("RPC pool failover", {
+        from: this._activeProvider,
+        to: newActive,
+        reason,
+        heliusHealthy: this._heliusHealth.isHealthy,
+        alchemyHealthy: this._alchemyHealth.isHealthy,
+      });
+      this._activeProvider = newActive;
+    }
+
+    // Log recovery events (already logged inside evaluate(), but bump counter).
+    void heliusBecameHealthy;
+    void alchemyBecameHealthy;
+  }
+
+  private async _probeProvider(provider: ProviderName): Promise<void> {
+    const conn = this._connectionFor(provider);
+    const health = provider === "helius" ? this._heliusHealth : this._alchemyHealth;
+    const start = this._now();
+    try {
+      const slot = await conn.getSlot();
+      const latencyMs = this._now() - start;
+      health.recordSuccess(latencyMs);
+      health.recordSlot(slot);
+      rpcRequestTotal.inc({ provider, method: "getSlot", result: "ok" });
+    } catch {
+      rpcRequestTotal.inc({ provider, method: "getSlot", result: "fail" });
+      health.recordFailure();
+    }
+  }
+
+  private _updateLatencyGauges(provider: ProviderName, health: RpcProviderHealth): void {
+    const p50 = health.computeP50();
+    const p99 = health.computeP99();
+    // Both rpcLatencyP50 and rpcLatencyP99 resolve to the same gauge with a "percentile" label.
+    if (p50 !== null) rpcLatencyP50.set({ provider, percentile: "p50" }, p50);
+    if (p99 !== null) rpcLatencyP99.set({ provider, percentile: "p99" }, p99);
+  }
+}
+
+// ── Singleton factory ─────────────────────────────────────────────────────
+
+let _sharedPool: RpcPool | null = null;
+
+/**
+ * Returns the process-wide RpcPool singleton, constructing it on first call.
+ * Pass explicit Connections for test injection; production callers omit both
+ * and let the pool construct from env vars.
+ */
+export function sharedRpcPool(
+  helius?: Connection,
+  alchemy?: Connection,
+  deps?: RpcPoolDeps,
+): RpcPool {
+  if (_sharedPool === null) {
+    const cfg = deps?.config ?? parseRpcPoolConfig(deps?.env ?? process.env);
+    const h = helius ?? new Connection(cfg.helius.url);
+    const a = alchemy ?? new Connection(cfg.alchemy.url || "https://placeholder.invalid");
+    _sharedPool = new RpcPool(h, a, { ...deps, config: cfg });
+  }
+  return _sharedPool;
+}
+
+/**
+ * Reset the singleton — used in tests to avoid cross-test state leakage.
+ */
+export function _resetSharedRpcPool(): void {
+  _sharedPool = null;
+}

--- a/src/lib/rpc-pool.ts
+++ b/src/lib/rpc-pool.ts
@@ -25,7 +25,7 @@ import type {
   BlockhashWithExpiryBlockHeight,
   GetProgramAccountsFilter,
 } from "@solana/web3.js";
-import { createLogger } from "@percolatorct/shared";
+import { createLogger, sendWarningAlert } from "@percolatorct/shared";
 import { RpcProviderHealth } from "./rpc-health.js";
 import {
   rpcRequestTotal,
@@ -126,8 +126,8 @@ export class RpcPool {
     // Allow Node.js to exit even if the timer is still running.
     if (this._timer.unref) this._timer.unref();
     logger.warn("RPC pool started", {
-      helius: this._config.helius.url.slice(0, 40),
-      alchemy: this._config.alchemy.url.slice(0, 40),
+      helius: this._config.helius.url.replace(/\/v2\/.*/i, "/v2/<redacted>"),
+      alchemy: this._config.alchemy.url.replace(/\/v2\/.*/i, "/v2/<redacted>"),
       healthCheckIntervalMs: this._config.healthCheckIntervalMs,
     });
   }
@@ -147,9 +147,15 @@ export class RpcPool {
   pickProvider(method: string): ProviderName {
     if (!this._config.enabled) return "helius";
 
-    // getProgramAccounts is heavy; always Alchemy when the override is set.
+    // getProgramAccounts is heavy; prefer Alchemy when the override is set.
+    // If Alchemy is unhealthy, fall back to Helius (degraded but operational).
     if (method === "getProgramAccounts" && this._config.forceAlchemyGpa) {
-      return "alchemy";
+      if (this._alchemyHealth.isHealthy) {
+        return "alchemy";
+      }
+      // Alchemy unhealthy — bump observable counter and fall through to Helius.
+      rpcFailoverTotal.inc({ from: "alchemy", to: "helius", reason: "gpa_alchemy_unhealthy" });
+      return "helius";
     }
 
     const heliusOk = this._heliusHealth.isHealthy;
@@ -278,47 +284,7 @@ export class RpcPool {
       this._probeProvider("helius"),
       this._probeProvider("alchemy"),
     ]);
-
-    const heliusSlot = this._heliusHealth.lastSeenSlot;
-    const alchemySlot = this._alchemyHealth.lastSeenSlot;
-
-    // Evaluate health (passing the other provider's slot for lag computation).
-    const heliusBecameHealthy = this._heliusHealth.evaluate(alchemySlot);
-    const alchemyBecameHealthy = this._alchemyHealth.evaluate(heliusSlot);
-
-    // Update Prometheus health gauges.
-    rpcProviderHealthy.set({ provider: "helius" }, this._heliusHealth.isHealthy ? 1 : 0);
-    rpcProviderHealthy.set({ provider: "alchemy" }, this._alchemyHealth.isHealthy ? 1 : 0);
-
-    // Update latency gauges.
-    this._updateLatencyGauges("helius", this._heliusHealth);
-    this._updateLatencyGauges("alchemy", this._alchemyHealth);
-
-    // Update slot-lag gauges.
-    const heliusLag = this._heliusHealth.computeSlotLag(alchemySlot);
-    const alchemyLag = this._alchemyHealth.computeSlotLag(heliusSlot);
-    if (heliusLag !== null) rpcSlotLag.set({ provider: "helius" }, heliusLag);
-    if (alchemyLag !== null) rpcSlotLag.set({ provider: "alchemy" }, alchemyLag);
-
-    // Detect failover transitions.
-    const newActive = this.pickProvider("_tick");
-    if (newActive !== this._activeProvider) {
-      const reason = this._heliusHealth.isHealthy ? "helius-recovered" : "helius-unhealthy";
-      rpcFailoverTotal.inc({ from: this._activeProvider, to: newActive, reason });
-      this._failoverCount++;
-      logger.warn("RPC pool failover", {
-        from: this._activeProvider,
-        to: newActive,
-        reason,
-        heliusHealthy: this._heliusHealth.isHealthy,
-        alchemyHealthy: this._alchemyHealth.isHealthy,
-      });
-      this._activeProvider = newActive;
-    }
-
-    // Log recovery events (already logged inside evaluate(), but bump counter).
-    void heliusBecameHealthy;
-    void alchemyBecameHealthy;
+    this._evaluateAndTransition();
   }
 
   private async _probeProvider(provider: ProviderName): Promise<void> {
@@ -334,6 +300,76 @@ export class RpcPool {
     } catch {
       rpcRequestTotal.inc({ provider, method: "getSlot", result: "fail" });
       health.recordFailure();
+    }
+  }
+
+  /**
+   * Exposed for testing: inject scripted probe results and run the evaluate +
+   * transition logic (the part of _healthTick that follows _probeProvider).
+   * Bypasses real network calls so property tests can drive the state machine
+   * directly. Pass null for a provider slot to simulate a probe failure.
+   */
+  tickForTest(
+    heliusSlotResult: number | null,
+    alchemySlotResult: number | null,
+    latencyMs = 100,
+  ): void {
+    for (const [provider, slotResult] of [
+      ["helius", heliusSlotResult],
+      ["alchemy", alchemySlotResult],
+    ] as const) {
+      const health = provider === "helius" ? this._heliusHealth : this._alchemyHealth;
+      if (slotResult === null) {
+        health.recordFailure();
+        rpcRequestTotal.inc({ provider, method: "getSlot", result: "fail" });
+      } else {
+        health.recordSuccess(latencyMs);
+        health.recordSlot(slotResult);
+        rpcRequestTotal.inc({ provider, method: "getSlot", result: "ok" });
+      }
+    }
+    this._evaluateAndTransition();
+  }
+
+  /** Core evaluate + failover-detection logic extracted for both _healthTick and tickForTest. */
+  private _evaluateAndTransition(): void {
+    const heliusSlot = this._heliusHealth.lastSeenSlot;
+    const alchemySlot = this._alchemyHealth.lastSeenSlot;
+
+    this._heliusHealth.evaluate(alchemySlot);
+    this._alchemyHealth.evaluate(heliusSlot);
+
+    rpcProviderHealthy.set({ provider: "helius" }, this._heliusHealth.isHealthy ? 1 : 0);
+    rpcProviderHealthy.set({ provider: "alchemy" }, this._alchemyHealth.isHealthy ? 1 : 0);
+
+    this._updateLatencyGauges("helius", this._heliusHealth);
+    this._updateLatencyGauges("alchemy", this._alchemyHealth);
+
+    const heliusLag = this._heliusHealth.computeSlotLag(alchemySlot);
+    const alchemyLag = this._alchemyHealth.computeSlotLag(heliusSlot);
+    if (heliusLag !== null) rpcSlotLag.set({ provider: "helius" }, heliusLag);
+    if (alchemyLag !== null) rpcSlotLag.set({ provider: "alchemy" }, alchemyLag);
+
+    const newActive = this.pickProvider("_tick");
+    if (newActive !== this._activeProvider) {
+      const from = this._activeProvider;
+      const to = newActive;
+      const reason = this._heliusHealth.isHealthy ? "helius-recovered" : "helius-unhealthy";
+      rpcFailoverTotal.inc({ from, to, reason });
+      this._failoverCount++;
+      logger.warn("RPC pool failover", {
+        from,
+        to,
+        reason,
+        heliusHealthy: this._heliusHealth.isHealthy,
+        alchemyHealthy: this._alchemyHealth.isHealthy,
+      });
+      sendWarningAlert("RPC failover", [
+        { name: "From", value: from, inline: true },
+        { name: "To", value: to, inline: true },
+        { name: "Reason", value: reason, inline: true },
+      ])?.catch(() => {});
+      this._activeProvider = newActive;
     }
   }
 

--- a/tests/lib/rpc-health.test.ts
+++ b/tests/lib/rpc-health.test.ts
@@ -189,18 +189,17 @@ describe("RpcProviderHealth", () => {
       h.evaluate(null);
       expect(h.isHealthy).toBe(false);
 
-      // Start clean recovery window.
+      // Start clean recovery window — but null otherLastSeenSlot means slot lag can't be
+      // verified, so the recovery clock never starts (Fix 2: null slot blocks recovery).
       for (let i = 0; i < 5; i++) h.recordSuccess(500);
-      // First clean evaluate — starts recovery clock.
       h.evaluate(null);
       expect(h.isHealthy).toBe(false);
 
-      // A new failure resets the recovery clock — now we need another full window.
+      // A new failure also blocks recovery via fails criterion. Advance past window — still unhealthy.
       h.recordFailure();
       t += 61_000;
       h.evaluate(null);
-      // Still unhealthy: fail incremented consecutiveFails = 1, so failBreach not triggered
-      // but recoveryFailsOk requires 0 consecutive fails → recovery clock resets.
+      // Still unhealthy: recoveryFailsOk requires 0 consecutive fails AND slot data.
       expect(h.isHealthy).toBe(false);
     });
 
@@ -218,6 +217,38 @@ describe("RpcProviderHealth", () => {
       // Even after advancing time, slot lag still blocks recovery.
       h.evaluate(1100);
       expect(h.isHealthy).toBe(false);
+    });
+
+    it("recovery is BLOCKED while otherLastSeenSlot is null — slot freshness unverifiable", () => {
+      // Fix 2: null otherLastSeenSlot must NOT satisfy the slot-lag recovery criterion.
+      // Even if P99 is good and consecutive fails = 0, recovery cannot proceed without
+      // affirmative slot data from the other provider.
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+
+      // Become unhealthy via consecutive fails.
+      for (let i = 0; i < 5; i++) h.recordFailure();
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(false);
+
+      // Restore P99 and zero fails — but other provider slot is still null.
+      for (let i = 0; i < 20; i++) h.recordSuccess(300);
+      // First evaluate with otherLastSeenSlot = null: slot lag is null → NOT recoverable.
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(false);
+
+      // Advance far past the recovery window — still blocked.
+      t += 120_000;
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(false);
+
+      // Provide affirmative slot data: now recovery clock can start.
+      h.recordSlot(1000);
+      h.evaluate(1005); // slot lag = 5 < recoverySlotLag (10) — clock starts now
+      expect(h.isHealthy).toBe(false); // window not elapsed
+
+      t += 61_000;
+      h.evaluate(1005);
+      expect(h.isHealthy).toBe(true); // recovered only once slot data confirmed
     });
   });
 

--- a/tests/lib/rpc-health.test.ts
+++ b/tests/lib/rpc-health.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { RpcProviderHealth } from "../../src/lib/rpc-health.js";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { vi } from "vitest";
+
+const TIGHT_CONFIG = {
+  windowMs: 60_000,
+  unhealthyP99Ms: 2_000,
+  unhealthySlotLag: 50,
+  unhealthyConsecutiveFails: 5,
+  recoveryWindowMs: 60_000,
+  recoveryP99Ms: 1_000,
+  recoverySlotLag: 10,
+};
+
+describe("RpcProviderHealth", () => {
+  let t = 1_700_000_000_000;
+  const now = () => t;
+
+  beforeEach(() => {
+    t = 1_700_000_000_000;
+  });
+
+  describe("initial state", () => {
+    it("starts healthy", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      expect(h.isHealthy).toBe(true);
+      expect(h.consecutiveFails).toBe(0);
+      expect(h.lastSeenSlot).toBeNull();
+    });
+
+    it("snapshot has null percentiles with no samples", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      const snap = h.snapshot();
+      expect(snap.p50Ms).toBeNull();
+      expect(snap.p99Ms).toBeNull();
+    });
+  });
+
+  describe("P99 threshold", () => {
+    it("marks unhealthy when P99 > 2000ms", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      // Fill with high-latency samples.
+      for (let i = 0; i < 10; i++) {
+        h.recordSuccess(2_500);
+      }
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(false);
+    });
+
+    it("stays healthy when P99 <= 2000ms", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      for (let i = 0; i < 10; i++) {
+        h.recordSuccess(1_000);
+      }
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(true);
+    });
+
+    it("P99 excludes samples outside the rolling window", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      // Old high-latency samples (expired).
+      for (let i = 0; i < 10; i++) {
+        h.recordSuccess(3_000);
+      }
+      // Advance past the window.
+      t += 61_000;
+      // New low-latency samples.
+      for (let i = 0; i < 10; i++) {
+        h.recordSuccess(500);
+        t += 100;
+      }
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(true);
+    });
+  });
+
+  describe("slot-lag threshold", () => {
+    it("marks unhealthy when slot lag > 50", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      h.recordSlot(1000);
+      // Other provider is 51 slots ahead.
+      h.evaluate(1051);
+      expect(h.isHealthy).toBe(false);
+    });
+
+    it("marks unhealthy when this provider is 51 slots ahead (negative lag)", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      h.recordSlot(1100);
+      // Other provider is 51 slots behind.
+      h.evaluate(1049);
+      expect(h.isHealthy).toBe(false);
+    });
+
+    it("stays healthy when slot lag = 50 (boundary, not over)", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      h.recordSlot(1000);
+      h.evaluate(1050);
+      expect(h.isHealthy).toBe(true);
+    });
+
+    it("no lag computed when other slot is null", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      h.recordSlot(1000);
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(true);
+    });
+  });
+
+  describe("consecutive-fail threshold", () => {
+    it("marks unhealthy on 5 consecutive fails", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      for (let i = 0; i < 5; i++) {
+        h.recordFailure();
+      }
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(false);
+    });
+
+    it("stays healthy on 4 consecutive fails", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      for (let i = 0; i < 4; i++) {
+        h.recordFailure();
+      }
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(true);
+    });
+
+    it("success resets the consecutive-fail counter", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      for (let i = 0; i < 4; i++) {
+        h.recordFailure();
+      }
+      h.recordSuccess(100);
+      expect(h.consecutiveFails).toBe(0);
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(true);
+    });
+  });
+
+  describe("recovery", () => {
+    it("does not recover before 60s window elapses", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      // Become unhealthy.
+      for (let i = 0; i < 5; i++) h.recordFailure();
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(false);
+
+      // Add good samples, but only 30s of window.
+      for (let i = 0; i < 10; i++) h.recordSuccess(500);
+      t += 30_000;
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(false);
+    });
+
+    it("recovers after 60s clean window with all 3 criteria met", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      // Become unhealthy.
+      for (let i = 0; i < 5; i++) h.recordFailure();
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(false);
+
+      // Add good samples and record a slot so all criteria are met.
+      for (let i = 0; i < 10; i++) h.recordSuccess(500);
+      h.recordSlot(1000);
+
+      // First clean evaluate — starts the recovery clock at t.
+      h.evaluate(1005); // slot lag = 5 < 10
+      expect(h.isHealthy).toBe(false); // not yet — window hasn't elapsed
+
+      // Advance past the recovery window and evaluate again.
+      t += 61_000;
+      h.evaluate(1005);
+      expect(h.isHealthy).toBe(true);
+    });
+
+    it("recovery resets when any criterion fails during the window", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      for (let i = 0; i < 5; i++) h.recordFailure();
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(false);
+
+      // Start clean recovery window.
+      for (let i = 0; i < 5; i++) h.recordSuccess(500);
+      // First clean evaluate — starts recovery clock.
+      h.evaluate(null);
+      expect(h.isHealthy).toBe(false);
+
+      // A new failure resets the recovery clock — now we need another full window.
+      h.recordFailure();
+      t += 61_000;
+      h.evaluate(null);
+      // Still unhealthy: fail incremented consecutiveFails = 1, so failBreach not triggered
+      // but recoveryFailsOk requires 0 consecutive fails → recovery clock resets.
+      expect(h.isHealthy).toBe(false);
+    });
+
+    it("recovery requires all 3 criteria — P99 alone insufficient", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      for (let i = 0; i < 5; i++) h.recordFailure();
+      h.evaluate(null);
+
+      // Good P99, but slot lag still too high — recovery clock never starts.
+      for (let i = 0; i < 10; i++) h.recordSuccess(500);
+      h.recordSlot(1000);
+      // Slot lag = 100 > 10; recovery criteria not met; clock never starts.
+      h.evaluate(1100);
+      t += 61_000;
+      // Even after advancing time, slot lag still blocks recovery.
+      h.evaluate(1100);
+      expect(h.isHealthy).toBe(false);
+    });
+  });
+
+  describe("computeSlotLag", () => {
+    it("returns null when this provider has no slot yet", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      expect(h.computeSlotLag(1000)).toBeNull();
+    });
+
+    it("returns null when other provider has no slot yet", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      h.recordSlot(1000);
+      expect(h.computeSlotLag(null)).toBeNull();
+    });
+
+    it("positive lag means this provider is behind", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      h.recordSlot(990);
+      expect(h.computeSlotLag(1000)).toBe(10);
+    });
+
+    it("negative lag means this provider is ahead", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      h.recordSlot(1010);
+      expect(h.computeSlotLag(1000)).toBe(-10);
+    });
+  });
+
+  describe("percentile computation", () => {
+    it("P50 and P99 are null with no samples", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      expect(h.computeP50()).toBeNull();
+      expect(h.computeP99()).toBeNull();
+    });
+
+    it("P50 and P99 equal the single sample when only one sample exists", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      h.recordSuccess(800);
+      expect(h.computeP50()).toBe(800);
+      expect(h.computeP99()).toBe(800);
+    });
+
+    it("P50 is median of even sample set", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      [100, 200, 300, 400].forEach((v) => h.recordSuccess(v));
+      // Sorted: [100,200,300,400]; P50 nearest-rank = ceil(0.5*4)-1 = 1 → 200.
+      expect(h.computeP50()).toBe(200);
+    });
+
+    it("failure clears the sample buffer", () => {
+      const h = new RpcProviderHealth("helius", TIGHT_CONFIG, now);
+      for (let i = 0; i < 5; i++) h.recordSuccess(500);
+      h.recordFailure();
+      expect(h.computeP50()).toBeNull();
+      expect(h.computeP99()).toBeNull();
+    });
+  });
+});

--- a/tests/lib/rpc-pool.property.test.ts
+++ b/tests/lib/rpc-pool.property.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fc from "fast-check";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/lib/metrics.js", () => ({
+  rpcRequestTotal: { inc: vi.fn() },
+  rpcLatencyP50: { set: vi.fn() },
+  rpcLatencyP99: { set: vi.fn() },
+  rpcProviderHealthy: { set: vi.fn() },
+  rpcFailoverTotal: { inc: vi.fn() },
+  rpcSlotLag: { set: vi.fn() },
+}));
+
+import { RpcPool, _resetSharedRpcPool } from "../../src/lib/rpc-pool.js";
+import type { RpcPoolConfig } from "../../src/config/rpc.js";
+import { PublicKey } from "@solana/web3.js";
+
+function makeConfig(overrides: Partial<RpcPoolConfig> = {}): RpcPoolConfig {
+  return {
+    enabled: true,
+    helius: { url: "https://helius.example.com", name: "helius" },
+    alchemy: { url: "https://alchemy.example.com", name: "alchemy" },
+    healthCheckIntervalMs: 5_000,
+    unhealthyP99Ms: 2_000,
+    unhealthySlotLag: 50,
+    unhealthyConsecutiveFails: 5,
+    recoveryWindowMs: 60_000,
+    forceAlchemyGpa: false,
+    ...overrides,
+  };
+}
+
+function makeConn(response: unknown = null) {
+  return {
+    getSlot: vi.fn(async () => 1000),
+    getAccountInfo: vi.fn(async () => response),
+    getMultipleAccountsInfo: vi.fn(async () => []),
+    getSignatureStatuses: vi.fn(async () => ({ value: [] })),
+    getProgramAccounts: vi.fn(async () => []),
+    getLatestBlockhash: vi.fn(async () => ({
+      blockhash: "mock-blockhash",
+      lastValidBlockHeight: 9999,
+    })),
+  } as any;
+}
+
+beforeEach(() => {
+  _resetSharedRpcPool();
+  vi.clearAllMocks();
+});
+
+// Arbitraries
+const healthEventArb = fc.oneof(
+  fc.record({
+    kind: fc.constant("success" as const),
+    latencyMs: fc.integer({ min: 1, max: 5_000 }),
+  }),
+  fc.record({ kind: fc.constant("fail" as const) }),
+  fc.record({
+    kind: fc.constant("slot" as const),
+    slot: fc.integer({ min: 1, max: 1_000_000 }),
+  }),
+);
+
+type HealthEvent =
+  | { kind: "success"; latencyMs: number }
+  | { kind: "fail" }
+  | { kind: "slot"; slot: number };
+
+function applyEvents(
+  pool: RpcPool,
+  heliusEvents: HealthEvent[],
+  alchemyEvents: HealthEvent[],
+): void {
+  for (const ev of heliusEvents) {
+    if (ev.kind === "success") pool.heliusHealth.recordSuccess(ev.latencyMs);
+    else if (ev.kind === "fail") pool.heliusHealth.recordFailure();
+    else pool.heliusHealth.recordSlot(ev.slot);
+  }
+  for (const ev of alchemyEvents) {
+    if (ev.kind === "success") pool.alchemyHealth.recordSuccess(ev.latencyMs);
+    else if (ev.kind === "fail") pool.alchemyHealth.recordFailure();
+    else pool.alchemyHealth.recordSlot(ev.slot);
+  }
+  pool.heliusHealth.evaluate(pool.alchemyHealth.lastSeenSlot);
+  pool.alchemyHealth.evaluate(pool.heliusHealth.lastSeenSlot);
+}
+
+describe("RpcPool — property tests", () => {
+  it(
+    "invariant: exactly one provider always selected for reads (never zero, never both)",
+    () => {
+      fc.assert(
+        fc.property(
+          fc.array(healthEventArb, { minLength: 0, maxLength: 50 }),
+          fc.array(healthEventArb, { minLength: 0, maxLength: 50 }),
+          fc.constantFrom<string>(
+            "getAccountInfo",
+            "getMultipleAccountsInfo",
+            "getSignatureStatuses",
+            "getLatestBlockhash",
+            "getSlot",
+          ),
+          (heliusEvents, alchemyEvents, method) => {
+            const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+              config: makeConfig(),
+            });
+            applyEvents(pool, heliusEvents, alchemyEvents);
+
+            const chosen = pool.pickProvider(method);
+            // Must be exactly one of the two providers.
+            expect(chosen === "helius" || chosen === "alchemy").toBe(true);
+          },
+        ),
+        { numRuns: 500 },
+      );
+    },
+    30_000,
+  );
+
+  it(
+    "invariant: failover counter monotonically increases (never decreases)",
+    () => {
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.record({
+              helius: fc.array(healthEventArb, { minLength: 0, maxLength: 10 }),
+              alchemy: fc.array(healthEventArb, { minLength: 0, maxLength: 10 }),
+            }),
+            { minLength: 1, maxLength: 20 },
+          ),
+          (rounds) => {
+            const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+              config: makeConfig(),
+            });
+            let lastCount = pool.failoverCount;
+            for (const { helius, alchemy } of rounds) {
+              applyEvents(pool, helius, alchemy);
+              const prevProvider = pool.pickProvider("getAccountInfo");
+              void prevProvider;
+              const current = pool.failoverCount;
+              expect(current).toBeGreaterThanOrEqual(lastCount);
+              lastCount = current;
+            }
+          },
+        ),
+        { numRuns: 500 },
+      );
+    },
+    30_000,
+  );
+
+  it(
+    "invariant: recovery requires all 3 conditions — any one missing keeps provider unhealthy",
+    () => {
+      // A provider that became unhealthy via consecutive fails should only
+      // recover if: P99 < 1000ms AND slot lag < 10 AND 0 consecutive fails
+      // for the full recovery window. If slot lag is high, it stays unhealthy.
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 51, max: 500 }),   // slot lag > 10 (recovery criterion fails)
+          (slotLag) => {
+            let t = 1_700_000_000_000;
+            const now = () => t;
+
+            const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+              config: makeConfig(),
+              now,
+            });
+
+            // Become unhealthy via consecutive fails.
+            for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+            pool.heliusHealth.evaluate(null);
+            expect(pool.heliusHealth.isHealthy).toBe(false);
+
+            // Good P99 and zero fails — but slot lag is too high.
+            for (let i = 0; i < 10; i++) pool.heliusHealth.recordSuccess(500);
+            pool.heliusHealth.recordSlot(1000);
+            // Slot lag > 10: recovery criteria not met; clock never starts.
+            pool.heliusHealth.evaluate(1000 + slotLag);
+            // Advance well past recovery window — but since clock never started, still unhealthy.
+            t += 120_000;
+            pool.heliusHealth.evaluate(1000 + slotLag);
+
+            // Must still be unhealthy because slot lag criterion is not met.
+            expect(pool.heliusHealth.isHealthy).toBe(false);
+          },
+        ),
+        { numRuns: 500 },
+      );
+    },
+    30_000,
+  );
+
+  it(
+    "invariant: write always returns Helius connection regardless of pool state",
+    () => {
+      fc.assert(
+        fc.property(
+          fc.array(healthEventArb, { minLength: 0, maxLength: 30 }),
+          fc.array(healthEventArb, { minLength: 0, maxLength: 30 }),
+          (heliusEvents, alchemyEvents) => {
+            const helius = makeConn() as any;
+            const alchemy = makeConn() as any;
+            const pool = new RpcPool(helius, alchemy, { config: makeConfig() });
+            applyEvents(pool, heliusEvents, alchemyEvents);
+            expect(pool.writeConnection).toBe(helius);
+          },
+        ),
+        { numRuns: 500 },
+      );
+    },
+    30_000,
+  );
+
+  it(
+    "invariant: disabled pool always picks helius regardless of health state",
+    () => {
+      fc.assert(
+        fc.property(
+          fc.array(healthEventArb, { minLength: 0, maxLength: 30 }),
+          fc.array(healthEventArb, { minLength: 0, maxLength: 30 }),
+          fc.constantFrom<string>(
+            "getAccountInfo",
+            "getProgramAccounts",
+            "getSlot",
+          ),
+          (heliusEvents, alchemyEvents, method) => {
+            const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+              config: makeConfig({ enabled: false }),
+            });
+            applyEvents(pool, heliusEvents, alchemyEvents);
+            expect(pool.pickProvider(method)).toBe("helius");
+          },
+        ),
+        { numRuns: 500 },
+      );
+    },
+    30_000,
+  );
+});

--- a/tests/lib/rpc-pool.property.test.ts
+++ b/tests/lib/rpc-pool.property.test.ts
@@ -8,6 +8,7 @@ vi.mock("@percolatorct/shared", () => ({
     error: vi.fn(),
     debug: vi.fn(),
   })),
+  sendWarningAlert: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("../../src/lib/metrics.js", () => ({
@@ -127,26 +128,27 @@ describe("RpcPool — property tests", () => {
   );
 
   it(
-    "invariant: failover counter monotonically increases (never decreases)",
+    "invariant: failover counter monotonically increases (never decreases) — driven via tickForTest",
     () => {
+      // Use tickForTest (which drives the real _evaluateAndTransition state machine)
+      // rather than applyEvents so _failoverCount is actually exercised.
       fc.assert(
         fc.property(
           fc.array(
             fc.record({
-              helius: fc.array(healthEventArb, { minLength: 0, maxLength: 10 }),
-              alchemy: fc.array(healthEventArb, { minLength: 0, maxLength: 10 }),
+              heliusSlot: fc.option(fc.integer({ min: 1, max: 1_000_000 }), { nil: null }),
+              alchemySlot: fc.option(fc.integer({ min: 1, max: 1_000_000 }), { nil: null }),
+              latencyMs: fc.integer({ min: 1, max: 5_000 }),
             }),
-            { minLength: 1, maxLength: 20 },
+            { minLength: 1, maxLength: 30 },
           ),
           (rounds) => {
             const pool = new RpcPool(makeConn() as any, makeConn() as any, {
               config: makeConfig(),
             });
             let lastCount = pool.failoverCount;
-            for (const { helius, alchemy } of rounds) {
-              applyEvents(pool, helius, alchemy);
-              const prevProvider = pool.pickProvider("getAccountInfo");
-              void prevProvider;
+            for (const { heliusSlot, alchemySlot, latencyMs } of rounds) {
+              pool.tickForTest(heliusSlot, alchemySlot, latencyMs);
               const current = pool.failoverCount;
               expect(current).toBeGreaterThanOrEqual(lastCount);
               lastCount = current;

--- a/tests/lib/rpc-pool.stress.test.ts
+++ b/tests/lib/rpc-pool.stress.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/lib/metrics.js", () => ({
+  rpcRequestTotal: { inc: vi.fn() },
+  rpcLatencyP50: { set: vi.fn() },
+  rpcLatencyP99: { set: vi.fn() },
+  rpcProviderHealthy: { set: vi.fn() },
+  rpcFailoverTotal: { inc: vi.fn() },
+  rpcSlotLag: { set: vi.fn() },
+}));
+
+import { RpcPool, _resetSharedRpcPool } from "../../src/lib/rpc-pool.js";
+import type { RpcPoolConfig } from "../../src/config/rpc.js";
+import { PublicKey } from "@solana/web3.js";
+
+const STRESS = process.env.STRESS === "true";
+
+function makeConfig(overrides: Partial<RpcPoolConfig> = {}): RpcPoolConfig {
+  return {
+    enabled: true,
+    helius: { url: "https://helius.example.com", name: "helius" },
+    alchemy: { url: "https://alchemy.example.com", name: "alchemy" },
+    healthCheckIntervalMs: 5_000,
+    unhealthyP99Ms: 2_000,
+    unhealthySlotLag: 50,
+    unhealthyConsecutiveFails: 5,
+    recoveryWindowMs: 60_000,
+    forceAlchemyGpa: true,
+    ...overrides,
+  };
+}
+
+let _heliusUp = true;
+
+function makeHeliusConn() {
+  return {
+    getSlot: vi.fn(async () => {
+      if (!_heliusUp) throw new Error("Helius 500");
+      return 1000;
+    }),
+    getAccountInfo: vi.fn(async () => {
+      if (!_heliusUp) throw new Error("Helius 500");
+      return { owner: "helius" } as any;
+    }),
+    getMultipleAccountsInfo: vi.fn(async () => []),
+    getSignatureStatuses: vi.fn(async () => ({ value: [] })),
+    getProgramAccounts: vi.fn(async () => []),
+    getLatestBlockhash: vi.fn(async () => ({
+      blockhash: "helius-blockhash",
+      lastValidBlockHeight: 9999,
+    })),
+  } as any;
+}
+
+function makeAlchemyConn() {
+  return {
+    getSlot: vi.fn(async () => 1001),
+    getAccountInfo: vi.fn(async () => ({ owner: "alchemy" } as any)),
+    getMultipleAccountsInfo: vi.fn(async () => []),
+    getSignatureStatuses: vi.fn(async () => ({ value: [] })),
+    getProgramAccounts: vi.fn(async () => []),
+    getLatestBlockhash: vi.fn(async () => ({
+      blockhash: "alchemy-blockhash",
+      lastValidBlockHeight: 9999,
+    })),
+  } as any;
+}
+
+beforeEach(() => {
+  _heliusUp = true;
+  _resetSharedRpcPool();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  _heliusUp = true;
+  _resetSharedRpcPool();
+});
+
+describe.skipIf(!STRESS)("RpcPool — stress / chaos (STRESS=true)", () => {
+  it(
+    "1000 concurrent read() during simulated provider failure — all complete, no drops",
+    async () => {
+      const helius = makeHeliusConn();
+      const alchemy = makeAlchemyConn();
+      const pool = new RpcPool(helius, alchemy, { config: makeConfig() });
+
+      // Force Helius unhealthy from the start.
+      for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+      pool.heliusHealth.evaluate(null);
+      expect(pool.heliusHealth.isHealthy).toBe(false);
+
+      const N = 1_000;
+      const results = await Promise.allSettled(
+        Array.from({ length: N }, () => pool.getAccountInfo(PublicKey.default)),
+      );
+
+      const fulfilled = results.filter((r) => r.status === "fulfilled");
+      const rejected = results.filter((r) => r.status === "rejected");
+
+      // All should complete — Alchemy is healthy so no drops.
+      expect(fulfilled.length).toBe(N);
+      expect(rejected.length).toBe(0);
+    },
+    60_000,
+  );
+
+  it(
+    "chaos: Helius 500s — all reads route to Alchemy within one health-check cycle",
+    async () => {
+      const helius = makeHeliusConn();
+      const alchemy = makeAlchemyConn();
+      const pool = new RpcPool(helius, alchemy, {
+        config: makeConfig({ unhealthyConsecutiveFails: 5 }),
+      });
+
+      // Simulate Helius returning 500s.
+      _heliusUp = false;
+
+      // After 5 failures Helius should be unhealthy.
+      for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+      pool.heliusHealth.evaluate(null);
+      expect(pool.heliusHealth.isHealthy).toBe(false);
+
+      // Now all reads should route to Alchemy.
+      const N = 100;
+      const results = await Promise.all(
+        Array.from({ length: N }, () => pool.getAccountInfo(PublicKey.default)),
+      );
+
+      // Every call returned (even if alchemy returns null-ish).
+      expect(results).toHaveLength(N);
+      expect(alchemy.getAccountInfo).toHaveBeenCalledTimes(N);
+      expect(helius.getAccountInfo).not.toHaveBeenCalled();
+    },
+    60_000,
+  );
+
+  it(
+    "chaos: both providers unhealthy simultaneously — fail-safe routes to Helius, no exception thrown",
+    async () => {
+      // Override Helius to return a value even in degraded mode for this test.
+      _heliusUp = true;
+      const helius = makeHeliusConn();
+      const alchemy = makeAlchemyConn();
+      const pool = new RpcPool(helius, alchemy, { config: makeConfig() });
+
+      // Mark both unhealthy.
+      for (let i = 0; i < 5; i++) {
+        pool.heliusHealth.recordFailure();
+        pool.alchemyHealth.recordFailure();
+      }
+      pool.heliusHealth.evaluate(null);
+      pool.alchemyHealth.evaluate(null);
+      expect(pool.heliusHealth.isHealthy).toBe(false);
+      expect(pool.alchemyHealth.isHealthy).toBe(false);
+
+      // Verify fail-safe: no exception thrown, reads go to Helius.
+      const N = 50;
+      // Helius is actually up — just marked unhealthy by the tracker.
+      const results = await Promise.allSettled(
+        Array.from({ length: N }, () => pool.getAccountInfo(PublicKey.default)),
+      );
+
+      expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+      // All went to Helius (fail-safe).
+      expect(helius.getAccountInfo).toHaveBeenCalledTimes(N);
+      expect(alchemy.getAccountInfo).not.toHaveBeenCalled();
+    },
+    60_000,
+  );
+
+  it(
+    "chaos: Helius recovers after 30s of 500s — reads return to Helius",
+    async () => {
+      let now = 1_700_000_000_000;
+      const mockNow = () => now;
+
+      const helius = makeHeliusConn();
+      const alchemy = makeAlchemyConn();
+      const pool = new RpcPool(helius, alchemy, {
+        config: makeConfig({ recoveryWindowMs: 60_000 }),
+        now: mockNow,
+      });
+
+      // Phase 1: Helius fails.
+      for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+      pool.heliusHealth.evaluate(null);
+      expect(pool.heliusHealth.isHealthy).toBe(false);
+
+      // Phase 2: Helius recovers — good samples then first clean evaluate starts clock.
+      for (let i = 0; i < 20; i++) pool.heliusHealth.recordSuccess(300);
+      pool.heliusHealth.recordSlot(2000);
+      // First clean evaluate: starts recovery clock at `now`.
+      pool.heliusHealth.evaluate(2005); // lag = 5 < 10
+      expect(pool.heliusHealth.isHealthy).toBe(false); // window not elapsed yet
+
+      // Advance past the recovery window; evaluate again.
+      now += 61_000;
+      pool.heliusHealth.evaluate(2005);
+      expect(pool.heliusHealth.isHealthy).toBe(true);
+
+      // Phase 3: reads go back to Helius.
+      const result = await pool.getAccountInfo(PublicKey.default);
+      void result;
+      expect(helius.getAccountInfo).toHaveBeenCalled();
+    },
+    60_000,
+  );
+});
+
+// Always-on lightweight version: avoids needing STRESS=true in CI.
+describe("RpcPool — lightweight concurrency smoke (always on)", () => {
+  it("100 concurrent reads all complete without exception", async () => {
+    const helius = makeHeliusConn();
+    const alchemy = makeAlchemyConn();
+    const pool = new RpcPool(helius, alchemy, { config: makeConfig() });
+
+    const N = 100;
+    const results = await Promise.allSettled(
+      Array.from({ length: N }, () => pool.getAccountInfo(PublicKey.default)),
+    );
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    expect(fulfilled.length).toBe(N);
+  });
+
+  it("failover smoke: unhealthy Helius routes to Alchemy", async () => {
+    const helius = makeHeliusConn();
+    const alchemy = makeAlchemyConn();
+    const pool = new RpcPool(helius, alchemy, { config: makeConfig() });
+
+    for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+    pool.heliusHealth.evaluate(null);
+
+    const N = 20;
+    await Promise.all(Array.from({ length: N }, () => pool.getAccountInfo(PublicKey.default)));
+    expect(alchemy.getAccountInfo).toHaveBeenCalledTimes(N);
+  });
+});

--- a/tests/lib/rpc-pool.stress.test.ts
+++ b/tests/lib/rpc-pool.stress.test.ts
@@ -7,6 +7,7 @@ vi.mock("@percolatorct/shared", () => ({
     error: vi.fn(),
     debug: vi.fn(),
   })),
+  sendWarningAlert: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("../../src/lib/metrics.js", () => ({

--- a/tests/lib/rpc-pool.test.ts
+++ b/tests/lib/rpc-pool.test.ts
@@ -7,6 +7,7 @@ vi.mock("@percolatorct/shared", () => ({
     error: vi.fn(),
     debug: vi.fn(),
   })),
+  sendWarningAlert: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("../../src/lib/metrics.js", () => ({
@@ -346,6 +347,93 @@ describe("RpcPool — lifecycle", () => {
     });
     pool.start(); // should not throw or spin up a timer
     pool.stop();
+  });
+});
+
+// ── GPA fallback on Alchemy unhealthy (Fix 3) ────────────────────────────────
+
+describe("RpcPool — GPA fallback when Alchemy unhealthy", () => {
+  it("getProgramAccounts falls back to Helius when forceAlchemyGpa=true but Alchemy is unhealthy", async () => {
+    const helius = makeConn();
+    const alchemy = makeConn();
+    const pool = new RpcPool(helius as any, alchemy as any, {
+      config: makeConfig({ forceAlchemyGpa: true }),
+      now: mockNow,
+    });
+
+    // Mark Alchemy unhealthy via consecutive fails.
+    for (let i = 0; i < 5; i++) pool.alchemyHealth.recordFailure();
+    pool.alchemyHealth.evaluate(null);
+    expect(pool.alchemyHealth.isHealthy).toBe(false);
+
+    await pool.getProgramAccounts(PublicKey.default);
+
+    // Must route to Helius — keeper can still operate, degraded.
+    expect(helius.getProgramAccounts).toHaveBeenCalledOnce();
+    expect(alchemy.getProgramAccounts).not.toHaveBeenCalled();
+  });
+
+  it("getProgramAccounts routes to Alchemy when forceAlchemyGpa=true and Alchemy is healthy", async () => {
+    const helius = makeConn();
+    const alchemy = makeConn();
+    const pool = new RpcPool(helius as any, alchemy as any, {
+      config: makeConfig({ forceAlchemyGpa: true }),
+      now: mockNow,
+    });
+
+    // Alchemy is healthy (default state).
+    expect(pool.alchemyHealth.isHealthy).toBe(true);
+
+    await pool.getProgramAccounts(PublicKey.default);
+
+    expect(alchemy.getProgramAccounts).toHaveBeenCalledOnce();
+    expect(helius.getProgramAccounts).not.toHaveBeenCalled();
+  });
+
+  it("gpa_alchemy_unhealthy failover counter is bumped when Alchemy unhealthy during GPA", async () => {
+    const metrics = await import("../../src/lib/metrics.js");
+    const helius = makeConn();
+    const alchemy = makeConn();
+    const pool = new RpcPool(helius as any, alchemy as any, {
+      config: makeConfig({ forceAlchemyGpa: true }),
+      now: mockNow,
+    });
+
+    for (let i = 0; i < 5; i++) pool.alchemyHealth.recordFailure();
+    pool.alchemyHealth.evaluate(null);
+    vi.clearAllMocks();
+
+    await pool.getProgramAccounts(PublicKey.default);
+
+    expect(metrics.rpcFailoverTotal.inc).toHaveBeenCalledWith({
+      from: "alchemy",
+      to: "helius",
+      reason: "gpa_alchemy_unhealthy",
+    });
+  });
+});
+
+// ── URL redaction (Fix 6) ─────────────────────────────────────────────────────
+
+describe("RpcPool — URL redaction in start() log", () => {
+  it("standard Alchemy URL shape: key after /v2/ is fully redacted", () => {
+    const standardUrl = "https://solana-mainnet.g.alchemy.com/v2/abcdef1234567890abcdef1234567890";
+    const redacted = standardUrl.replace(/\/v2\/.*/i, "/v2/<redacted>");
+    expect(redacted).toBe("https://solana-mainnet.g.alchemy.com/v2/<redacted>");
+    expect(redacted).not.toContain("abcdef");
+  });
+
+  it("short custom Alchemy URL shape: key after /v2/ is fully redacted regardless of base length", () => {
+    const shortUrl = "https://my.alchemy.com/v2/SECRETKEY123";
+    const redacted = shortUrl.replace(/\/v2\/.*/i, "/v2/<redacted>");
+    expect(redacted).toBe("https://my.alchemy.com/v2/<redacted>");
+    expect(redacted).not.toContain("SECRETKEY123");
+  });
+
+  it("URL without /v2/ path is returned unchanged (no key to strip)", () => {
+    const noV2Url = "https://helius.xyz/mainnet-key-here";
+    const redacted = noV2Url.replace(/\/v2\/.*/i, "/v2/<redacted>");
+    expect(redacted).toBe(noV2Url); // no /v2/ segment — nothing to strip
   });
 });
 

--- a/tests/lib/rpc-pool.test.ts
+++ b/tests/lib/rpc-pool.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/lib/metrics.js", () => ({
+  rpcRequestTotal: { inc: vi.fn() },
+  rpcLatencyP50: { set: vi.fn() },
+  rpcLatencyP99: { set: vi.fn() },
+  rpcProviderHealthy: { set: vi.fn() },
+  rpcFailoverTotal: { inc: vi.fn() },
+  rpcSlotLag: { set: vi.fn() },
+}));
+
+import { RpcPool, _resetSharedRpcPool } from "../../src/lib/rpc-pool.js";
+import type { RpcPoolConfig } from "../../src/config/rpc.js";
+import { PublicKey } from "@solana/web3.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeConfig(overrides: Partial<RpcPoolConfig> = {}): RpcPoolConfig {
+  return {
+    enabled: true,
+    helius: { url: "https://helius.example.com", name: "helius" },
+    alchemy: { url: "https://alchemy.example.com", name: "alchemy" },
+    healthCheckIntervalMs: 5_000,
+    unhealthyP99Ms: 2_000,
+    unhealthySlotLag: 50,
+    unhealthyConsecutiveFails: 5,
+    recoveryWindowMs: 60_000,
+    forceAlchemyGpa: true,
+    ...overrides,
+  };
+}
+
+function makeConn(overrides: Partial<{
+  getSlot: () => Promise<number>;
+  getAccountInfo: () => Promise<null>;
+  getMultipleAccountsInfo: () => Promise<null[]>;
+  getSignatureStatuses: () => Promise<{ value: null[] }>;
+  getProgramAccounts: () => Promise<never[]>;
+  getLatestBlockhash: () => Promise<{ blockhash: string; lastValidBlockHeight: number }>;
+}> = {}) {
+  return {
+    getSlot: vi.fn(async () => 1000),
+    getAccountInfo: vi.fn(async () => null),
+    getMultipleAccountsInfo: vi.fn(async () => []),
+    getSignatureStatuses: vi.fn(async () => ({ value: [] })),
+    getProgramAccounts: vi.fn(async () => []),
+    getLatestBlockhash: vi.fn(async () => ({
+      blockhash: "mock-blockhash",
+      lastValidBlockHeight: 9999,
+    })),
+    ...overrides,
+  } as any;
+}
+
+let t = 1_700_000_000_000;
+const mockNow = () => t;
+
+beforeEach(() => {
+  t = 1_700_000_000_000;
+  _resetSharedRpcPool();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  _resetSharedRpcPool();
+});
+
+// ── Routing tests ─────────────────────────────────────────────────────────────
+
+describe("RpcPool — routing", () => {
+  it("read returns Helius response when Helius healthy", async () => {
+    const helius = makeConn({ getAccountInfo: vi.fn(async () => ({ data: "helius" } as any)) });
+    const alchemy = makeConn({ getAccountInfo: vi.fn(async () => ({ data: "alchemy" } as any)) });
+    const pool = new RpcPool(helius as any, alchemy as any, { config: makeConfig(), now: mockNow });
+
+    await pool.getAccountInfo(PublicKey.default);
+
+    expect(helius.getAccountInfo).toHaveBeenCalledOnce();
+    expect(alchemy.getAccountInfo).not.toHaveBeenCalled();
+  });
+
+  it("read returns Alchemy response when Helius unhealthy", async () => {
+    const helius = makeConn({ getAccountInfo: vi.fn(async () => ({ data: "helius" } as any)) });
+    const alchemy = makeConn({ getAccountInfo: vi.fn(async () => ({ data: "alchemy" } as any)) });
+    const pool = new RpcPool(helius as any, alchemy as any, { config: makeConfig(), now: mockNow });
+
+    // Force Helius unhealthy via consecutive fails.
+    for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+    pool.heliusHealth.evaluate(null);
+
+    await pool.getAccountInfo(PublicKey.default);
+
+    expect(alchemy.getAccountInfo).toHaveBeenCalledOnce();
+    expect(helius.getAccountInfo).not.toHaveBeenCalled();
+  });
+
+  it("getProgramAccounts always routes to Alchemy when RPC_FORCE_ALCHEMY_GPA=true", async () => {
+    const helius = makeConn();
+    const alchemy = makeConn();
+    const pool = new RpcPool(helius as any, alchemy as any, {
+      config: makeConfig({ forceAlchemyGpa: true }),
+      now: mockNow,
+    });
+
+    await pool.getProgramAccounts(PublicKey.default);
+
+    expect(alchemy.getProgramAccounts).toHaveBeenCalledOnce();
+    expect(helius.getProgramAccounts).not.toHaveBeenCalled();
+  });
+
+  it("getProgramAccounts routes to Helius when forceAlchemyGpa=false and Helius healthy", async () => {
+    const helius = makeConn();
+    const alchemy = makeConn();
+    const pool = new RpcPool(helius as any, alchemy as any, {
+      config: makeConfig({ forceAlchemyGpa: false }),
+      now: mockNow,
+    });
+
+    await pool.getProgramAccounts(PublicKey.default);
+
+    expect(helius.getProgramAccounts).toHaveBeenCalledOnce();
+    expect(alchemy.getProgramAccounts).not.toHaveBeenCalled();
+  });
+
+  it("disabled mode (RPC_POOL_ENABLED=false) always routes to Helius", async () => {
+    const helius = makeConn();
+    const alchemy = makeConn();
+    const pool = new RpcPool(helius as any, alchemy as any, {
+      config: makeConfig({ enabled: false }),
+      now: mockNow,
+    });
+
+    // Force Helius unhealthy — should still route to Helius in disabled mode.
+    for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+    pool.heliusHealth.evaluate(null);
+
+    await pool.getAccountInfo(PublicKey.default);
+
+    expect(helius.getAccountInfo).toHaveBeenCalledOnce();
+    expect(alchemy.getAccountInfo).not.toHaveBeenCalled();
+  });
+
+  it("fail-safe: both unhealthy → reads still go to Helius", async () => {
+    const helius = makeConn();
+    const alchemy = makeConn();
+    const pool = new RpcPool(helius as any, alchemy as any, { config: makeConfig(), now: mockNow });
+
+    for (let i = 0; i < 5; i++) {
+      pool.heliusHealth.recordFailure();
+      pool.alchemyHealth.recordFailure();
+    }
+    pool.heliusHealth.evaluate(null);
+    pool.alchemyHealth.evaluate(null);
+
+    await pool.getAccountInfo(PublicKey.default);
+
+    expect(helius.getAccountInfo).toHaveBeenCalledOnce();
+    expect(alchemy.getAccountInfo).not.toHaveBeenCalled();
+  });
+});
+
+// ── Health transition tests ───────────────────────────────────────────────────
+
+describe("RpcPool — health transitions", () => {
+  it("marks Helius unhealthy when P99 > 2000ms", () => {
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig(),
+      now: mockNow,
+    });
+    for (let i = 0; i < 10; i++) pool.heliusHealth.recordSuccess(2_500);
+    pool.heliusHealth.evaluate(null);
+    expect(pool.heliusHealth.isHealthy).toBe(false);
+  });
+
+  it("marks Helius unhealthy when slot lag > 50", () => {
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig(),
+      now: mockNow,
+    });
+    pool.heliusHealth.recordSlot(1000);
+    pool.heliusHealth.evaluate(1060); // lag = 60
+    expect(pool.heliusHealth.isHealthy).toBe(false);
+  });
+
+  it("marks Helius unhealthy on 5 consecutive fails", () => {
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig(),
+      now: mockNow,
+    });
+    for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+    pool.heliusHealth.evaluate(null);
+    expect(pool.heliusHealth.isHealthy).toBe(false);
+  });
+
+  it("failover triggers when Helius transitions healthy→unhealthy", async () => {
+    const helius = makeConn();
+    const alchemy = makeConn();
+    const pool = new RpcPool(helius as any, alchemy as any, { config: makeConfig(), now: mockNow });
+
+    // Initially Helius is used.
+    expect(pool.pickProvider("getAccountInfo")).toBe("helius");
+
+    // Trigger unhealthy.
+    for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+    pool.heliusHealth.evaluate(null);
+
+    expect(pool.pickProvider("getAccountInfo")).toBe("alchemy");
+  });
+
+  it("recovery requires full 60s window meeting all 3 criteria", () => {
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig(),
+      now: mockNow,
+    });
+
+    // Become unhealthy.
+    for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+    pool.heliusHealth.evaluate(null);
+    expect(pool.heliusHealth.isHealthy).toBe(false);
+
+    // Add good samples + slot, then first clean evaluate starts recovery clock.
+    for (let i = 0; i < 10; i++) pool.heliusHealth.recordSuccess(400);
+    pool.heliusHealth.recordSlot(1000);
+    pool.heliusHealth.evaluate(1005); // lag = 5 < 10; clock starts
+    expect(pool.heliusHealth.isHealthy).toBe(false); // window not elapsed yet
+
+    // Advance past the recovery window.
+    t += 61_000;
+    pool.heliusHealth.evaluate(1005);
+    expect(pool.heliusHealth.isHealthy).toBe(true);
+  });
+});
+
+// ── Write path tests ──────────────────────────────────────────────────────────
+
+describe("RpcPool — write path", () => {
+  it("writeConnection always returns the Helius connection regardless of health", () => {
+    const helius = makeConn() as any;
+    const alchemy = makeConn() as any;
+    const pool = new RpcPool(helius, alchemy, { config: makeConfig(), now: mockNow });
+
+    // Helius unhealthy.
+    for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+    pool.heliusHealth.evaluate(null);
+
+    expect(pool.writeConnection).toBe(helius);
+  });
+
+  it("writeConnection is independent of pool state — always Helius", () => {
+    const helius = makeConn() as any;
+    const alchemy = makeConn() as any;
+    const pool = new RpcPool(helius, alchemy, { config: makeConfig(), now: mockNow });
+
+    // Both unhealthy.
+    for (let i = 0; i < 5; i++) {
+      pool.heliusHealth.recordFailure();
+      pool.alchemyHealth.recordFailure();
+    }
+    pool.heliusHealth.evaluate(null);
+    pool.alchemyHealth.evaluate(null);
+
+    expect(pool.writeConnection).toBe(helius);
+  });
+});
+
+// ── pickProvider exhaustive cases ──────────────────────────────────────────────
+
+describe("RpcPool — pickProvider", () => {
+  it("returns helius when pool disabled regardless of health state", () => {
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig({ enabled: false }),
+      now: mockNow,
+    });
+    for (let i = 0; i < 5; i++) pool.heliusHealth.recordFailure();
+    pool.heliusHealth.evaluate(null);
+    expect(pool.pickProvider("getSlot")).toBe("helius");
+  });
+
+  it("returns alchemy for getProgramAccounts when forceAlchemyGpa=true", () => {
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig({ forceAlchemyGpa: true }),
+      now: mockNow,
+    });
+    expect(pool.pickProvider("getProgramAccounts")).toBe("alchemy");
+  });
+
+  it("returns helius for getProgramAccounts when forceAlchemyGpa=false and healthy", () => {
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig({ forceAlchemyGpa: false }),
+      now: mockNow,
+    });
+    expect(pool.pickProvider("getProgramAccounts")).toBe("helius");
+  });
+
+  it("returns helius (fail-safe) when both unhealthy", () => {
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig({ forceAlchemyGpa: false }),
+      now: mockNow,
+    });
+    for (let i = 0; i < 5; i++) {
+      pool.heliusHealth.recordFailure();
+      pool.alchemyHealth.recordFailure();
+    }
+    pool.heliusHealth.evaluate(null);
+    pool.alchemyHealth.evaluate(null);
+    expect(pool.pickProvider("getAccountInfo")).toBe("helius");
+  });
+});
+
+// ── Lifecycle tests ───────────────────────────────────────────────────────────
+
+describe("RpcPool — lifecycle", () => {
+  it("start() is idempotent (no double-timer)", () => {
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig({ healthCheckIntervalMs: 999_999 }),
+      now: mockNow,
+    });
+    pool.start();
+    pool.start(); // second call should be a no-op
+    pool.stop();
+  });
+
+  it("stop() clears the timer", () => {
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig({ healthCheckIntervalMs: 999_999 }),
+      now: mockNow,
+    });
+    pool.start();
+    pool.stop();
+    // No assertions needed — main goal is no throw / no timer leak.
+  });
+
+  it("start() is a no-op when pool disabled", () => {
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig({ enabled: false }),
+      now: mockNow,
+    });
+    pool.start(); // should not throw or spin up a timer
+    pool.stop();
+  });
+});
+
+// ── Metric recording tests ────────────────────────────────────────────────────
+
+describe("RpcPool — metric recording", () => {
+  it("records rpcRequestTotal inc on successful read", async () => {
+    const metrics = await import("../../src/lib/metrics.js");
+    const pool = new RpcPool(makeConn() as any, makeConn() as any, {
+      config: makeConfig(),
+      now: mockNow,
+    });
+    vi.clearAllMocks();
+    await pool.getSlot();
+    expect(metrics.rpcRequestTotal.inc).toHaveBeenCalledWith({
+      provider: "helius",
+      method: "getSlot",
+      result: "ok",
+    });
+  });
+
+  it("records rpcRequestTotal fail on error", async () => {
+    const metrics = await import("../../src/lib/metrics.js");
+    const failConn = makeConn({
+      getSlot: vi.fn(async () => { throw new Error("rpc down"); }),
+    });
+    const pool = new RpcPool(failConn as any, makeConn() as any, {
+      config: makeConfig({ forceAlchemyGpa: false }),
+      now: mockNow,
+    });
+    vi.clearAllMocks();
+    await expect(pool.getSlot()).rejects.toThrow("rpc down");
+    expect(metrics.rpcRequestTotal.inc).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "helius", method: "getSlot", result: "fail" }),
+    );
+  });
+});


### PR DESCRIPTION
## What this adds

Three new keeper-internal modules providing RPC provider redundancy:

- **`src/lib/rpc-health.ts`** — per-provider P50/P99 latency tracker. Rolling 60-second window of latency samples (sorted-sample nearest-rank percentile), slot-lag tracking, and a three-criterion recovery gate. A provider only recovers if: P99 < 1000ms AND |slot lag| < 10 AND 0 consecutive fails, sustained for the full `recoveryWindowMs` (60s default). Any criterion failure resets the recovery clock.
- **`src/config/rpc.ts`** — env-var config parser. `ALCHEMY_RPC_URL` is validated only when `RPC_POOL_ENABLED=true` so existing keeper deployments without Alchemy configured boot without error.
- **`src/lib/rpc-pool.ts`** — generic pool wrapping two `Connection` instances. Reads route to Helius while healthy; fall back to Alchemy on Helius unhealthy; fail-safe returns Helius when both are unhealthy (degraded primary > no primary). `getProgramAccounts` prefers Alchemy when `RPC_FORCE_ALCHEMY_GPA=true` (default), but falls back to Helius if Alchemy is unhealthy. `writeConnection` getter always returns Helius unconditionally.

Extends **`src/lib/metrics.ts`** with five new exported metrics:
- `keeper_rpc_request_total{provider, method, result}`
- `keeper_rpc_latency_ms{provider, percentile}` (shared gauge, p50/p99 label)
- `keeper_rpc_provider_healthy{provider}`
- `keeper_rpc_failover_total{from, to, reason}`
- `keeper_rpc_slot_lag{provider}`

## Why

Provider redundancy without touching writes. Helius failure currently means all keeper reads fail. Alchemy as a health-checked failover gives reads a second path. Writes, LaserStream (Helius WebSocket), and `keeperSend` are structurally untouched.

## What this does NOT do

- No migration of existing `getConnection()` call sites — Workstream G is additive only. A follow-up PR will wire callers.
- No write-path changes. `keeperSend` and `keeperSend`-adjacent code are untouched.
- No LaserStream changes (`src/lib/account-loader.ts`, `src/lib/account-cache.ts` unchanged).
- No new npm dependencies. Uses Node 22 built-in fetch, existing `@solana/web3.js` `Connection`, `prom-client`.

## Test plan

| File | Type | Count |
|---|---|---|
| `tests/lib/rpc-health.test.ts` | Unit | 25 tests |
| `tests/lib/rpc-pool.test.ts` | Unit | 28 tests |
| `tests/lib/rpc-pool.property.test.ts` | Property (fast-check, 500 runs each) | 5 invariants |
| `tests/lib/rpc-pool.stress.test.ts` | Stress/chaos (STRESS=true gated) | 4 scenarios |

**Non-STRESS run:** 501 passing / 20 skipped
**STRESS=true run:** 516 passing / 5 skipped
**pnpm build:** clean (0 TypeScript errors, strict mode)

STRESS scenarios verified:
- 1000 concurrent `read()` during simulated provider failure — all 1000 complete, zero drops
- Chaos: Helius 500s — all reads route to Alchemy within one health-check cycle
- Chaos: both providers unhealthy simultaneously — fail-safe routes to Helius, no exception thrown
- Chaos: Helius recovers after failure — reads return to Helius after 60s clean window

## Operator config (new env vars)

Add to Railway/`.env`:

```bash
# Required when RPC_POOL_ENABLED=true:
ALCHEMY_RPC_URL=https://solana-mainnet.g.alchemy.com/v2/YOUR_KEY

# Optional tuning (shown with defaults):
RPC_POOL_ENABLED=false          # false = always Helius (safe default; set true to enable pool)
RPC_HEALTH_CHECK_INTERVAL_MS=5000
RPC_UNHEALTHY_P99_MS=2000
RPC_UNHEALTHY_SLOT_LAG=50
RPC_UNHEALTHY_CONSECUTIVE_FAILS=5
RPC_RECOVERY_WINDOW_MS=60000
RPC_FORCE_ALCHEMY_GPA=true
```

`RPC_POOL_ENABLED` defaults to `false`. Set to `true` once `ALCHEMY_RPC_URL` is configured.

## Follow-up

A separate PR will migrate existing `getConnection()` callers in services to use `sharedRpcPool().getAccountInfo(...)` etc. for reads. This PR intentionally ships the pool without touching call sites.

## Non-blocking follow-up: Workstream G.1 — slot sanity bound

Security item #25 (not in scope of original brief): Reject Alchemy `getSlot` responses where `slot > heliusSlot + MAX_REASONABLE_LAG (~1000)` to prevent slot-manipulation route hijacking. Tracked for a separate hardening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RPC pool failover mechanism that automatically routes requests to a secondary provider when the primary provider becomes unhealthy.
  * Implemented health monitoring with configurable thresholds for latency, slot lag, and consecutive failures to detect provider issues.
  * Added metrics for tracking RPC request routing, provider health status, and failover events.

* **Tests**
  * Added comprehensive test coverage for RPC pool failover behavior and health monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-keeper/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->