### PR TITLE
feat(keeper): Phase 1.5 Workstream I — fraud-detection layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,3 +115,11 @@ TX_QUEUE_CRANK_INTERVAL_CAP=10
 TX_QUEUE_CRANK_INTERVAL_MS=1000
 # How long (ms) to wait for in-flight txs to land during SIGTERM drain before giving up.
 TX_QUEUE_DRAIN_TIMEOUT_MS=30000
+
+# Fraud-detection layer (Workstream I) — cross-validates on-chain HYPERP EMA vs off-chain price.
+# Purely observational: alerts via Discord WARN, never blocks cranks or sends.
+# Set FRAUD_DETECT_ENABLED=false to disable entirely (e.g. during noisy feed periods).
+FRAUD_DETECT_ENABLED=true
+FRAUD_DETECT_DIVERGENCE_BPS=500       # alert threshold (500 = 5%)
+FRAUD_DETECT_INTERVAL_MS=30000        # check interval (30s)
+FRAUD_DETECT_PER_MINT_COOLDOWN_MS=1800000  # suppress repeat alerts within 30min per mint

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { CrankService } from "./services/crank.js";
 import { LiquidationService } from "./services/liquidation.js";
 import { AdlService } from "./services/adl.js";
 import { MonitorService } from "./services/monitor.js";
+import { FraudDetectorService } from "./services/fraud-detector.js";
 import { validateKeeperEnvGuards } from "./env-guards.js";
 import { isMainnet } from "./config/network.js";
 import { assertMainnetProgramId } from "./lib/boot-assertions.js";
@@ -52,6 +53,7 @@ const oracleService = new OracleService();
 const crankService = new CrankService(oracleService);
 const liquidationService = new LiquidationService(oracleService);
 const monitorService = new MonitorService();
+const fraudDetector = new FraudDetectorService(oracleService, () => crankService.getMarkets());
 
 // ADL service — gated by ADL_ENABLED=true env var until on-chain instruction
 // (PERC-8273 T8) is live and T10 devnet upgrade is done (PERC-8275).
@@ -606,6 +608,8 @@ async function start() {
     logger.info("Liquidation scanner started");
     monitorService.start(() => crankService.getMarkets());
     logger.info("MonitorService started (invariant + ADL staleness checks)");
+    fraudDetector.start();
+    logger.info("FraudDetectorService started");
 
     if (adlService) {
       adlService.start(() => crankService.getMarkets());
@@ -624,6 +628,8 @@ async function start() {
     logger.info("Liquidation service stopped (HA demote)");
     monitorService.stop();
     logger.info("MonitorService stopped (HA demote)");
+    fraudDetector.stop();
+    logger.info("FraudDetectorService stopped (HA demote)");
   }
 
   if (leaderLock) {
@@ -758,7 +764,11 @@ async function shutdown(signal: string): Promise<void> {
     // Stop crank service (clears timers, stops processing)
     logger.info("Stopping crank service");
     crankService.stop();
-    
+
+    // Stop fraud-detection loop
+    logger.info("Stopping fraud-detector service");
+    fraudDetector.stop();
+
     // Stop liquidation service (clears timers)
     logger.info("Stopping liquidation service");
     liquidationService.stop();

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -244,15 +244,32 @@ export const txQueueFailedTotal = new Counter({
   registers: [registry],
 });
 
-// ── Stubs for I/J — defined here so those workstreams can import without
-// introducing circular deps. Grafana panels will show "No data" until wired.
-//
-// (H's keeper_tx_queue_* metrics are fully wired above — no longer stubs.)
+// ── Workstream I: fraud-detection layer ──────────────────────────────────────
 
-// Wired in Workstream I (fraud-detection layer PR)
+// Per-mint divergence gauge: |onchain_mark - offchain_consensus| / offchain * 10_000.
+// Updated on every fraud-detector cycle regardless of whether the divergence
+// exceeds the alert threshold — allows trend analysis in Grafana.
 export const fraudDivergenceBps = new Gauge({
   name: "keeper_fraud_divergence_bps",
   help: "Absolute divergence in basis points between the on-chain EMA and the off-chain reference price, partitioned by mint",
+  labelNames: ["mint"] as const,
+  registers: [registry],
+});
+
+// Incremented each time a divergence alert fires for a mint (after cooldown passes).
+// Use rate() in Grafana to see alert frequency per mint.
+export const fraudAlertTotal = new Counter({
+  name: "keeper_fraud_alert_total",
+  help: "Total fraud-detection divergence alerts fired, partitioned by mint",
+  labelNames: ["mint"] as const,
+  registers: [registry],
+});
+
+// Incremented when the off-chain price is unavailable (null return, throw, or zero)
+// for a market. A sustained count indicates a feed outage for that mint.
+export const fraudOffchainUnavailableTotal = new Counter({
+  name: "keeper_fraud_offchain_unavailable_total",
+  help: "Total cycles where the off-chain price was unavailable for a market, partitioned by mint",
   labelNames: ["mint"] as const,
   registers: [registry],
 });

--- a/src/services/fraud-detector.ts
+++ b/src/services/fraud-detector.ts
@@ -1,0 +1,237 @@
+/**
+ * FraudDetectorService — periodic cross-validation of on-chain HYPERP mark price
+ * versus off-chain DexScreener / Jupiter consensus.
+ *
+ * This service is PURELY OBSERVATIONAL. It never pauses cranks, halts sends, or
+ * affects any other code path. A divergence above the threshold fires a Discord
+ * warning via sendWarningAlert and increments Prometheus counters only.
+ *
+ * On-chain mark source: engine.markPriceE6 (parsed from slab data by
+ * parseEngine). This field is updated on-chain by UpdateHyperpMark and
+ * represents the EMA mark price in E6 format (i.e. USD * 1e6).
+ *
+ * Off-chain consensus: OracleService.fetchPrice(mint, slabAddress), which
+ * returns the DexScreener / Jupiter median as priceE6 (also E6 format).
+ * Both values are therefore directly comparable after Number() conversion.
+ *
+ * Divergence formula (per brief): |onchain - offchain| / offchain * 10_000
+ * This is slightly asymmetric (result depends on which is the denominator).
+ * Using offchain as the denominator is intentional — we are assessing how far
+ * the on-chain mark has drifted from the market's view. See divergenceBps().
+ */
+
+import { createLogger, sendWarningAlert } from "@percolatorct/shared";
+import type { OracleService } from "./oracle.js";
+import type { MarketCrankState } from "./crank-types.js";
+import {
+  fraudDivergenceBps,
+  fraudAlertTotal,
+  fraudOffchainUnavailableTotal,
+} from "../lib/metrics.js";
+
+const logger = createLogger("keeper:fraud-detector");
+
+// Price scale used by both on-chain and off-chain price representations.
+// engine.markPriceE6 is in USD * 1e6; OracleService.fetchPrice returns priceE6
+// in the same units. No conversion required — just compare the raw bigint values
+// after converting to Number for the floating-point division.
+const PRICE_E6_SCALE = 1_000_000;
+
+/**
+ * Compute divergence in basis points between two E6-scaled prices.
+ *
+ * Returns |onchain - offchain| / |offchain| * 10_000.
+ * The formula uses offchain as denominator (per brief), which means the result
+ * is asymmetric: divergenceBps(A, B) != divergenceBps(B, A) in general.
+ * callers must supply values in (onchain, offchain) order to get a meaningful
+ * "how far has the chain drifted from the market" reading.
+ *
+ * Edge cases:
+ *   offchain == 0 → return 0 (caller must check and skip the market).
+ *   Result is always >= 0 (Math.abs on the numerator).
+ */
+export function divergenceBps(onchain: bigint | number, offchain: bigint | number): number {
+  const b = Number(offchain);
+  if (b === 0) return 0; // caller must treat 0 as "skip — cannot divide"
+  const a = Number(onchain);
+  return Math.round(Math.abs(a - b) / Math.abs(b) * 10_000);
+}
+
+// Config
+function getIntervalMs(): number {
+  return parseInt(process.env.FRAUD_DETECT_INTERVAL_MS ?? "30000", 10);
+}
+function getDivergenceThresholdBps(): number {
+  return parseInt(process.env.FRAUD_DETECT_DIVERGENCE_BPS ?? "500", 10);
+}
+function getPerMintCooldownMs(): number {
+  return parseInt(process.env.FRAUD_DETECT_PER_MINT_COOLDOWN_MS ?? "1800000", 10);
+}
+function isEnabled(): boolean {
+  return process.env.FRAUD_DETECT_ENABLED !== "false";
+}
+
+export class FraudDetectorService {
+  private _timer: ReturnType<typeof setInterval> | null = null;
+  /** Map<mint, timestamp-of-last-alert> for per-mint cooldown. */
+  private readonly _lastAlertByMint = new Map<string, number>();
+
+  constructor(
+    private readonly _oracleService: OracleService,
+    private readonly _getMarkets: () => Map<string, MarketCrankState>,
+  ) {}
+
+  start(): void {
+    if (!isEnabled()) {
+      logger.info("FraudDetectorService disabled via FRAUD_DETECT_ENABLED=false — no interval registered");
+      return;
+    }
+    if (this._timer) return;
+
+    const intervalMs = getIntervalMs();
+    logger.info("FraudDetectorService starting", {
+      intervalMs,
+      divergenceThresholdBps: getDivergenceThresholdBps(),
+      perMintCooldownMs: getPerMintCooldownMs(),
+    });
+
+    this._timer = setInterval(async () => {
+      try {
+        await this._runCheck();
+      } catch (err) {
+        logger.error("FraudDetectorService cycle failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }, intervalMs);
+
+    // Do not block process exit on this observational loop.
+    this._timer.unref();
+  }
+
+  stop(): void {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+      logger.info("FraudDetectorService stopped");
+    }
+  }
+
+  // Exposed for tests to invoke directly without waiting for the interval.
+  async _runCheck(): Promise<void> {
+    const markets = this._getMarkets();
+    const thresholdBps = getDivergenceThresholdBps();
+    const cooldownMs = getPerMintCooldownMs();
+    const now = Date.now();
+
+    for (const [slabAddress, state] of markets) {
+      // Only HYPERP markets have engine.markPriceE6 set by UpdateHyperpMark.
+      // Non-HYPERP markets use Pyth/Chainlink — no cross-validate needed here.
+      // HYPERP detection: indexFeedId all-zeros AND oracleAuthority all-zeros.
+      const feedBytes = state.market.config.indexFeedId.toBytes();
+      const isZeroFeed = feedBytes.every((b: number) => b === 0);
+      const isZeroAuthority = state.market.config.oracleAuthority.toBytes().every((b: number) => b === 0);
+      if (!isZeroFeed || !isZeroAuthority) {
+        // Not a true HYPERP market — no on-chain EMA to compare.
+        continue;
+      }
+
+      // On-chain mark price: engine.markPriceE6 (E6 units, updated by UpdateHyperpMark).
+      const onChainMarkE6 = state.market.engine.markPriceE6;
+      if (onChainMarkE6 === undefined || onChainMarkE6 === 0n) {
+        logger.debug("FraudDetector: on-chain markPriceE6 is zero — skipping market", {
+          slabAddress: slabAddress.slice(0, 8),
+        });
+        continue;
+      }
+
+      // mint label: collateralMint from config (used as Prometheus label + Discord field).
+      const mint = state.market.config.collateralMint.toBase58();
+
+      // Off-chain consensus from OracleService (DexScreener + Jupiter median).
+      // Use mainnetCA if set for devnet mirror markets.
+      const priceMint = state.mainnetCA ?? mint;
+      let offChainPriceE6: bigint;
+      try {
+        const entry = await this._oracleService.fetchPrice(priceMint, slabAddress);
+        if (entry === null || entry.priceE6 === undefined || entry.priceE6 === 0n) {
+          logger.debug("FraudDetector: off-chain price unavailable for market", {
+            mint: mint.slice(0, 8),
+            slabAddress: slabAddress.slice(0, 8),
+          });
+          fraudOffchainUnavailableTotal.inc({ mint });
+          continue;
+        }
+        offChainPriceE6 = entry.priceE6;
+      } catch (err) {
+        logger.debug("FraudDetector: off-chain price fetch threw for market", {
+          mint: mint.slice(0, 8),
+          slabAddress: slabAddress.slice(0, 8),
+          error: err instanceof Error ? err.message : String(err),
+        });
+        fraudOffchainUnavailableTotal.inc({ mint });
+        continue;
+      }
+
+      if (offChainPriceE6 === 0n) {
+        logger.debug("FraudDetector: off-chain price is zero — skipping market (cannot divide)", {
+          mint: mint.slice(0, 8),
+        });
+        fraudOffchainUnavailableTotal.inc({ mint });
+        continue;
+      }
+
+      const bps = divergenceBps(onChainMarkE6, offChainPriceE6);
+
+      // Update Prometheus gauge (always, regardless of threshold).
+      fraudDivergenceBps.set({ mint }, bps);
+
+      if (bps <= thresholdBps) {
+        logger.debug("FraudDetector: divergence within threshold", {
+          mint: mint.slice(0, 8),
+          divergenceBps: bps,
+          thresholdBps,
+          onChainMarkE6: onChainMarkE6.toString(),
+          offChainPriceE6: offChainPriceE6.toString(),
+        });
+        continue;
+      }
+
+      // Divergence exceeds threshold — apply per-mint cooldown before alerting.
+      const lastAlert = this._lastAlertByMint.get(mint) ?? 0;
+      if (now - lastAlert < cooldownMs) {
+        logger.debug("FraudDetector: divergence high but in cooldown window — suppressing alert", {
+          mint: mint.slice(0, 8),
+          divergenceBps: bps,
+          cooldownRemainingMs: cooldownMs - (now - lastAlert),
+        });
+        continue;
+      }
+
+      // Alert: update cooldown timestamp, increment counter, fire Discord warning.
+      this._lastAlertByMint.set(mint, now);
+      fraudAlertTotal.inc({ mint });
+
+      const onChainUsd = (Number(onChainMarkE6) / PRICE_E6_SCALE).toFixed(6);
+      const offChainUsd = (Number(offChainPriceE6) / PRICE_E6_SCALE).toFixed(6);
+
+      logger.warn("FraudDetector: on-chain/off-chain price divergence ALERT", {
+        mint: mint.slice(0, 8),
+        divergenceBps: bps,
+        thresholdBps,
+        onChainMarkUsd: onChainUsd,
+        offChainConsensusUsd: offChainUsd,
+        slabAddress: slabAddress.slice(0, 8),
+      });
+
+      sendWarningAlert("HYPERP price divergence detected", [
+        { name: "Mint", value: mint.slice(0, 16) + "...", inline: true },
+        { name: "On-chain mark", value: `$${onChainUsd}`, inline: true },
+        { name: "Off-chain consensus", value: `$${offChainUsd}`, inline: true },
+        { name: "Divergence", value: `${bps} bps (${(bps / 100).toFixed(2)}%)`, inline: true },
+        { name: "Threshold", value: `${thresholdBps} bps`, inline: true },
+        { name: "Market", value: slabAddress.slice(0, 16) + "...", inline: false },
+      ])?.catch(() => {});
+    }
+  }
+}

--- a/tests/services/fraud-detector.property.test.ts
+++ b/tests/services/fraud-detector.property.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Property-based tests for divergenceBps (fraud-detector).
+ * fast-check: >=500 runs per property.
+ *
+ * Properties under test:
+ *   1. Non-negativity: result is always >= 0.
+ *   2. Zero identity: divergenceBps(A, A) == 0 for any A > 0.
+ *   3. Zero-offchain guard: divergenceBps(A, 0) == 0 (divide-by-zero guard, caller skips).
+ *   4. Monotonicity: larger absolute diff → larger or equal divergence.
+ *   5. Approximate symmetry characterisation: divergenceBps(A, B) and divergenceBps(B, A)
+ *      agree within a factor of 2 for non-pathological inputs (A, B both > 0, ratio < 10x).
+ *      The brief prescribes |A-B|/B (offchain as denominator), so the formula is intentionally
+ *      asymmetric — we test that the asymmetry is bounded, not that it is zero.
+ *
+ * We do not test the NaN/Infinity properties because the implementation converts
+ * bigint to Number; a zero denominator is guarded explicitly. The property suite
+ * verifies both bigint and Number inputs.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { divergenceBps } from "../../src/services/fraud-detector.js";
+
+// We mute the metrics and shared imports at the module level — this file only
+// imports the exported pure function, so no service-layer mocks are needed.
+
+const NUM_RUNS = 500;
+
+describe("divergenceBps property tests", () => {
+  // 1. Non-negativity
+  it("result is always non-negative for any finite inputs", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 0n, max: 10_000_000_000n }),
+        fc.bigInt({ min: 0n, max: 10_000_000_000n }),
+        (a, b) => {
+          const result = divergenceBps(a, b);
+          expect(result).toBeGreaterThanOrEqual(0);
+          expect(Number.isFinite(result)).toBe(true);
+          expect(Number.isNaN(result)).toBe(false);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  // 2. Zero identity: divergenceBps(A, A) == 0 for A > 0
+  it("divergenceBps(A, A) === 0 for any positive A", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 1n, max: 10_000_000_000n }),
+        (a) => {
+          expect(divergenceBps(a, a)).toBe(0);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  // 3. Zero-offchain guard: returns 0, not NaN / Infinity
+  it("divergenceBps(A, 0n) returns 0 and not NaN or Infinity", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 0n, max: 10_000_000_000n }),
+        (a) => {
+          const result = divergenceBps(a, 0n);
+          expect(result).toBe(0);
+          expect(Number.isNaN(result)).toBe(false);
+          expect(Number.isFinite(result)).toBe(true);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  // Same guard with Number zero
+  it("divergenceBps(A, 0) returns 0 for Number inputs", () => {
+    fc.assert(
+      fc.property(
+        fc.float({ min: 0, max: 1e9, noNaN: true }),
+        (a) => {
+          const result = divergenceBps(a, 0);
+          expect(result).toBe(0);
+          expect(Number.isNaN(result)).toBe(false);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  // 4. Monotonicity: for fixed offchain B > 0, a larger |onchain - offchain|
+  //    must produce a larger or equal divergence.
+  //    We construct two onchain values equidistant from offchain on the same side.
+  it("larger absolute difference → larger or equal divergence (monotonicity)", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 1_000n, max: 1_000_000_000n }), // offchain
+        fc.bigInt({ min: 0n, max: 500_000n }),             // smallDiff
+        fc.bigInt({ min: 500_001n, max: 1_000_000n }),     // largeDiff
+        (b, smallDiff, largeDiff) => {
+          // Both onchain values are above offchain by different amounts
+          const aSmall = b + smallDiff;
+          const aLarge = b + largeDiff;
+          const dSmall = divergenceBps(aSmall, b);
+          const dLarge = divergenceBps(aLarge, b);
+          expect(dLarge).toBeGreaterThanOrEqual(dSmall);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  // 5. Approximate symmetry: with offchain as denominator the result is
+  //    asymmetric by construction. For inputs where both A and B are in
+  //    the range [1, 2B] (i.e., ratio < 2x), the two directions must agree
+  //    within a factor of 2 (they share the same numerator |A-B|; only the
+  //    denominator changes). This validates the math is correct, not that
+  //    it is symmetric.
+  it("asymmetry is bounded within factor of 2 when A and B are within 2x of each other", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 1_000n, max: 1_000_000_000n }), // B (offchain)
+        fc.bigInt({ min: 1n, max: 999n }),               // deviation as thousandths of B (< 100%)
+        (b, deviationThousandths) => {
+          // A is within [B - 99.9% B, B + 99.9% B] so ratio stays < 2x
+          const diff = (b * deviationThousandths) / 1000n;
+          const a = b + diff; // A > B case
+
+          const dAB = divergenceBps(a, b); // |A-B|/B * 10_000
+          const dBA = divergenceBps(b, a); // |B-A|/A * 10_000
+
+          // Both numerators are the same (|diff|); denominators differ (B vs A).
+          // Since A = B + diff, A >= B → dBA <= dAB.
+          // The ratio dAB / dBA = A / B, which is between 1 and 2.
+          // Check the weaker bound: max / min <= 2.
+          const maxD = Math.max(dAB, dBA);
+          const minD = Math.min(dAB, dBA);
+          if (minD === 0) {
+            // diff is 0 → both should be 0
+            expect(maxD).toBe(0);
+          } else {
+            expect(maxD / minD).toBeLessThanOrEqual(2.1); // allow tiny fp rounding
+          }
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  // 6. No NaN / Infinity for any Number inputs in the E6 price range
+  it("never produces NaN or Infinity for E6-range Number inputs", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 1_000_000_000_000 }), // up to $1_000_000 in E6
+        fc.integer({ min: 1, max: 1_000_000_000_000 }), // offchain > 0
+        (a, b) => {
+          const result = divergenceBps(a, b);
+          expect(Number.isNaN(result)).toBe(false);
+          expect(Number.isFinite(result)).toBe(true);
+          expect(result).toBeGreaterThanOrEqual(0);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});

--- a/tests/services/fraud-detector.test.ts
+++ b/tests/services/fraud-detector.test.ts
@@ -1,0 +1,402 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+
+// ── Shared mocks ─────────────────────────────────────────────────────────────
+// vi.hoisted() runs before vi.mock() factory — required for factory closures.
+
+const { mockWarnAlertFn, mockFraudDivergenceBps, mockFraudAlertTotal, mockFraudOffchainUnavailableTotal } =
+  vi.hoisted(() => ({
+    mockWarnAlertFn: vi.fn(),
+    mockFraudDivergenceBps: { set: vi.fn() },
+    mockFraudAlertTotal: { inc: vi.fn() },
+    mockFraudOffchainUnavailableTotal: { inc: vi.fn() },
+  }));
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  sendWarningAlert: mockWarnAlertFn,
+}));
+
+vi.mock("../../src/lib/metrics.js", () => ({
+  fraudDivergenceBps: mockFraudDivergenceBps,
+  fraudAlertTotal: mockFraudAlertTotal,
+  fraudOffchainUnavailableTotal: mockFraudOffchainUnavailableTotal,
+}));
+
+import {
+  FraudDetectorService,
+  divergenceBps,
+} from "../../src/services/fraud-detector.js";
+import type { OracleService } from "../../src/services/oracle.js";
+import type { MarketCrankState } from "../../src/services/crank-types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a minimal HYPERP MarketCrankState for tests. */
+function makeHyperpState(opts: {
+  markPriceE6?: bigint;
+  collateralMint?: string;
+  /** If true, make oracle authority non-zero (non-HYPERP market) */
+  nonZeroAuthority?: boolean;
+  /** If true, make indexFeedId non-zero (non-HYPERP market) */
+  nonZeroFeed?: boolean;
+  mainnetCA?: string;
+}): MarketCrankState {
+  const ZERO = new PublicKey("11111111111111111111111111111111");
+  const NONZERO = new PublicKey("So11111111111111111111111111111111111111112");
+  // Valid base58 mint address (44 chars, base58 alphabet only)
+  const mint = opts.collateralMint ?? "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+  return {
+    market: {
+      slabAddress: new PublicKey("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"), // valid base58
+      programId: new PublicKey("11111111111111111111111111111111"),
+      header: {} as never,
+      config: {
+        collateralMint: new PublicKey(mint),
+        indexFeedId: opts.nonZeroFeed ? NONZERO : ZERO,
+        oracleAuthority: opts.nonZeroAuthority ? NONZERO : ZERO,
+        dexPool: null,
+      } as never,
+      engine: {
+        markPriceE6: opts.markPriceE6 ?? 1_000_000n, // default $1.00 in E6
+      } as never,
+      params: {} as never,
+    },
+    lastCrankTime: 0,
+    successCount: 0,
+    failureCount: 0,
+    consecutiveFailures: 0,
+    isActive: true,
+    missingDiscoveryCount: 0,
+    mainnetCA: opts.mainnetCA,
+  };
+}
+
+/** Build a mock OracleService with controllable fetchPrice behavior. */
+function makeMockOracle(
+  resolveWith: Awaited<ReturnType<OracleService["fetchPrice"]>>,
+): OracleService {
+  return {
+    fetchPrice: vi.fn().mockResolvedValue(resolveWith),
+  } as unknown as OracleService;
+}
+
+function makeThrowingOracle(err: Error): OracleService {
+  return {
+    fetchPrice: vi.fn().mockRejectedValue(err),
+  } as unknown as OracleService;
+}
+
+// ── divergenceBps pure function ───────────────────────────────────────────────
+
+describe("divergenceBps", () => {
+  it("returns 0 when values are equal", () => {
+    expect(divergenceBps(1_000_000n, 1_000_000n)).toBe(0);
+  });
+
+  it("returns 0 when offchain is 0 (divide-by-zero guard)", () => {
+    expect(divergenceBps(1_000_000n, 0n)).toBe(0);
+    expect(divergenceBps(1_000_000n, 0)).toBe(0);
+  });
+
+  it("is always non-negative", () => {
+    expect(divergenceBps(900_000n, 1_000_000n)).toBeGreaterThanOrEqual(0);
+    expect(divergenceBps(1_100_000n, 1_000_000n)).toBeGreaterThanOrEqual(0);
+  });
+
+  it("computes 500 bps for 5% difference (onchain below offchain)", () => {
+    // 950_000 / 1_000_000 = 0.95 → diff 5% → 500 bps
+    expect(divergenceBps(950_000n, 1_000_000n)).toBe(500);
+  });
+
+  it("computes 500 bps for 5% difference (onchain above offchain)", () => {
+    // 1_050_000 vs 1_000_000 → |50_000| / 1_000_000 * 10_000 = 500
+    expect(divergenceBps(1_050_000n, 1_000_000n)).toBe(500);
+  });
+
+  it("accepts Number inputs as well as bigint", () => {
+    expect(divergenceBps(950_000, 1_000_000)).toBe(500);
+  });
+});
+
+// ── FraudDetectorService unit tests ─────────────────────────────────────────
+
+describe("FraudDetectorService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset env to defaults
+    delete process.env.FRAUD_DETECT_ENABLED;
+    delete process.env.FRAUD_DETECT_DIVERGENCE_BPS;
+    delete process.env.FRAUD_DETECT_PER_MINT_COOLDOWN_MS;
+    delete process.env.FRAUD_DETECT_INTERVAL_MS;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── FRAUD_DETECT_ENABLED=false ─────────────────────────────────────────────
+
+  it("start() is a no-op when FRAUD_DETECT_ENABLED=false", () => {
+    process.env.FRAUD_DETECT_ENABLED = "false";
+    vi.useFakeTimers();
+    const oracle = makeMockOracle(null);
+    const svc = new FraudDetectorService(oracle, () => new Map());
+    svc.start();
+    // Advance time by 60 seconds — no check cycle should fire
+    vi.advanceTimersByTime(60_000);
+    expect(oracle.fetchPrice).not.toHaveBeenCalled();
+    svc.stop();
+  });
+
+  // ── stop() clears interval ─────────────────────────────────────────────────
+
+  it("stop() clears the interval so no further checks run", async () => {
+    process.env.FRAUD_DETECT_INTERVAL_MS = "100";
+    vi.useFakeTimers();
+    const oracle = makeMockOracle(null);
+    const svc = new FraudDetectorService(oracle, () => new Map());
+    svc.start();
+    vi.advanceTimersByTime(50);
+    svc.stop();
+    vi.advanceTimersByTime(300);
+    // fetchPrice never called (no HYPERP markets in empty map)
+    expect(oracle.fetchPrice).not.toHaveBeenCalled();
+  });
+
+  // ── small divergence: no alert ────────────────────────────────────────────
+
+  it("does not alert when divergence is below threshold", async () => {
+    process.env.FRAUD_DETECT_DIVERGENCE_BPS = "500";
+    // on-chain: $1.01, off-chain: $1.00 → 100 bps (below 500)
+    const onChain = 1_010_000n; // E6
+    const offChain = 1_000_000n; // E6
+
+    const state = makeHyperpState({ markPriceE6: onChain });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeMockOracle({ priceE6: offChain, source: "dexscreener", timestamp: Date.now() });
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+    await svc._runCheck();
+
+    expect(mockWarnAlertFn).not.toHaveBeenCalled();
+    expect(mockFraudAlertTotal.inc).not.toHaveBeenCalled();
+    // Gauge is still updated
+    expect(mockFraudDivergenceBps.set).toHaveBeenCalledWith(
+      { mint: state.market.config.collateralMint.toBase58() },
+      expect.any(Number),
+    );
+  });
+
+  // ── large divergence: alert fires ────────────────────────────────────────
+
+  it("sends alert and increments counter when divergence exceeds threshold", async () => {
+    process.env.FRAUD_DETECT_DIVERGENCE_BPS = "500";
+    mockWarnAlertFn.mockReturnValue(Promise.resolve());
+
+    // on-chain: $2.00, off-chain: $1.00 → 10_000 bps (way above 500)
+    const onChain = 2_000_000n;
+    const offChain = 1_000_000n;
+
+    const state = makeHyperpState({ markPriceE6: onChain });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeMockOracle({ priceE6: offChain, source: "dexscreener", timestamp: Date.now() });
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+    await svc._runCheck();
+
+    expect(mockFraudAlertTotal.inc).toHaveBeenCalledOnce();
+    expect(mockWarnAlertFn).toHaveBeenCalledOnce();
+    expect(mockFraudDivergenceBps.set).toHaveBeenCalledWith(
+      { mint: state.market.config.collateralMint.toBase58() },
+      10_000,
+    );
+  });
+
+  // ── cooldown: second call within window suppresses alert ─────────────────
+
+  it("suppresses second alert within the cooldown window for the same mint", async () => {
+    process.env.FRAUD_DETECT_DIVERGENCE_BPS = "500";
+    process.env.FRAUD_DETECT_PER_MINT_COOLDOWN_MS = "1800000"; // 30 min
+    mockWarnAlertFn.mockReturnValue(Promise.resolve());
+
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const onChain = 2_000_000n;
+    const offChain = 1_000_000n;
+
+    const state = makeHyperpState({ markPriceE6: onChain });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeMockOracle({ priceE6: offChain, source: "dexscreener", timestamp: Date.now() });
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+
+    // First call — alert should fire
+    await svc._runCheck();
+    expect(mockFraudAlertTotal.inc).toHaveBeenCalledTimes(1);
+
+    // Advance by 5 minutes (well within 30min cooldown)
+    vi.advanceTimersByTime(5 * 60_000);
+
+    // Second call — should be suppressed
+    await svc._runCheck();
+    expect(mockFraudAlertTotal.inc).toHaveBeenCalledTimes(1); // still only 1
+    expect(mockWarnAlertFn).toHaveBeenCalledTimes(1); // still only 1
+  });
+
+  // ── cooldown expiry: alert re-fires ──────────────────────────────────────
+
+  it("re-fires alert after the cooldown window has expired", async () => {
+    process.env.FRAUD_DETECT_DIVERGENCE_BPS = "500";
+    process.env.FRAUD_DETECT_PER_MINT_COOLDOWN_MS = "60000"; // 60 seconds for test speed
+    mockWarnAlertFn.mockReturnValue(Promise.resolve());
+
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const onChain = 2_000_000n;
+    const offChain = 1_000_000n;
+
+    const state = makeHyperpState({ markPriceE6: onChain });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeMockOracle({ priceE6: offChain, source: "dexscreener", timestamp: Date.now() });
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+
+    // First alert
+    await svc._runCheck();
+    expect(mockFraudAlertTotal.inc).toHaveBeenCalledTimes(1);
+
+    // Advance past the 60s cooldown window
+    vi.advanceTimersByTime(61_000);
+
+    // Second alert — cooldown has expired
+    await svc._runCheck();
+    expect(mockFraudAlertTotal.inc).toHaveBeenCalledTimes(2);
+    expect(mockWarnAlertFn).toHaveBeenCalledTimes(2);
+  });
+
+  // ── missing off-chain price: skip + increment unavailable counter ─────────
+
+  it("skips market and increments unavailable counter when fetchPrice returns null", async () => {
+    const state = makeHyperpState({ markPriceE6: 1_000_000n });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeMockOracle(null);
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+    await svc._runCheck();
+
+    expect(mockFraudOffchainUnavailableTotal.inc).toHaveBeenCalledOnce();
+    expect(mockFraudAlertTotal.inc).not.toHaveBeenCalled();
+    expect(mockWarnAlertFn).not.toHaveBeenCalled();
+  });
+
+  it("skips market and increments unavailable counter when fetchPrice throws", async () => {
+    const state = makeHyperpState({ markPriceE6: 1_000_000n });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeThrowingOracle(new Error("network error"));
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+    await svc._runCheck();
+
+    expect(mockFraudOffchainUnavailableTotal.inc).toHaveBeenCalledOnce();
+    expect(mockFraudAlertTotal.inc).not.toHaveBeenCalled();
+    expect(mockWarnAlertFn).not.toHaveBeenCalled();
+  });
+
+  // ── non-HYPERP markets are skipped ──────────────────────────────────────
+
+  it("skips non-HYPERP market where oracleAuthority is non-zero", async () => {
+    const state = makeHyperpState({ nonZeroAuthority: true });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeMockOracle({ priceE6: 1_000_000n, source: "dexscreener", timestamp: Date.now() });
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+    await svc._runCheck();
+
+    expect(oracle.fetchPrice).not.toHaveBeenCalled();
+    expect(mockFraudAlertTotal.inc).not.toHaveBeenCalled();
+  });
+
+  it("skips non-HYPERP market where indexFeedId is non-zero", async () => {
+    const state = makeHyperpState({ nonZeroFeed: true });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeMockOracle({ priceE6: 1_000_000n, source: "dexscreener", timestamp: Date.now() });
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+    await svc._runCheck();
+
+    expect(oracle.fetchPrice).not.toHaveBeenCalled();
+  });
+
+  // ── on-chain mark price is zero: skip market ─────────────────────────────
+
+  it("skips market when engine.markPriceE6 is zero", async () => {
+    const state = makeHyperpState({ markPriceE6: 0n });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeMockOracle({ priceE6: 1_000_000n, source: "dexscreener", timestamp: Date.now() });
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+    await svc._runCheck();
+
+    expect(oracle.fetchPrice).not.toHaveBeenCalled();
+    expect(mockFraudOffchainUnavailableTotal.inc).not.toHaveBeenCalled();
+  });
+
+  // ── multiple markets: independent per-mint cooldowns ─────────────────────
+
+  it("applies independent cooldowns per mint — alert for one mint does not suppress the other", async () => {
+    process.env.FRAUD_DETECT_DIVERGENCE_BPS = "500";
+    process.env.FRAUD_DETECT_PER_MINT_COOLDOWN_MS = "1800000";
+    mockWarnAlertFn.mockReturnValue(Promise.resolve());
+
+    vi.useFakeTimers();
+
+    // Valid base58 mint addresses
+    const mint1 = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"; // USDC
+    const mint2 = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"; // USDT
+
+    const stateA = makeHyperpState({ markPriceE6: 2_000_000n, collateralMint: mint1 });
+    const stateB = makeHyperpState({ markPriceE6: 2_000_000n, collateralMint: mint2 });
+    const markets = new Map([["slabA", stateA], ["slabB", stateB]]);
+
+    const oracle = makeMockOracle({ priceE6: 1_000_000n, source: "dexscreener", timestamp: Date.now() });
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+
+    // Both markets should alert on first run
+    await svc._runCheck();
+    expect(mockFraudAlertTotal.inc).toHaveBeenCalledTimes(2);
+
+    // Second run within cooldown — both suppressed
+    await svc._runCheck();
+    expect(mockFraudAlertTotal.inc).toHaveBeenCalledTimes(2); // unchanged
+  });
+
+  // ── mainnetCA is used for price lookup when set ───────────────────────────
+
+  it("uses mainnetCA for price lookup when set on the market state", async () => {
+    process.env.FRAUD_DETECT_DIVERGENCE_BPS = "500";
+
+    // Valid base58 mainnet CA (SOL mint)
+    const mainnetCA = "So11111111111111111111111111111111111111112";
+    const state = makeHyperpState({ markPriceE6: 1_000_000n, mainnetCA });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeMockOracle({ priceE6: 1_000_000n, source: "dexscreener", timestamp: Date.now() });
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+    await svc._runCheck();
+
+    // fetchPrice should be called with mainnetCA, not the collateral mint
+    expect(oracle.fetchPrice).toHaveBeenCalledWith(mainnetCA, "slab1");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `FraudDetectorService` — a purely observational periodic loop that cross-validates the on-chain HYPERP EMA (`engine.markPriceE6`) against the off-chain DexScreener/Jupiter consensus from `OracleService.fetchPrice`
- Fires a Discord WARN and increments `keeper_fraud_alert_total{mint}` when divergence > `FRAUD_DETECT_DIVERGENCE_BPS` (500 bps default). Never blocks cranks, sends, or any other code path
- Per-mint cooldown (`FRAUD_DETECT_PER_MINT_COOLDOWN_MS`, 30 min default) prevents alert spam

## Design

**On-chain mark source:** `engine.markPriceE6` from `DiscoveredMarket.engine` (parsed by `parseEngine` from the slab bytes). This field is updated on-chain by the `UpdateHyperpMark` instruction and represents the EMA mark price in E6 format. Both the on-chain value and OracleService's `priceE6` return are in the same USD*1e6 units — no conversion needed.

**HYPERP detection:** markets where both `indexFeedId` and `oracleAuthority` are all-zeros (same logic as `crankService.isHyperpOracle`). Non-HYPERP markets (Pyth/Chainlink) are skipped.

**Divergence formula:** `|onchain - offchain| / |offchain| * 10_000` — uses offchain as denominator per brief. Intentionally asymmetric; documented in source.

**Wiring:** constructed after `crankService` + `oracleService`, started/stopped symmetrically with `MonitorService` inside `startAllServices`/`stopAllServices`/`shutdown`. Respects HA leader mode — only the leader node runs fraud detection.

## Metrics (wired)

| Metric | Type | Labels | Description |
|---|---|---|---|
| `keeper_fraud_divergence_bps` | Gauge | `mint` | Updated every cycle regardless of threshold |
| `keeper_fraud_alert_total` | Counter | `mint` | Incremented when alert fires (post-cooldown) |
| `keeper_fraud_offchain_unavailable_total` | Counter | `mint` | Incremented when off-chain fetch fails/returns null |

## Operator notes

- Default: enabled, 30s interval, 500 bps threshold, 30min per-mint cooldown
- Set `FRAUD_DETECT_ENABLED=false` to disable the entire loop (e.g. during feed outages causing noisy alerts)
- `keeper_fraud_offchain_unavailable_total` rising for a mint = feed outage, not fraud

## Alert spam prevention

Per-mint cooldown tracked in `_lastAlertByMint: Map<mint, timestamp>`. Second alert within the 30min window is logged at debug level but does not fire Discord or increment the counter.

## Test evidence

```
Test Files  45 passed | 1 skipped (46)
     Tests  574 passed | 23 skipped (597)
```

548 → 574 passing (+26 new tests):
- 19 unit tests (fraud-detector.test.ts)
- 7 property tests, 500 runs each (fraud-detector.property.test.ts)

Properties covered: non-negativity, zero identity, divide-by-zero guard (both bigint and Number), monotonicity, bounded asymmetry, NaN/Infinity exclusion.

## Test plan

- [ ] CI green
- [ ] `FRAUD_DETECT_ENABLED=false` → no interval registered (unit test)
- [ ] 30min cooldown respected — second alert in window suppressed (unit test with fake timers)
- [ ] After cooldown expires, alert re-fires (unit test)
- [ ] `OracleService.fetchPrice` returns null → increments `fraudOffchainUnavailableTotal`, no alert (unit test)
- [ ] Shadow-deploy with `DRY_RUN=true` for 24h to observe divergence gauge values before alerting in prod
- [ ] Tune `FRAUD_DETECT_DIVERGENCE_BPS` if baseline divergence from feed latency is consistently above 200 bps

🤖 Generated with [Claude Code](https://claude.com/claude-code)