### PR TITLE
feat(keeper): Phase 1.5 Workstream J — shadow-keeper observation harness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,3 +123,15 @@ FRAUD_DETECT_ENABLED=true
 FRAUD_DETECT_DIVERGENCE_BPS=500       # alert threshold (500 = 5%)
 FRAUD_DETECT_INTERVAL_MS=30000        # check interval (30s)
 FRAUD_DETECT_PER_MINT_COOLDOWN_MS=1800000  # suppress repeat alerts within 30min per mint
+
+# Shadow-keeper observation harness (Workstream J) — v16 cutover safety net.
+# Enable ONLY in DRY_RUN shadow deploys (separate region, not production primary).
+# When enabled, every "would have fired" transaction is logged to the decision log
+# and a periodic comparison loop cross-checks shadow decisions against live tx counts.
+# If divergence exceeds SHADOW_HARNESS_DIVERGENCE_THRESHOLD_PCT, a Discord WARN fires
+# and the cutover should be blocked until the root cause is understood.
+# Production primary MUST leave this false.
+SHADOW_HARNESS_ENABLED=false
+# SHADOW_HARNESS_COMPARE_WINDOW_MS=300000        # comparison window (5 min default)
+# SHADOW_HARNESS_DIVERGENCE_THRESHOLD_PCT=1.0    # alert threshold (1% default)
+# SHADOW_HARNESS_DECISION_LOG_PATH=/tmp/keeper-decisions.jsonl  # JSONL log path

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ import { LeaderLock, makeIdentity } from "./lib/leader.js";
 import { captureAndExit } from "./lib/exit-handlers.js";
 import { StartupTracker } from "./lib/startup-tracker.js";
 import { sharedTxQueue, DRAIN_TIMEOUT_MS } from "./lib/tx-queue.js";
+import { initSharedShadowHarness, sharedShadowHarness } from "./lib/shadow-harness.js";
+import { sharedDecisionLog } from "./lib/decision-log.js";
 
 // Monitoring — alerts to Discord on threshold breaches
 export const monitors = createServiceMonitors("Keeper");
@@ -512,6 +514,40 @@ res.writeHead(401, secureJsonHeaders);
     const statusCode = currentRole === "standby" ? 200 : status === "down" ? 503 : 200; // "starting", "ok", "degraded" → 200
     res.writeHead(statusCode, secureJsonHeaders);
     res.end(JSON.stringify(healthData));
+  } else if (req.url !== null && req.url !== undefined && (req.url === "/shadow/report" || req.url.startsWith("/shadow/report?")) && req.method === "GET") {
+    // GET /shadow/report?from=<epoch_ms>&to=<epoch_ms>
+    // Returns the current shadow-keeper comparison report.
+    // Only meaningful when SHADOW_HARNESS_ENABLED=true (DRY_RUN shadow deploy).
+    if (process.env.SHADOW_HARNESS_ENABLED !== "true") {
+      res.writeHead(200, secureJsonHeaders);
+      res.end(JSON.stringify({ enabled: false, message: "SHADOW_HARNESS_ENABLED is not set to true" }));
+      return;
+    }
+    const harness = sharedShadowHarness;
+    if (!harness) {
+      res.writeHead(503, secureJsonHeaders);
+      res.end(JSON.stringify({ error: "Shadow harness not initialized" }));
+      return;
+    }
+    void (async () => {
+      try {
+        const urlObj = new URL(req.url!, `http://localhost`);
+        const fromParam = urlObj.searchParams.get("from");
+        const toParam = urlObj.searchParams.get("to");
+        const fromMs = fromParam !== null ? Number(fromParam) : undefined;
+        const toMs = toParam !== null ? Number(toParam) : undefined;
+        const report = await harness.buildReport(
+          fromMs !== undefined && Number.isFinite(fromMs) ? fromMs : undefined,
+          toMs !== undefined && Number.isFinite(toMs) ? toMs : undefined,
+        );
+        res.writeHead(200, secureJsonHeaders);
+        res.end(JSON.stringify({ enabled: true, ...report }));
+      } catch (err) {
+        logger.error("/shadow/report error", { error: err instanceof Error ? err.message : String(err) });
+        res.writeHead(500, secureJsonHeaders);
+        res.end(JSON.stringify({ error: "Internal error" }));
+      }
+    })();
   } else {
     res.writeHead(404, { "Content-Type": "text/plain" });
     res.end("Not Found");
@@ -672,6 +708,20 @@ async function start() {
   registerDefaultMetrics();
   metricsServer.start();
 
+  // J: Shadow harness — only in DRY_RUN shadow deploys.
+  if (process.env.SHADOW_HARNESS_ENABLED === "true") {
+    const conn = (await import("@percolatorct/shared")).getConnection();
+    const harness = initSharedShadowHarness({
+      connection: conn,
+      readDecisions: (fromMs, toMs) => sharedDecisionLog.readWindow(fromMs, toMs),
+    });
+    harness.start();
+    logger.info("Shadow harness started", {
+      compareWindowMs: Number(process.env.SHADOW_HARNESS_COMPARE_WINDOW_MS ?? 300_000),
+      divergenceThresholdPct: Number(process.env.SHADOW_HARNESS_DIVERGENCE_THRESHOLD_PCT ?? 1.0),
+    });
+  }
+
   // Send startup alert
   await sendInfoAlert("Keeper service started", [
     { name: "Markets Tracked", value: markets.length.toString(), inline: true },
@@ -729,6 +779,13 @@ async function shutdown(signal: string): Promise<void> {
       oracle: qStats.oracle,
       crank: qStats.crank,
     });
+
+    // J: Stop shadow harness and flush decision log before releasing leader lock.
+    if (sharedShadowHarness) {
+      sharedShadowHarness.stop();
+      logger.info("Shadow harness stopped");
+    }
+    await sharedDecisionLog.close();
 
     // Stop stale oracle + liquidation + SOL balance checks
     clearInterval(staleCheckInterval);

--- a/src/lib/decision-log.ts
+++ b/src/lib/decision-log.ts
@@ -1,0 +1,155 @@
+/**
+ * DecisionLog — append-only JSONL writer for shadow-keeper decisions.
+ *
+ * Every "would have fired" send from the DRY_RUN intercept in keeper-send.ts
+ * lands here as a structured JSONL line. The comparison loop in
+ * shadow-harness.ts reads back these entries and cross-checks them against the
+ * live keeper's on-chain tx history.
+ *
+ * Design constraints:
+ *   - File writes are ALWAYS swallowed on error — a write failure must never
+ *     propagate to the keeper crank path.
+ *   - Reads iterate lazily: a single malformed line is skipped, not thrown.
+ *   - No buffering beyond the OS page cache: each append is a direct
+ *     fileHandle.write so SIGKILL does not lose in-flight decisions.
+ *   - No new npm deps: uses Node 22 built-in fs/promises only.
+ */
+
+import fs from "node:fs/promises";
+import { createLogger } from "@percolatorct/shared";
+import type { TxType } from "./budget.js";
+import { shadowDecisionsTotal } from "./metrics.js";
+
+const logger = createLogger("keeper:decision-log");
+
+export interface DecisionEntry {
+  timestamp: string;
+  txType: TxType;
+  market: string;
+  accounts: string[];
+  instructionData: string;
+  estimatedCost: number;
+  reasonChain: string[];
+}
+
+export class DecisionLog {
+  private readonly logPath: string;
+  private _handle: fs.FileHandle | null = null;
+  private _opening = false;
+
+  constructor(logPath?: string) {
+    this.logPath = logPath ?? process.env.SHADOW_HARNESS_DECISION_LOG_PATH ?? "/tmp/keeper-decisions.jsonl";
+  }
+
+  private async _getHandle(): Promise<fs.FileHandle | null> {
+    if (this._handle) return this._handle;
+    if (this._opening) return null;
+    this._opening = true;
+    try {
+      this._handle = await fs.open(this.logPath, "a");
+      return this._handle;
+    } catch (err) {
+      logger.error("DecisionLog: failed to open log file", {
+        path: this.logPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    } finally {
+      this._opening = false;
+    }
+  }
+
+  /**
+   * Append a decision entry as a single JSONL line.
+   * Errors are swallowed — a log write failure must not block the crank path.
+   */
+  async append(entry: DecisionEntry): Promise<void> {
+    try {
+      const handle = await this._getHandle();
+      if (!handle) return;
+      const line = JSON.stringify(entry) + "\n";
+      await handle.write(line);
+      shadowDecisionsTotal.inc({ txType: entry.txType });
+    } catch (err) {
+      logger.error("DecisionLog: append failed", {
+        path: this.logPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Read all valid entries from the log file. Malformed lines are skipped.
+   * Returns an empty array if the file does not exist or cannot be read.
+   */
+  async readAll(): Promise<DecisionEntry[]> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.logPath, "utf8");
+    } catch {
+      return [];
+    }
+    const entries: DecisionEntry[] = [];
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (isDecisionEntry(parsed)) {
+          entries.push(parsed);
+        }
+      } catch {
+        // malformed line — skip
+      }
+    }
+    return entries;
+  }
+
+  /**
+   * Read entries within a time window [fromMs, toMs].
+   * fromMs and toMs are Unix epoch milliseconds.
+   */
+  async readWindow(fromMs: number, toMs: number): Promise<DecisionEntry[]> {
+    const all = await this.readAll();
+    return all.filter((e) => {
+      const ts = Date.parse(e.timestamp);
+      return !Number.isNaN(ts) && ts >= fromMs && ts <= toMs;
+    });
+  }
+
+  /**
+   * Flush and close the underlying file handle.
+   * Called during graceful shutdown.
+   */
+  async close(): Promise<void> {
+    if (!this._handle) return;
+    try {
+      await this._handle.close();
+      this._handle = null;
+    } catch (err) {
+      logger.error("DecisionLog: close failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+function isDecisionEntry(v: unknown): v is DecisionEntry {
+  if (typeof v !== "object" || v === null) return false;
+  const e = v as Record<string, unknown>;
+  return (
+    typeof e["timestamp"] === "string" &&
+    typeof e["txType"] === "string" &&
+    typeof e["market"] === "string" &&
+    Array.isArray(e["accounts"]) &&
+    typeof e["instructionData"] === "string" &&
+    typeof e["estimatedCost"] === "number" &&
+    Array.isArray(e["reasonChain"])
+  );
+}
+
+/**
+ * Singleton instance. Import this in keeper-send.ts to append decisions
+ * from the DRY_RUN intercept, and in shadow-harness.ts for reads.
+ */
+export const sharedDecisionLog = new DecisionLog();

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -7,6 +7,7 @@ import type { TxType, TxResult } from "./budget.js";
 import { HeliusPriorityFeeEstimator } from "./priority-fee.js";
 import type { PriorityFeeEstimator, PriorityFeeTier } from "./priority-fee.js";
 import { CuEstimator } from "./cu-estimator.js";
+import { sharedDecisionLog } from "./decision-log.js";
 
 const logger = createLogger("keeper:send");
 
@@ -147,6 +148,31 @@ export async function keeperSend(
       })),
       uniqueAccounts: Array.from(new Set(accountKeys)),
     });
+
+    // When the shadow harness is enabled, log the decision for the comparison
+    // loop. Errors are swallowed inside DecisionLog.append() — they must never
+    // propagate here. When SHADOW_HARNESS_ENABLED is false, this branch still
+    // runs but the append is still called; the decisionLog.append itself is a
+    // no-op overhead of <1ms. If that ever becomes a concern, add the env guard
+    // inside append() rather than here to keep this path readable.
+    if (process.env.SHADOW_HARNESS_ENABLED === "true") {
+      const firstIx = instructions[0];
+      // The market is the first non-system account from the first instruction.
+      // For crank/liquidation/adl ixs the slab address is always at index 0.
+      const market = firstIx?.keys[0]?.pubkey.toBase58() ?? "unknown";
+      const instructionData =
+        firstIx !== undefined ? Buffer.from(firstIx.data).toString("base64") : "";
+      void sharedDecisionLog.append({
+        timestamp: new Date().toISOString(),
+        txType,
+        market,
+        accounts: Array.from(new Set(accountKeys)),
+        instructionData,
+        estimatedCost,
+        reasonChain: [],
+      });
+    }
+
     budget.recordTx(estimatedCost, txType, "success");
     return { signature, estimatedCost, simulatedCu };
   }

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -274,7 +274,33 @@ export const fraudOffchainUnavailableTotal = new Counter({
   registers: [registry],
 });
 
-// Wired in Workstream J (shadow-keeper observation harness PR)
+// ── Workstream J: shadow-keeper observation harness ──────────────────────────
+
+// Incremented on every decision the shadow keeper would have fired.
+// Partitioned by txType so the operator can tell which crank type the shadow
+// is most active on. Wired from decision-log.ts append().
+export const shadowDecisionsTotal = new Counter({
+  name: "keeper_shadow_decisions_total",
+  help: "Total shadow-keeper decisions logged (would-have-fired), partitioned by txType",
+  labelNames: ["txType"] as const,
+  registers: [registry],
+});
+
+// Incremented on every compared decision/tx pair. result is one of:
+//   "match"        — shadow decision matched a live tx
+//   "live_only"    — live tx had no corresponding shadow decision
+//   "shadow_only"  — shadow decision had no corresponding live tx
+// Wired from shadow-harness.ts compare().
+export const shadowMatchTotal = new Counter({
+  name: "keeper_shadow_match_total",
+  help: "Total shadow-keeper comparison outcomes, partitioned by txType and result",
+  labelNames: ["txType", "result"] as const,
+  registers: [registry],
+});
+
+// Updated after each comparison cycle. divergence_pct per txType computed
+// independently: (live_only + shadow_only) / total * 100. Wired from
+// shadow-harness.ts compare().
 export const shadowDivergencePct = new Gauge({
   name: "keeper_shadow_divergence_pct",
   help: "Divergence percentage between shadow-keeper decision and live-keeper decision, partitioned by txType",

--- a/src/lib/shadow-harness.ts
+++ b/src/lib/shadow-harness.ts
@@ -1,0 +1,304 @@
+/**
+ * ShadowHarness — comparison loop for the shadow-keeper observation harness.
+ *
+ * When SHADOW_HARNESS_ENABLED=true the keeper runs in DRY_RUN mode in a
+ * separate shadow region. Every "would have fired" decision is logged by
+ * DecisionLog. This harness runs a periodic comparison loop that cross-checks
+ * those decisions against the live keeper's on-chain tx count (via
+ * getSignaturesForAddress on the program id) and fires a Discord WARN if
+ * divergence exceeds the configured threshold.
+ *
+ * v1 matching strategy — aggregate divergence:
+ *   divergence_pct = |shadow_total - live_total| / max(shadow_total, live_total, 1) * 100
+ *
+ * Rationale: a per-tx match requires one getTransaction RPC call per live tx
+ * (up to 1000 calls per comparison cycle). At production scale that would take
+ * 10–100 seconds per cycle and consume most of our RPC quota. Aggregate
+ * comparison detects the failure modes we care about (shadow over-fires or
+ * under-fires) without that cost. A TODO is left for per-tx matching once a
+ * memo-based txType tag is available on live txs.
+ *
+ * TODO(phase2): when live txs include a memo with txType, match per-(txType+window)
+ * rather than just aggregate counts.
+ *
+ * Design constraints:
+ *   - The comparison loop must NEVER block or crash the keeper.
+ *   - All errors (RPC, file-read, Discord) are swallowed with logger.error.
+ *   - The /shadow/report endpoint is served on the existing health server
+ *     (port 8081) via the caller wiring in index.ts — this module just exposes
+ *     buildReport() for that endpoint to call.
+ */
+
+import type { Connection } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
+import { createLogger, sendWarningAlert } from "@percolatorct/shared";
+import type { DecisionEntry } from "./decision-log.js";
+import type { TxType } from "./budget.js";
+import {
+  shadowMatchTotal,
+  shadowDivergencePct,
+} from "./metrics.js";
+
+const logger = createLogger("keeper:shadow-harness");
+
+const DEFAULT_COMPARE_WINDOW_MS = 300_000; // 5 minutes
+const DEFAULT_DIVERGENCE_THRESHOLD_PCT = 1.0;
+// When the program id is not set in env, fall back to the mainnet constant.
+// This constant must match MAINNET_PROGRAM_ID in boot-assertions.ts.
+const FALLBACK_PROGRAM_ID = "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv";
+
+export interface ShadowCompareResult {
+  windowMs: number;
+  fromMs: number;
+  toMs: number;
+  shadowTotal: number;
+  liveTotal: number;
+  divergencePct: number;
+  /** Per-txType breakdown of shadow decisions in the window. */
+  shadowByType: Record<string, number>;
+}
+
+export interface ShadowReportResult {
+  fromMs: number;
+  toMs: number;
+  shadowTotal: number;
+  liveTotal: number;
+  divergencePct: number;
+  shadowByType: Record<string, number>;
+}
+
+/**
+ * Pure divergence formula — exported so property tests can exercise it in
+ * isolation without any I/O.
+ *
+ * Returns a value in [0, 100]. Returns 0 when both totals are 0 (no activity,
+ * no divergence). Returns 100 when one side is 0 and the other is non-zero.
+ */
+export function computeDivergencePct(shadowTotal: number, liveTotal: number): number {
+  const maxTotal = Math.max(shadowTotal, liveTotal);
+  if (maxTotal === 0) return 0;
+  const diff = Math.abs(shadowTotal - liveTotal);
+  return Math.min((diff / maxTotal) * 100, 100);
+}
+
+interface ShadowHarnessDeps {
+  connection: Connection;
+  programId?: string;
+  readDecisions: (fromMs: number, toMs: number) => Promise<DecisionEntry[]>;
+  now?: () => number;
+  compareWindowMs?: number;
+  divergenceThresholdPct?: number;
+}
+
+export class ShadowHarness {
+  private readonly connection: Connection;
+  private readonly programId: PublicKey;
+  private readonly readDecisions: (fromMs: number, toMs: number) => Promise<DecisionEntry[]>;
+  private readonly _now: () => number;
+  private readonly compareWindowMs: number;
+  private readonly divergenceThresholdPct: number;
+  private _intervalHandle: ReturnType<typeof setInterval> | null = null;
+  /** Last comparison result — used by buildReport(). */
+  private _lastResult: ShadowCompareResult | null = null;
+
+  constructor(deps: ShadowHarnessDeps) {
+    this.connection = deps.connection;
+    const rawProgramId =
+      deps.programId ??
+      process.env.PROGRAM_ID ??
+      FALLBACK_PROGRAM_ID;
+    this.programId = new PublicKey(rawProgramId);
+    this.readDecisions = deps.readDecisions;
+    this._now = deps.now ?? (() => Date.now());
+    this.compareWindowMs =
+      deps.compareWindowMs ??
+      Number(process.env.SHADOW_HARNESS_COMPARE_WINDOW_MS ?? DEFAULT_COMPARE_WINDOW_MS);
+    this.divergenceThresholdPct =
+      deps.divergenceThresholdPct ??
+      Number(process.env.SHADOW_HARNESS_DIVERGENCE_THRESHOLD_PCT ?? DEFAULT_DIVERGENCE_THRESHOLD_PCT);
+  }
+
+  /**
+   * Start the periodic comparison loop.
+   * Safe to call multiple times — second call is a no-op.
+   */
+  start(): void {
+    if (this._intervalHandle !== null) return;
+    logger.info("ShadowHarness: comparison loop started", {
+      compareWindowMs: this.compareWindowMs,
+      divergenceThresholdPct: this.divergenceThresholdPct,
+      programId: this.programId.toBase58(),
+    });
+    // Run immediately, then on the interval.
+    void this._runCycle();
+    this._intervalHandle = setInterval(() => {
+      void this._runCycle();
+    }, this.compareWindowMs);
+    this._intervalHandle.unref();
+  }
+
+  /**
+   * Stop the comparison loop.
+   */
+  stop(): void {
+    if (this._intervalHandle === null) return;
+    clearInterval(this._intervalHandle);
+    this._intervalHandle = null;
+    logger.info("ShadowHarness: comparison loop stopped");
+  }
+
+  /**
+   * Run one comparison cycle. Called by the interval and exposed for testing.
+   * Errors are fully swallowed.
+   */
+  async runCycle(): Promise<ShadowCompareResult> {
+    return this._runCycle();
+  }
+
+  private async _runCycle(): Promise<ShadowCompareResult> {
+    const toMs = this._now();
+    const fromMs = toMs - this.compareWindowMs;
+    const result = await this._compare(fromMs, toMs);
+    this._lastResult = result;
+    return result;
+  }
+
+  private async _compare(fromMs: number, toMs: number): Promise<ShadowCompareResult> {
+    const windowMs = toMs - fromMs;
+
+    let decisions: DecisionEntry[] = [];
+    try {
+      decisions = await this.readDecisions(fromMs, toMs);
+    } catch (err) {
+      logger.error("ShadowHarness: failed to read decisions", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const shadowTotal = decisions.length;
+
+    // Aggregate shadow decisions by txType.
+    const shadowByType: Record<string, number> = {};
+    for (const d of decisions) {
+      shadowByType[d.txType] = (shadowByType[d.txType] ?? 0) + 1;
+    }
+
+    let liveTotal = 0;
+    try {
+      const fromSec = Math.floor(fromMs / 1000);
+      const toSec = Math.floor(toMs / 1000);
+      const signatures = await this.connection.getSignaturesForAddress(
+        this.programId,
+        { limit: 1000 },
+      );
+      // Filter by blockTime within the window.
+      liveTotal = signatures.filter((s) => {
+        const bt = s.blockTime;
+        return bt !== null && bt !== undefined && bt >= fromSec && bt <= toSec;
+      }).length;
+    } catch (err) {
+      logger.error("ShadowHarness: getSignaturesForAddress failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const divergencePct = computeDivergencePct(shadowTotal, liveTotal);
+
+    // Per-txType metrics. Since we have no per-type breakdown for live txs in
+    // v1, we record aggregate metrics under a synthetic "all" label and per-type
+    // shadow-only counts. The gauge gets one entry per known txType.
+    const allTxTypes: TxType[] = ["crank", "liquidation", "oracle", "adl"];
+    for (const txType of allTxTypes) {
+      const shadowTypeTotal = shadowByType[txType] ?? 0;
+      // In v1 we don't have per-type live counts, so divergence per type is
+      // only meaningful for shadow-only cases. We still emit the gauge so
+      // dashboards have a stable label set.
+      shadowDivergencePct.set({ txType }, shadowTypeTotal === 0 ? 0 : divergencePct);
+    }
+
+    // Aggregate comparison outcome metrics.
+    const liveOnly = Math.max(0, liveTotal - shadowTotal);
+    const shadowOnly = Math.max(0, shadowTotal - liveTotal);
+    const matches = Math.min(shadowTotal, liveTotal);
+
+    for (const txType of allTxTypes) {
+      const frac = shadowTotal > 0 ? (shadowByType[txType] ?? 0) / shadowTotal : 0;
+      const typeMatches = Math.round(matches * frac);
+      const typeShadowOnly = Math.round(shadowOnly * frac);
+      if (typeMatches > 0) {
+        shadowMatchTotal.inc({ txType, result: "match" }, typeMatches);
+      }
+      if (typeShadowOnly > 0) {
+        shadowMatchTotal.inc({ txType, result: "shadow_only" }, typeShadowOnly);
+      }
+    }
+    if (liveOnly > 0) {
+      // live_only cannot be attributed to a txType without per-tx RPC lookup.
+      // Record under a synthetic "unknown" label so the counter is not lost.
+      shadowMatchTotal.inc({ txType: "unknown" as TxType, result: "live_only" }, liveOnly);
+    }
+
+    logger.info("ShadowHarness: comparison cycle complete", {
+      fromMs,
+      toMs,
+      shadowTotal,
+      liveTotal,
+      divergencePct: divergencePct.toFixed(2),
+    });
+
+    // Alert if divergence exceeds threshold.
+    if (divergencePct > this.divergenceThresholdPct) {
+      sendWarningAlert("Shadow keeper divergence threshold exceeded", [
+        { name: "Shadow Total", value: String(shadowTotal), inline: true },
+        { name: "Live Total", value: String(liveTotal), inline: true },
+        { name: "Divergence", value: `${divergencePct.toFixed(2)}%`, inline: true },
+        { name: "Threshold", value: `${this.divergenceThresholdPct}%`, inline: true },
+        { name: "Window", value: `${Math.round(windowMs / 60_000)} min`, inline: true },
+      ]).catch(() => {});
+    }
+
+    return {
+      windowMs,
+      fromMs,
+      toMs,
+      shadowTotal,
+      liveTotal,
+      divergencePct,
+      shadowByType,
+    };
+  }
+
+  /**
+   * Build the report object for the /shadow/report endpoint.
+   * fromMs and toMs are optional — defaults to last comparison window.
+   */
+  async buildReport(fromMs?: number, toMs?: number): Promise<ShadowReportResult> {
+    const now = this._now();
+    const effectiveTo = toMs ?? now;
+    const effectiveFrom = fromMs ?? effectiveTo - this.compareWindowMs;
+    const result = await this._compare(effectiveFrom, effectiveTo);
+    return {
+      fromMs: result.fromMs,
+      toMs: result.toMs,
+      shadowTotal: result.shadowTotal,
+      liveTotal: result.liveTotal,
+      divergencePct: result.divergencePct,
+      shadowByType: result.shadowByType,
+    };
+  }
+
+  getLastResult(): ShadowCompareResult | null {
+    return this._lastResult;
+  }
+}
+
+/**
+ * Singleton factory — call initSharedShadowHarness() from index.ts after the
+ * connection is available.  sharedShadowHarness is null until that call.
+ */
+export let sharedShadowHarness: ShadowHarness | null = null;
+
+export function initSharedShadowHarness(deps: ShadowHarnessDeps): ShadowHarness {
+  sharedShadowHarness = new ShadowHarness(deps);
+  return sharedShadowHarness;
+}

--- a/tests/lib/decision-log.test.ts
+++ b/tests/lib/decision-log.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/lib/metrics.js", () => ({
+  shadowDecisionsTotal: { inc: vi.fn() },
+  shadowMatchTotal: { inc: vi.fn() },
+  shadowDivergencePct: { set: vi.fn() },
+}));
+
+import { DecisionLog } from "../../src/lib/decision-log.js";
+import type { DecisionEntry } from "../../src/lib/decision-log.js";
+
+function makeEntry(overrides: Partial<DecisionEntry> = {}): DecisionEntry {
+  return {
+    timestamp: new Date().toISOString(),
+    txType: "crank",
+    market: "F4HytAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    accounts: ["pk1", "pk2"],
+    instructionData: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]).toString("base64"),
+    estimatedCost: 5_000,
+    reasonChain: [],
+    ...overrides,
+  };
+}
+
+async function makeTempLog(): Promise<{ log: DecisionLog; logPath: string }> {
+  const logPath = path.join(os.tmpdir(), `keeper-test-decisions-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`);
+  const log = new DecisionLog(logPath);
+  return { log, logPath };
+}
+
+describe("DecisionLog — JSONL writes", () => {
+  it("writes a single entry as a valid JSON line", async () => {
+    const { log, logPath } = await makeTempLog();
+    try {
+      const entry = makeEntry();
+      await log.append(entry);
+      await log.close();
+      const raw = await fs.readFile(logPath, "utf8");
+      const lines = raw.split("\n").filter((l) => l.trim());
+      expect(lines).toHaveLength(1);
+      const parsed = JSON.parse(lines[0]!) as DecisionEntry;
+      expect(parsed.txType).toBe("crank");
+      expect(parsed.estimatedCost).toBe(5_000);
+    } finally {
+      await fs.unlink(logPath).catch(() => {});
+    }
+  });
+
+  it("each line is independently parseable JSON", async () => {
+    const { log, logPath } = await makeTempLog();
+    try {
+      for (let i = 0; i < 5; i++) {
+        await log.append(makeEntry({ estimatedCost: i * 1_000 }));
+      }
+      await log.close();
+      const raw = await fs.readFile(logPath, "utf8");
+      const lines = raw.split("\n").filter((l) => l.trim());
+      expect(lines).toHaveLength(5);
+      for (const line of lines) {
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+    } finally {
+      await fs.unlink(logPath).catch(() => {});
+    }
+  });
+
+  it("lines are separated by newlines, not concatenated", async () => {
+    const { log, logPath } = await makeTempLog();
+    try {
+      await log.append(makeEntry({ market: "AAA" }));
+      await log.append(makeEntry({ market: "BBB" }));
+      await log.close();
+      const raw = await fs.readFile(logPath, "utf8");
+      // Must end with a newline after last entry
+      expect(raw.endsWith("\n")).toBe(true);
+      // Must have exactly 2 newlines for 2 entries
+      expect(raw.split("\n").filter((l) => l.trim()).length).toBe(2);
+    } finally {
+      await fs.unlink(logPath).catch(() => {});
+    }
+  });
+});
+
+describe("DecisionLog — append-only (existing entries preserved)", () => {
+  it("appending to an existing file preserves prior entries", async () => {
+    const { log: log1, logPath } = await makeTempLog();
+    try {
+      await log1.append(makeEntry({ market: "FIRST" }));
+      await log1.close();
+
+      const log2 = new DecisionLog(logPath);
+      await log2.append(makeEntry({ market: "SECOND" }));
+      await log2.close();
+
+      const entries = await new DecisionLog(logPath).readAll();
+      expect(entries).toHaveLength(2);
+      expect(entries[0]!.market).toBe("FIRST");
+      expect(entries[1]!.market).toBe("SECOND");
+    } finally {
+      await fs.unlink(logPath).catch(() => {});
+    }
+  });
+});
+
+describe("DecisionLog — read round-trip", () => {
+  it("write 100 entries, read back 100 entries", async () => {
+    const { log, logPath } = await makeTempLog();
+    try {
+      for (let i = 0; i < 100; i++) {
+        await log.append(makeEntry({ estimatedCost: i, txType: i % 2 === 0 ? "crank" : "liquidation" }));
+      }
+      await log.close();
+
+      const readLog = new DecisionLog(logPath);
+      const entries = await readLog.readAll();
+      expect(entries).toHaveLength(100);
+      // Spot check: first and last
+      expect(entries[0]!.estimatedCost).toBe(0);
+      expect(entries[99]!.estimatedCost).toBe(99);
+    } finally {
+      await fs.unlink(logPath).catch(() => {});
+    }
+  });
+
+  it("returns empty array when file does not exist", async () => {
+    const log = new DecisionLog("/tmp/nonexistent-keeper-decisions-" + Date.now() + ".jsonl");
+    const entries = await log.readAll();
+    expect(entries).toHaveLength(0);
+  });
+});
+
+describe("DecisionLog — malformed line skipping (chaos)", () => {
+  it("skips 1 malformed line in the middle of 100 good ones → yields 99", async () => {
+    const logPath = path.join(os.tmpdir(), `keeper-chaos-${Date.now()}.jsonl`);
+    try {
+      const goodEntry = JSON.stringify(makeEntry()) + "\n";
+      // Write 50 good, then 1 malformed, then 49 good
+      const lines = [
+        ...Array.from({ length: 50 }, () => goodEntry),
+        "NOT VALID JSON }{{\n",
+        ...Array.from({ length: 49 }, () => goodEntry),
+      ].join("");
+      await fs.writeFile(logPath, lines, "utf8");
+
+      const log = new DecisionLog(logPath);
+      const entries = await log.readAll();
+      expect(entries).toHaveLength(99);
+    } finally {
+      await fs.unlink(logPath).catch(() => {});
+    }
+  });
+
+  it("skips a line that is valid JSON but missing required fields", async () => {
+    const logPath = path.join(os.tmpdir(), `keeper-schema-${Date.now()}.jsonl`);
+    try {
+      const good = JSON.stringify(makeEntry()) + "\n";
+      const bad = JSON.stringify({ foo: "bar" }) + "\n"; // missing DecisionEntry fields
+      await fs.writeFile(logPath, good + bad + good, "utf8");
+
+      const log = new DecisionLog(logPath);
+      const entries = await log.readAll();
+      expect(entries).toHaveLength(2);
+    } finally {
+      await fs.unlink(logPath).catch(() => {});
+    }
+  });
+});
+
+describe("DecisionLog — time window filtering", () => {
+  it("readWindow returns only entries within [fromMs, toMs]", async () => {
+    const { log, logPath } = await makeTempLog();
+    try {
+      const now = Date.now();
+      const old = new Date(now - 600_000).toISOString(); // 10 min ago
+      const recent = new Date(now - 60_000).toISOString(); // 1 min ago
+
+      await log.append(makeEntry({ timestamp: old, market: "OLD" }));
+      await log.append(makeEntry({ timestamp: recent, market: "RECENT" }));
+      await log.close();
+
+      const readLog = new DecisionLog(logPath);
+      const window = await readLog.readWindow(now - 120_000, now);
+      expect(window).toHaveLength(1);
+      expect(window[0]!.market).toBe("RECENT");
+    } finally {
+      await fs.unlink(logPath).catch(() => {});
+    }
+  });
+});
+
+describe("DecisionLog — metrics wiring", () => {
+  it("increments shadowDecisionsTotal counter on each append", async () => {
+    const { log, logPath } = await makeTempLog();
+    try {
+      const { shadowDecisionsTotal } = await import("../../src/lib/metrics.js");
+      await log.append(makeEntry({ txType: "liquidation" }));
+      expect(vi.mocked(shadowDecisionsTotal.inc)).toHaveBeenCalledWith({ txType: "liquidation" });
+    } finally {
+      await log.close();
+      await fs.unlink(logPath).catch(() => {});
+    }
+  });
+});

--- a/tests/lib/shadow-harness.property.test.ts
+++ b/tests/lib/shadow-harness.property.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Property tests for shadow-harness divergence formula.
+ * ≥500 runs per property (fast-check default ≥ 100, overridden to 500 here).
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { computeDivergencePct } from "../../src/lib/shadow-harness.js";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  sendWarningAlert: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../src/lib/metrics.js", () => ({
+  shadowDecisionsTotal: { inc: vi.fn() },
+  shadowMatchTotal: { inc: vi.fn() },
+  shadowDivergencePct: { set: vi.fn() },
+}));
+
+import { vi } from "vitest";
+
+const NUM_RUNS = 500;
+
+// Arbitrary non-negative safe integer for shadow/live totals.
+const nonNegSafeInt = fc.nat({ max: Number.MAX_SAFE_INTEGER });
+
+describe("computeDivergencePct — property tests (≥500 runs)", () => {
+  it("result is always in [0, 100] for any non-negative integers", () => {
+    fc.assert(
+      fc.property(nonNegSafeInt, nonNegSafeInt, (shadow, live) => {
+        const result = computeDivergencePct(shadow, live);
+        return result >= 0 && result <= 100;
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it("result is never NaN for any non-negative integers", () => {
+    fc.assert(
+      fc.property(nonNegSafeInt, nonNegSafeInt, (shadow, live) => {
+        const result = computeDivergencePct(shadow, live);
+        return !Number.isNaN(result);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it("result is never Infinity for any non-negative integers", () => {
+    fc.assert(
+      fc.property(nonNegSafeInt, nonNegSafeInt, (shadow, live) => {
+        const result = computeDivergencePct(shadow, live);
+        return Number.isFinite(result);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it("when both are 0, result is 0 (no activity = no divergence)", () => {
+    expect(computeDivergencePct(0, 0)).toBe(0);
+  });
+
+  it("when shadow === live AND both > 0, result is 0 (perfect match)", () => {
+    fc.assert(
+      fc.property(fc.nat({ max: 1_000_000 }), (n) => {
+        if (n === 0) return true; // 0,0 case handled above
+        return computeDivergencePct(n, n) === 0;
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it("when matches=0 (one side is 0) and other > 0, result is 100", () => {
+    fc.assert(
+      fc.property(fc.nat({ max: 1_000_000 }), (n) => {
+        if (n === 0) return true; // 0,0 case handled separately
+        return computeDivergencePct(n, 0) === 100 && computeDivergencePct(0, n) === 100;
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it("divergence is symmetric: computeDivergencePct(a, b) === computeDivergencePct(b, a)", () => {
+    fc.assert(
+      fc.property(nonNegSafeInt, nonNegSafeInt, (a, b) => {
+        return computeDivergencePct(a, b) === computeDivergencePct(b, a);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it("divergence is monotone: more imbalanced inputs produce >= divergence", () => {
+    // shadow=n, live=2n is more imbalanced than shadow=n, live=n+1
+    fc.assert(
+      fc.property(fc.nat({ max: 100_000 }), (n) => {
+        if (n === 0) return true;
+        const balanced = computeDivergencePct(n, n + 1);
+        const imbalanced = computeDivergencePct(n, 2 * n);
+        return imbalanced >= balanced;
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});

--- a/tests/lib/shadow-harness.stress.test.ts
+++ b/tests/lib/shadow-harness.stress.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Stress + chaos tests for shadow-harness comparison loop.
+ * Gated by STRESS=true so CI runs are fast.
+ * Target: 10k decision-log entries + 10k live signatures — comparison <5s wall-clock.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  sendWarningAlert: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../src/lib/metrics.js", () => ({
+  shadowDecisionsTotal: { inc: vi.fn() },
+  shadowMatchTotal: { inc: vi.fn() },
+  shadowDivergencePct: { set: vi.fn() },
+}));
+
+import { DecisionLog } from "../../src/lib/decision-log.js";
+import { ShadowHarness } from "../../src/lib/shadow-harness.js";
+import type { DecisionEntry } from "../../src/lib/decision-log.js";
+import type { Connection } from "@solana/web3.js";
+
+const N = 10_000;
+const DIVERGENCE_FRACTION = 0.05; // 5% intentional divergence
+const PROGRAM_ID = "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv";
+
+// Span all entries within the last 60 seconds so the 5-min window covers all of them.
+// Entry i gets timestamp = now - (N - i) * 6ms, so oldest is now - 60s, newest is now.
+function makeEntry(i: number): DecisionEntry {
+  return {
+    timestamp: new Date(Date.now() - (N - i) * 6).toISOString(),
+    txType: i % 4 === 0 ? "liquidation" : i % 4 === 1 ? "oracle" : i % 4 === 2 ? "adl" : "crank",
+    market: `Market${(i % 10).toString().padStart(40, "A")}`,
+    accounts: [`pk${i}`, `pk${i + 1}`],
+    instructionData: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]).toString("base64"),
+    estimatedCost: 5_000 + i,
+    reasonChain: [],
+  };
+}
+
+function makeConnection(liveCount: number): Connection {
+  const now = Math.floor(Date.now() / 1000);
+  const sigs = Array.from({ length: liveCount }, (_, i) => ({
+    signature: `livesig_${i}`,
+    slot: 2_000_000 + i,
+    // All within last 5 min window
+    blockTime: now - Math.floor(Math.random() * 280),
+    err: null,
+    memo: null,
+    confirmationStatus: "finalized" as const,
+  }));
+  return {
+    getSignaturesForAddress: vi.fn(async () => sigs),
+  } as unknown as Connection;
+}
+
+describe.skipIf(!process.env.STRESS)("ShadowHarness STRESS — 10k entries", { timeout: 30_000 }, () => {
+  let logPath: string;
+  let log: DecisionLog;
+
+  beforeAll(async () => {
+    logPath = path.join(os.tmpdir(), `keeper-stress-${Date.now()}.jsonl`);
+    log = new DecisionLog(logPath);
+    for (let i = 0; i < N; i++) {
+      await log.append(makeEntry(i));
+    }
+    await log.close();
+  });
+
+  afterAll(async () => {
+    await fs.unlink(logPath).catch(() => {});
+  });
+
+  it("10k decisions + 10k live sigs: comparison completes in <5s", async () => {
+    // 5% divergence: shadow=10k, live=9500
+    const liveCount = Math.floor(N * (1 - DIVERGENCE_FRACTION));
+    const conn = makeConnection(liveCount);
+    const readLog = new DecisionLog(logPath);
+
+    const harness = new ShadowHarness({
+      connection: conn,
+      programId: PROGRAM_ID,
+      readDecisions: (fromMs, toMs) => readLog.readWindow(fromMs, toMs),
+      compareWindowMs: 300_000,
+      divergenceThresholdPct: 99, // disable alert for stress test
+    });
+
+    const start = Date.now();
+    const result = await harness.runCycle();
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(5_000);
+    expect(result.shadowTotal).toBe(N);
+    expect(result.liveTotal).toBe(liveCount);
+    expect(result.divergencePct).toBeGreaterThan(0);
+    expect(result.divergencePct).toBeLessThanOrEqual(100);
+  });
+
+  it("CHAOS: prepend malformed line — comparison succeeds with 9999 valid entries", async () => {
+    const chaoPath = path.join(os.tmpdir(), `keeper-chaos-stress-${Date.now()}.jsonl`);
+    try {
+      // Write the malformed line first, then all 10k good entries
+      const goodRaw = await fs.readFile(logPath, "utf8");
+      await fs.writeFile(chaoPath, "MALFORMED_JSON_LINE\n" + goodRaw, "utf8");
+
+      const liveCount = N;
+      const conn = makeConnection(liveCount);
+      const readLog = new DecisionLog(chaoPath);
+
+      const harness = new ShadowHarness({
+        connection: conn,
+        programId: PROGRAM_ID,
+        readDecisions: (fromMs, toMs) => readLog.readWindow(fromMs, toMs),
+        compareWindowMs: 300_000,
+        divergenceThresholdPct: 99,
+      });
+
+      const start = Date.now();
+      const result = await harness.runCycle();
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(5_000);
+      // The malformed line is skipped; valid entries = N
+      // (All N entries are within window since they're timestamped within last 5 min)
+      expect(result.shadowTotal).toBe(N);
+      expect(result.divergencePct).toBeGreaterThanOrEqual(0);
+      expect(result.divergencePct).toBeLessThanOrEqual(100);
+    } finally {
+      await fs.unlink(chaoPath).catch(() => {});
+    }
+  });
+
+  it("read 10k entries round-trip via DecisionLog", async () => {
+    const readLog = new DecisionLog(logPath);
+    const entries = await readLog.readAll();
+    expect(entries).toHaveLength(N);
+  });
+});

--- a/tests/lib/shadow-harness.test.ts
+++ b/tests/lib/shadow-harness.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  sendWarningAlert: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../src/lib/metrics.js", () => ({
+  shadowDecisionsTotal: { inc: vi.fn() },
+  shadowMatchTotal: { inc: vi.fn() },
+  shadowDivergencePct: { set: vi.fn() },
+}));
+
+import * as shared from "@percolatorct/shared";
+import { ShadowHarness, computeDivergencePct } from "../../src/lib/shadow-harness.js";
+import type { DecisionEntry } from "../../src/lib/decision-log.js";
+import type { Connection } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
+
+const PROGRAM_ID = "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv";
+
+function makeDecision(
+  txType: DecisionEntry["txType"] = "crank",
+  market = "F4HytAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+): DecisionEntry {
+  return {
+    timestamp: new Date().toISOString(),
+    txType,
+    market,
+    accounts: ["pk1", "pk2"],
+    instructionData: "AQIDBAUG",
+    estimatedCost: 5_000,
+    reasonChain: [],
+  };
+}
+
+function makeConnection(signatureCount = 5): Connection {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    getSignaturesForAddress: vi.fn(async () =>
+      Array.from({ length: signatureCount }, (_, i) => ({
+        signature: `sig_${i}`,
+        slot: 1_000_000 + i,
+        // All within the last 60s so they always fall inside the 300s window
+        blockTime: now - (i % 60),
+        err: null,
+        memo: null,
+        confirmationStatus: "finalized" as const,
+      })),
+    ),
+  } as unknown as Connection;
+}
+
+function makeHarness(
+  decisions: DecisionEntry[],
+  signatureCount = decisions.length,
+  threshold = 1.0,
+): ShadowHarness {
+  const conn = makeConnection(signatureCount);
+  return new ShadowHarness({
+    connection: conn,
+    programId: PROGRAM_ID,
+    readDecisions: vi.fn(async () => decisions),
+    compareWindowMs: 300_000,
+    divergenceThresholdPct: threshold,
+  });
+}
+
+describe("computeDivergencePct — pure formula", () => {
+  it("returns 0 when both are 0", () => {
+    expect(computeDivergencePct(0, 0)).toBe(0);
+  });
+
+  it("returns 0 when shadow === live (perfect match)", () => {
+    expect(computeDivergencePct(10, 10)).toBe(0);
+    expect(computeDivergencePct(1, 1)).toBe(0);
+    expect(computeDivergencePct(1000, 1000)).toBe(0);
+  });
+
+  it("returns 100 when one side is 0", () => {
+    expect(computeDivergencePct(0, 100)).toBe(100);
+    expect(computeDivergencePct(100, 0)).toBe(100);
+  });
+
+  it("returns correct percentage for partial divergence", () => {
+    // shadow=50, live=100 → diff=50, max=100 → 50%
+    expect(computeDivergencePct(50, 100)).toBe(50);
+    // shadow=100, live=50 → diff=50, max=100 → 50%
+    expect(computeDivergencePct(100, 50)).toBe(50);
+  });
+
+  it("result is always in [0, 100]", () => {
+    expect(computeDivergencePct(0, 0)).toBeGreaterThanOrEqual(0);
+    expect(computeDivergencePct(Number.MAX_SAFE_INTEGER, 0)).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("ShadowHarness — comparison logic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.SHADOW_HARNESS_ENABLED;
+  });
+
+  it("returns zero divergence when shadow and live counts match", async () => {
+    const decisions = Array.from({ length: 5 }, () => makeDecision());
+    const harness = makeHarness(decisions, 5);
+    const result = await harness.runCycle();
+    expect(result.shadowTotal).toBe(5);
+    expect(result.liveTotal).toBe(5);
+    expect(result.divergencePct).toBe(0);
+  });
+
+  it("detects live-only divergence (live > shadow)", async () => {
+    const decisions = Array.from({ length: 3 }, () => makeDecision());
+    const harness = makeHarness(decisions, 10); // 10 live, 3 shadow
+    const result = await harness.runCycle();
+    expect(result.shadowTotal).toBe(3);
+    expect(result.liveTotal).toBe(10);
+    expect(result.divergencePct).toBeGreaterThan(0);
+  });
+
+  it("detects shadow-only divergence (shadow > live)", async () => {
+    const decisions = Array.from({ length: 20 }, () => makeDecision());
+    const harness = makeHarness(decisions, 5); // 5 live, 20 shadow
+    const result = await harness.runCycle();
+    expect(result.shadowTotal).toBe(20);
+    expect(result.liveTotal).toBe(5);
+    expect(result.divergencePct).toBeGreaterThan(0);
+  });
+
+  it("per-txType breakdown in shadowByType is accurate", async () => {
+    const decisions = [
+      ...Array.from({ length: 4 }, () => makeDecision("crank")),
+      ...Array.from({ length: 6 }, () => makeDecision("liquidation")),
+    ];
+    const harness = makeHarness(decisions, 10);
+    const result = await harness.runCycle();
+    expect(result.shadowByType["crank"]).toBe(4);
+    expect(result.shadowByType["liquidation"]).toBe(6);
+    expect(result.shadowByType["oracle"]).toBeUndefined();
+  });
+
+  it("discord alert fires when divergence_pct > threshold", async () => {
+    const decisions = Array.from({ length: 1 }, () => makeDecision());
+    const harness = makeHarness(decisions, 100, 1.0); // shadow=1, live=100 → ~99% divergence
+    await harness.runCycle();
+    expect(vi.mocked(shared.sendWarningAlert)).toHaveBeenCalledOnce();
+    const [title] = vi.mocked(shared.sendWarningAlert).mock.calls[0]!;
+    expect(title).toContain("divergence");
+  });
+
+  it("discord alert does NOT fire when divergence_pct <= threshold", async () => {
+    const decisions = Array.from({ length: 10 }, () => makeDecision());
+    const harness = makeHarness(decisions, 10, 1.0); // perfect match → 0% divergence
+    await harness.runCycle();
+    expect(vi.mocked(shared.sendWarningAlert)).not.toHaveBeenCalled();
+  });
+
+  it("discord alert does NOT fire when divergence_pct is exactly at threshold", async () => {
+    // shadow=50, live=100 → 50% divergence; threshold=51 → no alert
+    const decisions = Array.from({ length: 50 }, () => makeDecision());
+    const harness = makeHarness(decisions, 100, 51.0);
+    await harness.runCycle();
+    expect(vi.mocked(shared.sendWarningAlert)).not.toHaveBeenCalled();
+  });
+
+  it("RPC failure is swallowed — result has liveTotal=0", async () => {
+    const conn = {
+      getSignaturesForAddress: vi.fn(async () => { throw new Error("RPC down"); }),
+    } as unknown as Connection;
+    const harness = new ShadowHarness({
+      connection: conn,
+      programId: PROGRAM_ID,
+      readDecisions: vi.fn(async () => [makeDecision()]),
+      compareWindowMs: 300_000,
+      divergenceThresholdPct: 99,
+    });
+    const result = await harness.runCycle();
+    expect(result.liveTotal).toBe(0);
+    expect(result.shadowTotal).toBe(1);
+    // 100% divergence but threshold is 99 — should still alert
+    expect(vi.mocked(shared.sendWarningAlert)).toHaveBeenCalled();
+  });
+
+  it("decision read failure is swallowed — result has shadowTotal=0", async () => {
+    const conn = makeConnection(5);
+    const harness = new ShadowHarness({
+      connection: conn,
+      programId: PROGRAM_ID,
+      readDecisions: vi.fn(async () => { throw new Error("fs failure"); }),
+      compareWindowMs: 300_000,
+      divergenceThresholdPct: 99,
+    });
+    const result = await harness.runCycle();
+    expect(result.shadowTotal).toBe(0);
+    expect(result.liveTotal).toBeGreaterThan(0);
+  });
+
+  it("getLastResult() returns null before first cycle, then the result", async () => {
+    const harness = makeHarness([], 0);
+    expect(harness.getLastResult()).toBeNull();
+    await harness.runCycle();
+    expect(harness.getLastResult()).not.toBeNull();
+  });
+
+  it("start/stop lifecycle does not throw", () => {
+    const harness = makeHarness([], 0);
+    expect(() => harness.start()).not.toThrow();
+    expect(() => harness.start()).not.toThrow(); // idempotent
+    expect(() => harness.stop()).not.toThrow();
+    expect(() => harness.stop()).not.toThrow(); // idempotent
+  });
+});
+
+describe("ShadowHarness — buildReport (used by /shadow/report)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns expected report shape with fromMs and toMs", async () => {
+    const decisions = Array.from({ length: 3 }, () => makeDecision("oracle"));
+    const harness = makeHarness(decisions, 3);
+    const report = await harness.buildReport();
+    expect(typeof report.fromMs).toBe("number");
+    expect(typeof report.toMs).toBe("number");
+    expect(report.toMs).toBeGreaterThan(report.fromMs);
+    expect(typeof report.shadowTotal).toBe("number");
+    expect(typeof report.liveTotal).toBe("number");
+    expect(typeof report.divergencePct).toBe("number");
+    expect(typeof report.shadowByType).toBe("object");
+  });
+
+  it("accepts custom fromMs and toMs", async () => {
+    const now = Date.now();
+    const harness = makeHarness([], 0);
+    const report = await harness.buildReport(now - 60_000, now);
+    expect(report.fromMs).toBe(now - 60_000);
+    expect(report.toMs).toBe(now);
+  });
+
+  it("returned divergencePct is in [0, 100]", async () => {
+    const harness = makeHarness([], 5);
+    const report = await harness.buildReport();
+    expect(report.divergencePct).toBeGreaterThanOrEqual(0);
+    expect(report.divergencePct).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("ShadowHarness — metrics wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shadowDivergencePct.set is called for all 4 txTypes after a cycle", async () => {
+    const { shadowDivergencePct } = await import("../../src/lib/metrics.js");
+    const harness = makeHarness([], 0);
+    await harness.runCycle();
+    // Should have been called for crank, liquidation, oracle, adl
+    const callLabels = vi.mocked(shadowDivergencePct.set).mock.calls.map((c) => c[0]);
+    expect(callLabels.some((l) => l.txType === "crank")).toBe(true);
+    expect(callLabels.some((l) => l.txType === "liquidation")).toBe(true);
+    expect(callLabels.some((l) => l.txType === "oracle")).toBe(true);
+    expect(callLabels.some((l) => l.txType === "adl")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements the v16 cutover safety net: a DRY_RUN shadow keeper logs every would-have-fired decision as structured JSONL and compares aggregate counts against the live keeper's on-chain tx history every 5 minutes.
- Decision logger extends the existing DRY_RUN intercept in `keeper-send.ts` (no second intercept point). When `SHADOW_HARNESS_ENABLED=true AND DRY_RUN=true`, every intercepted send becomes a logged decision entry. When disabled, the path runs unchanged.
- `/shadow/report` endpoint added to the existing health server (port 8081), not the metrics server. Returns JSON with `shadowTotal`, `liveTotal`, `divergencePct`, `shadowByType` per txType.

## Harness design

**Decision log** (`src/lib/decision-log.ts`): Append-only JSONL via `fs/promises.open(path, 'a')`. No buffering beyond OS page cache. Malformed lines skipped by try/catch in the line-level iterator. Singleton `sharedDecisionLog` exported.

**Comparison loop** (`src/lib/shadow-harness.ts`): Runs every `SHADOW_HARNESS_COMPARE_WINDOW_MS` (5 min). Reads shadow decisions from JSONL; pulls live tx signatures via `getSignaturesForAddress(programId, {limit: 1000})`, filtered by `blockTime` within the window.

**Matching strategy (v1 — aggregate)**:
`divergence_pct = |shadow_total - live_total| / max(shadow_total, live_total, 1) * 100`

Per-tx matching (by txType+market+ix prefix) would require one `getTransaction` RPC call per live tx (up to 1000 calls/cycle), which would consume 10–100s and most RPC quota. Aggregate comparison detects both failure modes (shadow over-fires or under-fires) without that cost. A TODO is left for per-tx matching once live txs carry a memo-based txType tag.

**Alert**: If `divergence_pct > SHADOW_HARNESS_DIVERGENCE_THRESHOLD_PCT` (default 1%), `sendWarningAlert` fires to Discord. Errors on the alert call are `.catch(() => {})` — never block the loop.

**Metrics wired**: `shadowDecisionsTotal{txType}` (new), `shadowMatchTotal{txType, result}` (new), `shadowDivergencePct{txType}` (K stub, now wired). The "Wired in Workstream J" stub comment removed from `metrics.ts`.

## /shadow/report shape

```json
{
  "enabled": true,
  "fromMs": 1748000000000,
  "toMs": 1748000300000,
  "shadowTotal": 142,
  "liveTotal": 139,
  "divergencePct": 2.1,
  "shadowByType": { "crank": 80, "liquidation": 40, "oracle": 22 }
}
```

Accepts optional `?from=<epoch_ms>&to=<epoch_ms>` query params; defaults to last 5-minute window.

## Operator usage

Enable **only** in DRY_RUN shadow deploys (separate region, never production primary):

```env
SHADOW_HARNESS_ENABLED=true
DRY_RUN=true
SHADOW_HARNESS_COMPARE_WINDOW_MS=300000
SHADOW_HARNESS_DIVERGENCE_THRESHOLD_PCT=1.0
SHADOW_HARNESS_DECISION_LOG_PATH=/tmp/keeper-decisions.jsonl
```

If divergence > 1%, Discord warns and the v16 cutover should be blocked until the root cause is understood.

## Test plan

- [x] `pnpm build` — clean (zero TS errors)
- [x] `pnpm test` — 612 passing | 26 skipped (baseline was 574 | 23; net +38 new tests)
- [x] `STRESS=true pnpm test` — 633 passing | 5 skipped; 10k decision-log entries + 10k live sigs comparison completed in **137ms** (well under 5s budget)
- [x] Chaos test: malformed JSONL line prepended to 10k valid entries — comparison succeeds with all 10000 valid entries counted
- [x] Property tests: 500+ runs per property for `computeDivergencePct` — always in [0,100], no NaN/Infinity, symmetric, monotone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shadow-keeper observation system to monitor decisions against actual on-chain activity.
  * New `/shadow/report` endpoint for decision analysis and metrics.
  * Divergence metrics with configurable thresholds and Discord alerting.
  * Configuration options to enable and tune the observation system.

* **Tests**
  * Comprehensive test coverage for observation, logging, and reporting functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-keeper/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->