### PR TITLE
fix(liquidation): dedupe per-cycle by (slabAddress, accountIdx)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -202,11 +202,18 @@ export class LiquidationService {
   private readonly _debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly _DEBOUNCE_MS = 1_000;
   private _unsubLoader?: () => void;
-  // B4: per-cycle dedup so the same owner is never targeted twice in the same
-  // scan cycle. A user underwater in multiple markets used to get N parallel
-  // liquidates fired; now we attempt one per cycle and let the next cycle pick
-  // up any residual undercollateralization.
-  private _cycleSeenOwners = new Set<string>();
+  // C1 (post-mainnet-audit): per-cycle dedup keyed on (slabAddress, accountIdx)
+  // — the unique on-chain identifier of a User sub-account in Percolator. The
+  // previous "B4" key was the owner pubkey, which silently dropped liquidations
+  // of every additional sub-account belonging to the same owner; with multiple
+  // sub-accounts per owner being normal usage on a perp DEX, owner-keyed dedup
+  // left residual bad debt for the insurance fund to absorb. We still cap
+  // liquidations per owner per cycle to bound RPC fan-out and preserve
+  // fairness — a single whale with many sub-accounts cannot monopolize the
+  // scan budget. Residual positions above the cap are picked up next cycle.
+  private _cycleSeenPositions = new Set<string>();
+  private _cycleOwnerCounts = new Map<string, number>();
+  private static readonly MAX_LIQ_PER_OWNER_PER_CYCLE = 3;
   // B5: collapse per-liquidation Discord alerts into a single summary alert per
   // market within a 5 s window — prevents cascade-driven channel flooding.
   private readonly _liquidationAlertAggregator = new AlertAggregator(
@@ -549,10 +556,11 @@ export class LiquidationService {
     let scanned = 0;
     let candidateCount = 0;
     let liquidated = 0;
-    // B4: fresh per-cycle dedup set — owners targeted in earlier cycles can
-    // be re-targeted next cycle (the previous liquidate may have only chipped
-    // away part of their exposure).
-    this._cycleSeenOwners.clear();
+    // C1: fresh per-cycle dedup state — positions targeted in earlier cycles
+    // can be re-targeted next cycle (a previous liquidate may have only chipped
+    // away part of the exposure; partial-fill retry is intentional).
+    this._cycleSeenPositions.clear();
+    this._cycleOwnerCounts.clear();
 
     // P2 FIX: Periodically clear permanentlySkipped to allow recovery when SDK is updated.
     // Markets re-add themselves on next parse failure, so this is safe.
@@ -597,16 +605,27 @@ export class LiquidationService {
         candidateCount += candidates.length;
 
         // Liquidations are sequential (each is a transaction).
-        // B4: skip owners already targeted earlier in this scan cycle.
+        // C1: dedup per on-chain (slab, accountIdx) position; rate-limit per
+        // owner across the cycle.
         for (const candidate of candidates) {
-          if (this._cycleSeenOwners.has(candidate.owner)) {
-            logger.debug("Skipping owner already targeted this cycle", {
+          const positionKey = `${candidate.slabAddress}:${candidate.accountIdx}`;
+          if (this._cycleSeenPositions.has(positionKey)) {
+            logger.debug("Skipping position already targeted this cycle", {
+              positionKey,
               owner: candidate.owner.slice(0, 8),
-              slabAddress: candidate.slabAddress.slice(0, 8),
             });
             continue;
           }
-          this._cycleSeenOwners.add(candidate.owner);
+          const ownerCount = this._cycleOwnerCounts.get(candidate.owner) ?? 0;
+          if (ownerCount >= LiquidationService.MAX_LIQ_PER_OWNER_PER_CYCLE) {
+            logger.debug("Owner hit per-cycle liquidation cap", {
+              owner: candidate.owner.slice(0, 8),
+              cap: LiquidationService.MAX_LIQ_PER_OWNER_PER_CYCLE,
+            });
+            continue;
+          }
+          this._cycleSeenPositions.add(positionKey);
+          this._cycleOwnerCounts.set(candidate.owner, ownerCount + 1);
           const sig = await this.liquidate(filteredBatch[j]!.market, candidate.accountIdx);
           if (sig) liquidated++;
         }

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -672,10 +672,12 @@ describe('LiquidationService', () => {
     });
   });
 
-  // A.14 (MED): per-cycle owner dedup — same underwater owner across N markets
-  // produces ONE liquidate call per cycle, not N. The set resets between
-  // cycles so a residual undercollateralization can be retargeted next time.
-  describe('A.14: scanAndLiquidateAll owner dedup', () => {
+  // C1: per-cycle dedup is keyed on the on-chain position identifier
+  // (slabAddress, accountIdx), not the owner pubkey. An owner with multiple
+  // undercollateralized sub-accounts must get each one liquidated in the same
+  // cycle — owner-only dedup previously left residual bad debt for the
+  // insurance fund. A per-owner cap bounds RPC fan-out for fairness.
+  describe('C1: scanAndLiquidateAll position dedup', () => {
     function makeMarketAt(slabAddr: string) {
       return {
         slabAddress: { toBase58: () => slabAddr, equals: () => false },
@@ -690,29 +692,27 @@ describe('LiquidationService', () => {
       };
     }
 
-    it('liquidates the same owner ONCE when present in two markets in the same cycle', async () => {
+    function makeCandidate(slabAddress: string, accountIdx: number, owner: string) {
+      return {
+        slabAddress,
+        accountIdx,
+        owner,
+        positionSize: 1_000n,
+        capital: 100n,
+        pnl: -50n,
+        marginRatio: 4.0,
+        maintenanceMarginBps: 500n,
+      };
+    }
+
+    it('liquidates BOTH positions when the same owner is underwater in two markets', async () => {
       const svc = new LiquidationService(mockOracleService as any);
       const sharedOwner = 'OwnerShared111111111111111111111111111111111';
 
-      // Stub scanMarket directly so we can return identical candidates for
-      // both markets without wrestling with parser mocks.
       const scanSpy = vi.spyOn(svc, 'scanMarket').mockImplementation(
         async (market: any) =>
-          [
-            {
-              slabAddress: market.slabAddress.toBase58(),
-              accountIdx: 1,
-              owner: sharedOwner,
-              positionSize: 1_000n,
-              capital: 100n,
-              pnl: -50n,
-              marginRatio: 4.0,
-              maintenanceMarginBps: 500n,
-            },
-          ] as any,
+          [makeCandidate(market.slabAddress.toBase58(), 1, sharedOwner)] as any,
       );
-
-      // Stub liquidate so it just counts calls without exercising the send path.
       const liquidateSpy = vi
         .spyOn(svc, 'liquidate')
         .mockResolvedValue('mock-liq-sig');
@@ -724,46 +724,112 @@ describe('LiquidationService', () => {
 
       const result = await svc.scanAndLiquidateAll(markets);
 
-      // Both markets scanned…
+      // Both markets scanned, and both sub-accounts liquidated — distinct
+      // (slab, accountIdx) pairs even though the owner pubkey is shared.
       expect(scanSpy).toHaveBeenCalledTimes(2);
-      // …but liquidate fired only once thanks to the dedup set.
-      expect(liquidateSpy).toHaveBeenCalledTimes(1);
+      expect(liquidateSpy).toHaveBeenCalledTimes(2);
       expect(result.candidates).toBe(2);
-      expect(result.liquidated).toBe(1);
+      expect(result.liquidated).toBe(2);
     });
 
-    it('permits the same owner to be liquidated again on the NEXT cycle', async () => {
+    it('liquidates BOTH sub-accounts when the same owner has two positions in the SAME market', async () => {
       const svc = new LiquidationService(mockOracleService as any);
-      const sharedOwner = 'OwnerShared222222222222222222222222222222222';
+      const sharedOwner = 'OwnerSameMarket111111111111111111111111111';
 
-      const scanSpy = vi.spyOn(svc, 'scanMarket').mockImplementation(
+      vi.spyOn(svc, 'scanMarket').mockImplementation(
         async (market: any) =>
           [
-            {
-              slabAddress: market.slabAddress.toBase58(),
-              accountIdx: 1,
-              owner: sharedOwner,
-              positionSize: 1_000n,
-              capital: 100n,
-              pnl: -50n,
-              marginRatio: 4.0,
-              maintenanceMarginBps: 500n,
-            },
+            makeCandidate(market.slabAddress.toBase58(), 1, sharedOwner),
+            makeCandidate(market.slabAddress.toBase58(), 2, sharedOwner),
           ] as any,
       );
       const liquidateSpy = vi.spyOn(svc, 'liquidate').mockResolvedValue('mock-liq-sig');
 
       const markets = new Map([
-        ['SlabC3333333333333333333333333333333333333', { market: makeMarketAt('SlabC3333333333333333333333333333333333333') as any }],
+        ['SlabA1111111111111111111111111111111111111', { market: makeMarketAt('SlabA1111111111111111111111111111111111111') as any }],
+      ]);
+
+      const result = await svc.scanAndLiquidateAll(markets);
+
+      // Two distinct accountIdx in the same slab — both liquidated.
+      expect(liquidateSpy).toHaveBeenCalledTimes(2);
+      expect(liquidateSpy.mock.calls.map((c) => c[1]).sort()).toEqual([1, 2]);
+      expect(result.liquidated).toBe(2);
+    });
+
+    it('dedupes exact (slab, accountIdx) duplicates within the same cycle', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const owner = 'OwnerDupe1111111111111111111111111111111';
+      const slab = 'SlabDupe111111111111111111111111111111111';
+
+      // Defensive: scanMarket somehow returns the same candidate twice in the
+      // same cycle. The composite-key dedup should collapse it to one liquidate.
+      vi.spyOn(svc, 'scanMarket').mockResolvedValue([
+        makeCandidate(slab, 7, owner),
+        makeCandidate(slab, 7, owner),
+      ] as any);
+      const liquidateSpy = vi.spyOn(svc, 'liquidate').mockResolvedValue('mock-liq-sig');
+
+      const markets = new Map([
+        [slab, { market: makeMarketAt(slab) as any }],
       ]);
 
       await svc.scanAndLiquidateAll(markets);
+
+      expect(liquidateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('caps liquidations per owner at MAX_LIQ_PER_OWNER_PER_CYCLE (3) per cycle', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const whale = 'OwnerWhale1111111111111111111111111111111';
+
+      // One owner, five distinct (slab, accountIdx) positions across five
+      // markets — every position is genuinely underwater, but the per-owner
+      // cap of 3 keeps the keeper from blowing its RPC budget on a single
+      // whale. Residual positions are picked up on the next cycle.
+      const slabs = [
+        'SlabW0000000000000000000000000000000000000',
+        'SlabW1111111111111111111111111111111111111',
+        'SlabW2222222222222222222222222222222222222',
+        'SlabW3333333333333333333333333333333333333',
+        'SlabW4444444444444444444444444444444444444',
+      ];
+      vi.spyOn(svc, 'scanMarket').mockImplementation(
+        async (market: any) =>
+          [makeCandidate(market.slabAddress.toBase58(), 0, whale)] as any,
+      );
+      const liquidateSpy = vi.spyOn(svc, 'liquidate').mockResolvedValue('mock-liq-sig');
+
+      const markets = new Map(
+        slabs.map((s) => [s, { market: makeMarketAt(s) as any }]),
+      );
+
+      const result = await svc.scanAndLiquidateAll(markets);
+
+      expect(liquidateSpy).toHaveBeenCalledTimes(3);
+      expect(result.liquidated).toBe(3);
+      expect(result.candidates).toBe(5);
+    });
+
+    it('clears per-cycle dedup state between scanAndLiquidateAll invocations', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const owner = 'OwnerNextCycle111111111111111111111111111';
+      const slab = 'SlabC3333333333333333333333333333333333333';
+
+      vi.spyOn(svc, 'scanMarket').mockImplementation(
+        async (market: any) =>
+          [makeCandidate(market.slabAddress.toBase58(), 1, owner)] as any,
+      );
+      const liquidateSpy = vi.spyOn(svc, 'liquidate').mockResolvedValue('mock-liq-sig');
+
+      const markets = new Map([[slab, { market: makeMarketAt(slab) as any }]]);
+
+      await svc.scanAndLiquidateAll(markets);
       await svc.scanAndLiquidateAll(markets);
 
-      // Two cycles, two liquidates — the dedup set is per-cycle, not lifetime.
+      // Per-cycle dedup, not lifetime: the same (slab, idx) can be retargeted
+      // next cycle (partial-fill retry path).
       expect(liquidateSpy).toHaveBeenCalledTimes(2);
-      // sanity: scanMarket also called twice (once per cycle)
-      expect(scanSpy).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Summary

Internal pre-mainnet audit identified that the per-cycle dedup in `scanAndLiquidateAll` is keyed on the owner pubkey (`_cycleSeenOwners`). Because Percolator User accounts are identified on-chain by `(slabAddress, accountIdx)`, a single owner pubkey can legitimately hold multiple positions across one or more markets. Owner-keyed dedup silently dropped liquidations of every additional underwater sub-account belonging to the same owner; residual bad debt was absorbed by the insurance fund instead of being liquidated.

The on-chain `liquidate_at_oracle` instruction takes `(slab, accountIdx)` and has no objection to N independent liquidations against the same owner's distinct sub-accounts in one transaction batch.

## Fix

- **Key the cycle dedup on the on-chain position identifier** `(slabAddress, accountIdx)` via a renamed `_cycleSeenPositions: Set<string>`. Two distinct sub-accounts of the same owner are now both liquidated within a single cycle.
- **Add a per-owner cap** (`MAX_LIQ_PER_OWNER_PER_CYCLE = 3`) tracked in a new `_cycleOwnerCounts: Map<string, number>` to bound RPC fan-out. A single whale with many underwater sub-accounts cannot monopolize the keeper's scan budget. Residual positions above the cap are picked up on the next cycle, preserving the original partial-fill retry intent.
- Both dedup structures are cleared at the start of every `scanAndLiquidateAll` invocation.

## Test plan

- [x] Rewrote the existing `A.14: scanAndLiquidateAll owner dedup` describe block (which previously encoded the buggy owner-only semantics) into a new `C1: scanAndLiquidateAll position dedup` suite asserting the corrected behavior.
- [x] **New** — liquidates both positions when one owner is underwater in two markets (the C1 regression guard).
- [x] **New** — liquidates both sub-accounts when one owner has two positions in the same market.
- [x] **New** — dedupes exact `(slab, accountIdx)` duplicates within a cycle (defensive composite-key check).
- [x] **New** — caps liquidations per owner at 3 per cycle, residual picked up next cycle.
- [x] **New** — clears per-cycle dedup state between `scanAndLiquidateAll` invocations (per-cycle, not lifetime).

Test suite result: **615 passed, 26 skipped, 0 failed** across 48 test files.

## Risk

- **RPC burst:** liquidations per cycle can grow ~3x for users with multiple underwater sub-accounts (the intended/correct outcome). The per-owner cap bounds the worst case; the existing `sharedTxQueue` lane budget (concurrency=10, intervalCap=30/interval) absorbs the burst.
- **Backward compatibility:** the renamed private field is only referenced inside `liquidation.ts` (verified via grep). No external API change.
- **Insurance fund implication:** correct accounting in steady state; under a market-wide cascade, more liquidations land — protecting the insurance fund from the bad-debt class previously absorbed.

## Files

- `src/services/liquidation.ts` — renamed `_cycleSeenOwners` to `_cycleSeenPositions`, added `_cycleOwnerCounts` Map and `MAX_LIQ_PER_OWNER_PER_CYCLE` constant, updated comments and dedup logic at the candidate loop in `scanAndLiquidateAll`.
- `tests/services/liquidation.test.ts` — replaced the `A.14` block with a new `C1` block covering 5 scenarios.
