### PR TITLE
fix(account-loader): C3 — RPC snapshot on (re)connect prevents empty cache after stream gap

### DIFF
--- a/src/lib/account-loader.ts
+++ b/src/lib/account-loader.ts
@@ -1,4 +1,4 @@
-import { PublicKey } from "@solana/web3.js";
+import { PublicKey, type Connection } from "@solana/web3.js";
 import { createLogger } from "@percolatorct/shared";
 import { AccountCache } from "./account-cache.js";
 import { ReconnectBackoff } from "./stream-reconnect.js";
@@ -8,6 +8,8 @@ const logger = createLogger("keeper:account-loader");
 
 const MAINNET_PROGRAM_ID = "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv";
 const DEFAULT_DROP_QUEUE_MAX = 10_000;
+// C3: getMultipleAccountsInfo RPC accepts up to 100 pubkeys per call.
+const SNAPSHOT_CHUNK_SIZE = 100;
 
 export interface AccountUpdate {
   pubkey: string;
@@ -39,6 +41,13 @@ export interface AccountLoaderOptions {
   onDriftAlert?: (drift: number) => void;
   /** Injected getRpcSlot for SlotTracker; defaults to a no-op that never fires drift alerts. */
   getRpcSlot?: () => Promise<number>;
+  /**
+   * C3: optional RPC Connection used to backfill the cache on (re)connect.
+   * The stream uses replay:false, so without a snapshot the cache stays empty
+   * (or stale, after invalidateAll) until each tracked account is next mutated.
+   * When absent, the loader logs a warning and proceeds without seeding.
+   */
+  connection?: Connection;
 }
 
 /**
@@ -242,6 +251,16 @@ export class AccountLoader {
 
   private async connect(): Promise<void> {
     try {
+      // C3 (CRITICAL): pre-seed the cache via RPC BEFORE subscribing.
+      // Rationale: the stream is started with replay:false and onStreamError
+      // calls cache.invalidateAll(). Without this snapshot, every reconnect
+      // leaves downstream consumers (LiquidationService, CrankService) reading
+      // an empty cache until each tracked account is next mutated — risking
+      // missed liquidations / stale decisions for an unbounded window.
+      // Ordering: snapshot runs FIRST so it can't race against stream-driven
+      // cache.set() calls and overwrite newer slot data with older RPC data.
+      await this._snapshotKnownAccounts();
+
       await this.adapter.start(
         this.opts,
         (update) => this.enqueue(update),
@@ -259,11 +278,64 @@ export class AccountLoader {
       });
     } catch (err) {
       this.connected = false;
-      logger.warn("AccountLoader: initial connection failed", {
+      // adapter.stop() is idempotent; safe whether the failure was in the
+      // snapshot (no stream started) or the stream start (no stream running).
+      this.adapter.stop();
+      logger.warn("AccountLoader: connection failed", {
         error: err instanceof Error ? err.message : String(err),
       });
       this.scheduleReconnect();
     }
+  }
+
+  /**
+   * C3: fetch current account state for additionalAccounts via RPC and seed
+   * the cache. Uses getMultipleAccountsInfoAndContext so every entry is stamped
+   * with the RPC-context slot (not 0), which keeps slot-monotonicity guards in
+   * AccountCache.get() and SlotTracker behaving correctly.
+   *
+   * Throws on RPC failure — caller (connect()) catches and reschedules.
+   */
+  private async _snapshotKnownAccounts(): Promise<void> {
+    const accounts = this.opts.additionalAccounts ?? [];
+    if (accounts.length === 0) return;
+
+    if (!this.opts.connection) {
+      logger.warn(
+        "AccountLoader: RPC connection not provided — skipping cache snapshot. " +
+          "After reconnect, cache will be empty until each tracked account is next mutated.",
+        { additionalAccounts: accounts.length },
+      );
+      return;
+    }
+
+    const pubkeys = accounts.map((a) => new PublicKey(a));
+    let seeded = 0;
+
+    for (let i = 0; i < pubkeys.length; i += SNAPSHOT_CHUNK_SIZE) {
+      const chunk = pubkeys.slice(i, i + SNAPSHOT_CHUNK_SIZE);
+      const resp = await this.opts.connection.getMultipleAccountsInfoAndContext(
+        chunk,
+        { commitment: "confirmed" },
+      );
+      const slot = resp.context.slot;
+      for (let j = 0; j < chunk.length; j++) {
+        const info = resp.value[j];
+        if (!info) continue;
+        // info.data is a Node Buffer (which extends Uint8Array). Copy into a
+        // detached Uint8Array so the cache entry doesn't share the Buffer pool.
+        const raw = info.data as unknown as Uint8Array;
+        const data = new Uint8Array(raw.byteLength);
+        data.set(raw);
+        this.cache.set(chunk[j].toBase58(), data, info.owner.toBase58(), slot);
+        seeded++;
+      }
+    }
+
+    logger.info("AccountLoader: cache snapshot seeded", {
+      requested: accounts.length,
+      seeded,
+    });
   }
 
   private onStreamError(err: Error): void {

--- a/tests/lib/account-loader.test.ts
+++ b/tests/lib/account-loader.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { PublicKey } from "@solana/web3.js";
 import {
   AccountLoader,
   type AccountUpdate,
@@ -19,6 +20,42 @@ const BASE_OPTS: AccountLoaderOptions = {
   apiKey: "test-key",
   endpoint: "http://localhost:1234",
 };
+
+/**
+ * C3: minimal Connection stub exposing only getMultipleAccountsInfoAndContext.
+ * The real type is large; the loader only calls this one method.
+ */
+interface AccountInfoLite {
+  data: Uint8Array;
+  owner: PublicKey;
+}
+function makeMockConnection(opts: {
+  accounts: Record<string, AccountInfoLite | null>;
+  slot?: number;
+  throws?: Error;
+  trackCalls?: { count: number; lastChunkSizes: number[] };
+}) {
+  return {
+    getMultipleAccountsInfoAndContext: vi.fn(
+      async (pubkeys: PublicKey[]) => {
+        if (opts.trackCalls) {
+          opts.trackCalls.count++;
+          opts.trackCalls.lastChunkSizes.push(pubkeys.length);
+        }
+        if (opts.throws) throw opts.throws;
+        return {
+          context: { slot: opts.slot ?? 1000 },
+          value: pubkeys.map((p) => opts.accounts[p.toBase58()] ?? null),
+        };
+      },
+    ),
+  };
+}
+
+// Two valid Solana pubkeys for additionalAccounts tests.
+const PK_A = "So11111111111111111111111111111111111111112";
+const PK_B = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const OWNER = "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv";
 
 /** Test double for StreamAdapter that lets tests control connection lifecycle. */
 class FakeAdapter implements StreamAdapter {
@@ -290,6 +327,163 @@ describe("AccountLoader", () => {
       // At least 3 attempts made (initial + 2 reconnects)
       expect(failing.startCallCount).toBeGreaterThanOrEqual(3);
       await errLoader.stop();
+    });
+  });
+
+  describe("C3: RPC snapshot on (re)connect", () => {
+    it("seeds cache from RPC before adapter.start() returns", async () => {
+      const conn = makeMockConnection({
+        accounts: {
+          [PK_A]: { data: new Uint8Array([0xaa, 0xbb]), owner: new PublicKey(OWNER) },
+          [PK_B]: { data: new Uint8Array([0xcc]), owner: new PublicKey(OWNER) },
+        },
+        slot: 5000,
+      });
+      const ad = new FakeAdapter();
+      const l = new AccountLoader(
+        { ...BASE_OPTS, additionalAccounts: [PK_A, PK_B], connection: conn as never },
+        ad,
+      );
+      await l.start();
+
+      expect(conn.getMultipleAccountsInfoAndContext).toHaveBeenCalledTimes(1);
+      // The snapshot must run before adapter.start completes — otherwise
+      // downstream code could read from the cache during the gap. We assert
+      // this indirectly: at the moment loader.start() resolves, the cache is
+      // already populated.
+      const a = l.getCache().get(PK_A, 5000);
+      const b = l.getCache().get(PK_B, 5000);
+      expect(a?.slot).toBe(5000);
+      expect(b?.slot).toBe(5000);
+      expect(a?.owner).toBe(OWNER);
+      await l.stop();
+    });
+
+    it("schedules reconnect when snapshot RPC throws and leaves connected=false", async () => {
+      vi.useFakeTimers();
+      const conn = makeMockConnection({
+        accounts: {},
+        throws: new Error("rpc 503"),
+      });
+      const ad = new FakeAdapter();
+      const l = new AccountLoader(
+        { ...BASE_OPTS, additionalAccounts: [PK_A], connection: conn as never },
+        ad,
+      );
+      await l.start();
+
+      // adapter.start() must NOT have been called — snapshot ran first and failed.
+      expect(ad.startCallCount).toBe(0);
+      expect(l.getStats().connected).toBe(false);
+      // Reconnect must be queued.
+      await vi.advanceTimersByTimeAsync(1_100);
+      expect(l.getStats().reconnectCount).toBeGreaterThanOrEqual(1);
+      vi.useRealTimers();
+      await l.stop();
+    });
+
+    it("re-runs snapshot after stream error → reconnect", async () => {
+      vi.useFakeTimers();
+      const conn = makeMockConnection({
+        accounts: {
+          [PK_A]: { data: new Uint8Array([1]), owner: new PublicKey(OWNER) },
+        },
+        slot: 7000,
+      });
+      const ad = new FakeAdapter();
+      const l = new AccountLoader(
+        { ...BASE_OPTS, additionalAccounts: [PK_A], connection: conn as never },
+        ad,
+      );
+      await l.start();
+      expect(conn.getMultipleAccountsInfoAndContext).toHaveBeenCalledTimes(1);
+
+      ad.pushError(new Error("stream dropped"));
+      // Cache flushed on error (existing behavior).
+      expect(l.getCache().size()).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(1_100); // first backoff
+      await Promise.resolve();
+      vi.useRealTimers();
+
+      // Snapshot must have been re-run on reconnect.
+      expect(conn.getMultipleAccountsInfoAndContext).toHaveBeenCalledTimes(2);
+      expect(l.getCache().get(PK_A, 7000)?.slot).toBe(7000);
+      await l.stop();
+    });
+
+    it("chunks additionalAccounts > 100 into separate RPC calls", async () => {
+      // Build 250 valid pubkeys (we use derived seeds of PK_A for simplicity).
+      // Easier: use a sequence of 32-byte buffers cast through PublicKey.
+      const pubkeys: string[] = [];
+      const accountsMap: Record<string, AccountInfoLite> = {};
+      for (let i = 0; i < 250; i++) {
+        const bytes = new Uint8Array(32);
+        bytes[0] = i & 0xff;
+        bytes[1] = (i >> 8) & 0xff;
+        const pk = new PublicKey(bytes).toBase58();
+        pubkeys.push(pk);
+        accountsMap[pk] = { data: new Uint8Array([1]), owner: new PublicKey(OWNER) };
+      }
+      const tracker = { count: 0, lastChunkSizes: [] as number[] };
+      const conn = makeMockConnection({ accounts: accountsMap, slot: 8000, trackCalls: tracker });
+      const ad = new FakeAdapter();
+      const l = new AccountLoader(
+        { ...BASE_OPTS, additionalAccounts: pubkeys, connection: conn as never },
+        ad,
+      );
+      await l.start();
+
+      // 250 / 100 = 3 chunks (100, 100, 50).
+      expect(tracker.count).toBe(3);
+      expect(tracker.lastChunkSizes).toEqual([100, 100, 50]);
+      expect(l.getCache().size()).toBe(250);
+      await l.stop();
+    });
+
+    it("skips snapshot when no connection is provided (degraded mode)", async () => {
+      // No `connection` opt — loader logs warn and proceeds without seeding.
+      const ad = new FakeAdapter();
+      const l = new AccountLoader(
+        { ...BASE_OPTS, additionalAccounts: [PK_A] },
+        ad,
+      );
+      await l.start();
+      expect(l.getStats().connected).toBe(true);
+      expect(l.getCache().size()).toBe(0);
+      await l.stop();
+    });
+
+    it("skips snapshot when additionalAccounts is empty (no RPC call)", async () => {
+      const conn = makeMockConnection({ accounts: {} });
+      const ad = new FakeAdapter();
+      const l = new AccountLoader(
+        { ...BASE_OPTS, connection: conn as never },
+        ad,
+      );
+      await l.start();
+      expect(conn.getMultipleAccountsInfoAndContext).not.toHaveBeenCalled();
+      expect(l.getStats().connected).toBe(true);
+      await l.stop();
+    });
+
+    it("skips entries whose RPC value is null (account does not exist)", async () => {
+      const conn = makeMockConnection({
+        accounts: {
+          [PK_A]: { data: new Uint8Array([1]), owner: new PublicKey(OWNER) },
+          [PK_B]: null,
+        },
+        slot: 9000,
+      });
+      const ad = new FakeAdapter();
+      const l = new AccountLoader(
+        { ...BASE_OPTS, additionalAccounts: [PK_A, PK_B], connection: conn as never },
+        ad,
+      );
+      await l.start();
+      expect(l.getCache().get(PK_A, 9000)?.slot).toBe(9000);
+      expect(l.getCache().get(PK_B, 9000)).toBeNull();
+      await l.stop();
     });
   });
 });

--- a/tests/poc/c3.poc.test.ts
+++ b/tests/poc/c3.poc.test.ts
@@ -1,0 +1,121 @@
+/**
+ * C3 PoC — stream-error reconnect leaves the cache empty (or stale) until
+ * each tracked account is next mutated.
+ *
+ * THE BUG (pre-fix):
+ *   onStreamError → cache.invalidateAll(). The Helius LaserStream subscription
+ *   was opened with `replay: false`, so the stream only emits NEW changes
+ *   after reconnect — never the current state. Between the invalidateAll() and
+ *   the first account mutation, downstream readers (LiquidationService,
+ *   CrankService) see an EMPTY cache. They may make decisions on stale or
+ *   missing data for an unbounded window.
+ *
+ * THE FIX (this PR):
+ *   AccountLoader.connect() now runs an RPC backfill snapshot via
+ *   getMultipleAccountsInfoAndContext BEFORE adapter.start(). The cache is
+ *   pre-seeded with current state. If snapshot fails, the loader stays
+ *   disconnected and schedules a reconnect — it does NOT silently proceed
+ *   with an empty cache.
+ *
+ * This PoC demonstrates: in the OLD flow, scenario "stream-error then
+ * reconnect" yields cache.size()=0 while consumers are reading; in the NEW
+ * flow, the snapshot guarantees cache.size() == additionalAccounts.length
+ * before consumers see connected=true.
+ */
+import { describe, it, expect } from "vitest";
+
+interface MiniCache {
+  data: Map<string, { slot: number; data: Uint8Array }>;
+  size: () => number;
+  invalidateAll: () => void;
+  set: (k: string, slot: number, data: Uint8Array) => void;
+  get: (k: string) => { slot: number; data: Uint8Array } | undefined;
+}
+
+function makeCache(): MiniCache {
+  const data = new Map<string, { slot: number; data: Uint8Array }>();
+  return {
+    data,
+    size: () => data.size,
+    invalidateAll: () => data.clear(),
+    set: (k, slot, d) => { data.set(k, { slot, data: d }); },
+    get: (k) => data.get(k),
+  };
+}
+
+describe("C3 PoC — stream reconnect cache backfill", () => {
+  it("OLD path: invalidateAll on stream error leaves cache empty until next mutation", () => {
+    const cache = makeCache();
+    const tracked = ["acctA", "acctB", "acctC"];
+
+    // Initial warm-up via stream events.
+    for (const k of tracked) cache.set(k, 100, new Uint8Array([1, 2, 3]));
+    expect(cache.size()).toBe(3);
+
+    // Stream errors → OLD code path
+    cache.invalidateAll();
+    // No backfill runs here.
+
+    // Reconnect scheduled and stream resumes. But replay:false → the stream
+    // doesn't re-emit current state, only future changes. Until any account
+    // is mutated, the cache stays empty.
+    expect(cache.size()).toBe(0);
+
+    // Meanwhile, a LiquidationService scan tick runs and asks for acctA:
+    const fetched = cache.get("acctA");
+    expect(fetched).toBeUndefined();
+    // ↑ Downstream consumer gets a CACHE MISS for tracked data it expected to
+    //   have, while the stream is "connected." This is the bug: the keeper
+    //   makes decisions on missing state during the reconnect window.
+  });
+
+  it("NEW path: pre-seed snapshot via RPC guarantees cache is hot before consumers see connected=true", async () => {
+    const cache = makeCache();
+    const tracked = ["acctA", "acctB", "acctC"];
+
+    // First connect: cache pre-seeded.
+    cache.set("acctA", 100, new Uint8Array([1]));
+    cache.set("acctB", 100, new Uint8Array([2]));
+    cache.set("acctC", 100, new Uint8Array([3]));
+
+    // Stream error → invalidate (NEW code keeps this for defense in depth).
+    cache.invalidateAll();
+    expect(cache.size()).toBe(0);
+
+    // NEW: connect() runs snapshot BEFORE flipping connected=true.
+    async function fakeRpcSnapshot(pubkeys: string[], slot: number) {
+      for (const k of pubkeys) cache.set(k, slot, new Uint8Array([0xff]));
+    }
+    await fakeRpcSnapshot(tracked, 5000);
+
+    // Now connected=true is exposed to consumers. Cache is hot:
+    expect(cache.size()).toBe(3);
+    expect(cache.get("acctA")?.slot).toBe(5000);
+    // ↑ A LiquidationService scan during this window sees the freshly
+    //   snapshotted state — no missed decisions.
+  });
+
+  it("PoC: snapshot failure must NOT expose connected=true with empty cache", async () => {
+    const cache = makeCache();
+    cache.invalidateAll();
+    expect(cache.size()).toBe(0);
+
+    let connected = false;
+
+    async function rpcSnapshot(): Promise<void> {
+      throw new Error("RPC 503");
+    }
+
+    try {
+      await rpcSnapshot();
+      connected = true; // would happen on success
+    } catch {
+      connected = false; // NEW code stays disconnected and reschedules
+    }
+
+    expect(connected).toBe(false);
+    expect(cache.size()).toBe(0);
+    // ↑ Critically, connected stays false. Consumers see "not connected"
+    //   and skip decisions, instead of seeing "connected with empty data."
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **C3 (CRITICAL)** from the internal pre-mainnet audit: after any stream gap, the `AccountLoader` cache is empty (or stale, post-`invalidateAll()`) until each tracked account is next mutated. With `replay: false` on the LaserStream subscription, the stream only emits **new** changes — never the current state. `LiquidationService` and `CrankService` use the cache for in-loop decisions, so this window can cause **missed liquidations** and **stale crank decisions** for an unbounded period.

## Fix

On every `connect()` (initial and post-error reconnect), the loader runs an RPC snapshot via `getMultipleAccountsInfoAndContext` over `additionalAccounts` **before** subscribing to the stream. Ordering matters: snapshot-first guarantees the snapshot's `cache.set()` calls cannot race against (and overwrite) newer stream-driven writes.

### Behavior changes

- `AccountLoaderOptions` gains optional `connection?: Connection`.
- **Degraded mode** when `connection` is omitted: the loader logs a warning and proceeds without seeding. Callers without an RPC client still build cleanly.
- Snapshot batches in chunks of **100** (the `getMultipleAccountsInfo` RPC limit).
- Every seeded entry is stamped with `resp.context.slot` so slot-monotonicity guards in `AccountCache.get()` and `SlotTracker` remain correct.
- On RPC failure, the catch in `connect()` keeps `connected=false`, calls `adapter.stop()` (idempotent), and schedules a reconnect via the existing backoff path.
- `cache.invalidateAll()` is retained in `onStreamError` (defense in depth) — the next `connect()` re-seeds before consumers see the cache.

### Deferred to follow-up PRs (per "1 fix = 1 PR")

- Wiring the keeper bootstrap to inject `connection` into the loader.
- `getProgramAccounts` re-seed for slab/market accounts (this PR covers only `additionalAccounts`).
- Listener-pause during snapshot — current slot-monotonicity already prevents older-stream-data overwrite once snapshot returns; tightening to a hard pause is a follow-up.

## Test plan

- [x] 7 new C3 unit tests in `tests/lib/account-loader.test.ts`:
  - snapshot seeds cache before `connected=true`
  - RPC throw schedules reconnect and leaves `connected=false`
  - reconnect re-runs snapshot
  - 250 pubkeys chunk into 3 RPC calls (100, 100, 50)
  - degraded mode without `connection`
  - no-op when `additionalAccounts` is empty
  - null RPC entries (non-existent accounts) skipped
- [x] Full vitest suite: **623 passed / 26 skipped** (preexisting skips).
- [x] `pnpm build` clean (no TS errors).

## Risk

- **Backward-compatible.** `connection` is optional; existing call sites continue to work in degraded mode with only a startup warning.
- **No new failure modes on the happy path.** Snapshot is idempotent — repeated calls overwrite with the same/fresher data.
- **Snapshot failure → reconnect loop** uses the same backoff as adapter failures, so it cannot tight-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional pre-seeding of account data from Solana RPC upon connection for faster initial loads.
  * Enhanced error handling with automatic reconnection scheduling on connection failures.

* **Tests**
  * Added comprehensive test coverage for RPC snapshot behavior, chunking, and error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->