### PR TITLE
fix(adl): H1 — exact cross-multiplied ranking (defense-in-depth)

### DIFF
--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -133,7 +133,6 @@ const ADL_INSURANCE_UTIL_THRESHOLD_BPS = parseBigIntEnv(
 
 interface RankedPosition {
   idx: number;
-  pnlPct: bigint;   // PnL as % of capital × 1_000_000 (fixed-point)
   pnlAbs: bigint;   // Absolute positive PnL (raw)
   capital: bigint;
 }
@@ -270,17 +269,30 @@ function rankProfitablePositions(
 
     const capital = account.capital > 0n ? account.capital : 1n; // guard div-by-zero
     const pnlAbs = account.pnl;
-    // pnlPct = pnl * 1_000_000 / capital  (fixed-point, 6 decimal places)
-    const pnlPct = (pnlAbs * 1_000_000n) / capital;
 
-    profitable.push({ idx, pnlPct, pnlAbs, capital });
+    profitable.push({ idx, pnlAbs, capital });
   }
 
-  // Sort descending by PnL%: highest earner deleveraged first.
-  // Tie-break by absolute PnL descending.
+  // H1: rank by exact cross-multiplied PnL ratio — no precision loss.
+  //
+  // The previous implementation computed pnlPct = (pnlAbs * 1_000_000) / capital
+  // with BigInt floor division, then sorted descending by pnlPct with a
+  // pnlAbs-descending tie-break. Two positions with materially different
+  // true ratios could share the same truncated pnlPct, and the tie-break
+  // then placed the position with the larger pnlAbs first — potentially
+  // ranking an honest counterparty ahead of an attacker who tuned their
+  // position to collide on the truncated bucket. Cross-multiplication
+  // compares a.pnl/a.cap vs b.pnl/b.cap with exact BigInt arithmetic, so
+  // every position with a higher true ratio strictly outranks every
+  // position with a lower true ratio. We tie-break on pnlAbs descending
+  // (preserved from the original behavior), then on idx ascending so the
+  // final order is fully deterministic.
   profitable.sort((a, b) => {
-    if (b.pnlPct !== a.pnlPct) return b.pnlPct > a.pnlPct ? 1 : -1;
-    return b.pnlAbs > a.pnlAbs ? 1 : -1;
+    const lhs = a.pnlAbs * b.capital;
+    const rhs = b.pnlAbs * a.capital;
+    if (lhs !== rhs) return rhs > lhs ? 1 : -1;
+    if (b.pnlAbs !== a.pnlAbs) return b.pnlAbs > a.pnlAbs ? 1 : -1;
+    return a.idx - b.idx;
   });
 
   return profitable;
@@ -343,7 +355,10 @@ export class AdlService {
         idx: r.idx,
         pnlAbs: r.pnlAbs.toString(),
         capital: r.capital.toString(),
-        pnlPctMillionths: r.pnlPct.toString(),
+        // pnlPct is no longer stored on RankedPosition (H1 — ranking is via
+        // exact cross-multiplication). The API contract for observability
+        // still surfaces a millionths value computed on the fly.
+        pnlPctMillionths: ((r.pnlAbs * 1_000_000n) / r.capital).toString(),
       }));
     }
 
@@ -508,7 +523,7 @@ export class AdlService {
         logger.info("ADL tx sent", {
           slabAddress,
           targetIdx: pos.idx,
-          pnlPct: (Number(pos.pnlPct) / 1_000_000).toFixed(4) + "%",
+          pnlPct: (Number((pos.pnlAbs * 1_000_000n) / pos.capital) / 1_000_000).toFixed(4) + "%",
           sig,
         });
 

--- a/tests/poc/h1.poc.test.ts
+++ b/tests/poc/h1.poc.test.ts
@@ -1,0 +1,94 @@
+/**
+ * H1 PoC — ADL ranking truncation collision.
+ *
+ * THE BUG (pre-fix):
+ *   rankProfitablePositions computed pnlPct = (pnl * 1_000_000n) / capital
+ *   with BigInt floor division. Two positions with materially different
+ *   TRUE ratios can collapse to the same TRUNCATED pnlPct, and the sort
+ *   tie-breaks by pnlAbs descending — placing whichever position has the
+ *   larger absolute PnL first. An attacker who tunes their position to
+ *   bucket-collide with an honest counterparty AND has lower pnlAbs gets
+ *   ranked SECOND while the honest party is deleveraged first.
+ *
+ * THE FIX (this PR):
+ *   Replace the fixed-point comparator with cross-multiplication
+ *   (a.pnl * b.capital vs b.pnl * a.capital). Exact BigInt arithmetic —
+ *   every position with a strictly higher true ratio outranks every
+ *   position with a strictly lower one, regardless of fixed-point bucket.
+ *   Tie-break preserved on pnlAbs desc; final tie-break on idx asc
+ *   (deterministic).
+ *
+ * This PoC walks through the collision math and shows the OLD sort orders
+ * honest-first while the NEW sort orders attacker-first.
+ */
+import { describe, it, expect } from "vitest";
+
+interface Pos { idx: number; pnl: bigint; capital: bigint; }
+
+function oldSort(positions: Pos[]): Pos[] {
+  return [...positions]
+    .map((p) => ({ ...p, pnlPct: (p.pnl * 1_000_000n) / p.capital, pnlAbs: p.pnl }))
+    .sort((a, b) => {
+      if (b.pnlPct !== a.pnlPct) return b.pnlPct > a.pnlPct ? 1 : -1;
+      return b.pnlAbs > a.pnlAbs ? 1 : -1;
+    });
+}
+
+function newSort(positions: Pos[]): Pos[] {
+  return [...positions].sort((a, b) => {
+    const lhs = a.pnl * b.capital;
+    const rhs = b.pnl * a.capital;
+    if (lhs !== rhs) return rhs > lhs ? 1 : -1;
+    if (b.pnl !== a.pnl) return b.pnl > a.pnl ? 1 : -1;
+    return a.idx - b.idx;
+  });
+}
+
+describe("H1 PoC — ADL ranking truncation collision", () => {
+  it("collision quadruple: both positions truncate to pnlPct=5 but have different TRUE ratios", () => {
+    const honest = { idx: 11, pnl: 1_000n,   capital: 200_000_000n }; // true: 5e-6
+    const attacker = { idx: 22, pnl: 1n,     capital: 170_000n };    // true: ~5.88e-6
+
+    const honestTruncated = (honest.pnl * 1_000_000n) / honest.capital;
+    const attackerTruncated = (attacker.pnl * 1_000_000n) / attacker.capital;
+    expect(honestTruncated).toBe(5n);
+    expect(attackerTruncated).toBe(5n);
+    // Truncated values match → tie. But the TRUE ratios differ:
+    // honest:   1000 / 200_000_000 = 5 / 1_000_000
+    // attacker: 1    / 170_000     ≈ 5.88 / 1_000_000  (17.6% higher!)
+  });
+
+  it("OLD sort: honest gets ranked first (deleveraged) — attacker skates", () => {
+    const honest = { idx: 11, pnl: 1_000n, capital: 200_000_000n };
+    const attacker = { idx: 22, pnl: 1n,   capital: 170_000n };
+
+    const ranked = oldSort([honest, attacker]);
+    expect(ranked[0]!.idx).toBe(11); // ← honest first (BUG)
+    expect(ranked[1]!.idx).toBe(22); // ← attacker spared
+  });
+
+  it("NEW sort: attacker (truly higher ratio) is ranked first — honest spared", () => {
+    const honest = { idx: 11, pnl: 1_000n, capital: 200_000_000n };
+    const attacker = { idx: 22, pnl: 1n,   capital: 170_000n };
+
+    const ranked = newSort([honest, attacker]);
+    expect(ranked[0]!.idx).toBe(22); // ← attacker first (correct math)
+    expect(ranked[1]!.idx).toBe(11); // ← honest spared
+  });
+
+  it("PoC — preserved invariant: positions with truly EQUAL ratios still tie-break by pnlAbs desc", () => {
+    // Both 30% PnL: 300k/1M and 600k/2M.
+    const small = { idx: 3, pnl: 300_000n,  capital: 1_000_000n };
+    const big   = { idx: 8, pnl: 600_000n,  capital: 2_000_000n };
+
+    const ranked = newSort([small, big]);
+    expect(ranked[0]!.idx).toBe(8); // higher pnlAbs first — preserved
+  });
+
+  it("PoC — deterministic final tie-break on idx ascending when ratio AND pnlAbs are identical", () => {
+    const a = { idx: 17, pnl: 500_000n, capital: 1_000_000n };
+    const b = { idx: 4,  pnl: 500_000n, capital: 1_000_000n };
+    const ranked = newSort([a, b]);
+    expect(ranked[0]!.idx).toBe(4); // lower idx wins the final tie-break
+  });
+});

--- a/tests/services/adl.test.ts
+++ b/tests/services/adl.test.ts
@@ -236,6 +236,54 @@ describe("AdlService", () => {
       const result = await service.scanMarket(slabAddress, makeMarket() as any);
       expect(result).toBe(0);
     });
+
+    // ─── H1: cross-multiplied ranking — no truncation collisions ───────────
+    it("H1: ranks by exact ratio, not truncated 1e6 fixed-point", async () => {
+      // Both positions truncate to the same pnlPct under the old code:
+      //   (1000 * 1_000_000) / 200_000_000 = 5
+      //   (1    * 1_000_000) / 170_000     = 5  (true 5.88, floored)
+      // True ratios: honest 1000/200M = 5e-6, attacker 1/170k ≈ 5.88e-6.
+      // OLD code: honest first (tie-break pnlAbs desc, 1000 > 1).
+      // NEW code: attacker first (cross-mult: 1*200M=200M > 1000*170k=170M).
+      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+        makeAccounts([
+          { idx: 11, pnl: 1_000n, capital: 200_000_000n, positionSize: 100n }, // honest
+          { idx: 22, pnl: 1n,     capital: 170_000n,    positionSize: 50n },  // attacker
+        ]) as any
+      );
+
+      await service.scanMarket(slabAddress, makeMarket() as any);
+
+      // Attacker (idx 22) has the higher true ratio → must be targeted first.
+      expect(sdk.encodeExecuteAdl).toHaveBeenNthCalledWith(1, { targetIdx: 22 });
+    });
+
+    it("H1: equal true ratios still tie-break by pnlAbs descending (preserved)", async () => {
+      // Both have ratio 30%: 300k/1M and 600k/2M. Higher pnlAbs ranks first.
+      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+        makeAccounts([
+          { idx: 3, pnl: 300_000n, capital: 1_000_000n, positionSize: 100n },
+          { idx: 8, pnl: 600_000n, capital: 2_000_000n, positionSize: 200n },
+        ]) as any
+      );
+
+      await service.scanMarket(slabAddress, makeMarket() as any);
+      expect(sdk.encodeExecuteAdl).toHaveBeenNthCalledWith(1, { targetIdx: 8 });
+    });
+
+    it("H1: when pnlAbs AND ratio are equal, idx ascending is the final deterministic tie-break", async () => {
+      // Both ratio 50%, both pnlAbs 500_000. Without the idx tie-break, ordering
+      // would be sort-stability-dependent. We assert the lower idx wins.
+      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+        makeAccounts([
+          { idx: 17, pnl: 500_000n, capital: 1_000_000n, positionSize: 100n },
+          { idx:  4, pnl: 500_000n, capital: 1_000_000n, positionSize: 100n },
+        ]) as any
+      );
+
+      await service.scanMarket(slabAddress, makeMarket() as any);
+      expect(sdk.encodeExecuteAdl).toHaveBeenNthCalledWith(1, { targetIdx: 4 });
+    });
   });
 
   describe("scanMarket — oracle key selection", () => {
@@ -461,6 +509,35 @@ describe("AdlService", () => {
       const after = sharedBudget.getStats();
       expect(after.cycleTxCount).toBe(before.cycleTxCount + 1);
       expect(after.cycleSpend).toBeGreaterThan(before.cycleSpend);
+    });
+  });
+
+  // H1: regression guard on the /api/adl/rankings API contract. The fix drops
+  // the stored pnlPct field; the response still has to surface pnlPctMillionths.
+  describe("H1: getAdlState API contract", () => {
+    beforeEach(() => {
+      service = new AdlService();
+    });
+
+    it("surfaces pnlPctMillionths computed from pnlAbs/capital after the fix", async () => {
+      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+      vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 1_000_000n }) as any);
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
+      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+        makeAccounts([
+          { idx: 1, pnl: 300_000n, capital: 1_000_000n, positionSize: 100n }, // 30% → 300000 millionths
+          { idx: 2, pnl: 600_000n, capital: 1_000_000n, positionSize: 200n }, // 60% → 600000 millionths
+        ]) as any,
+      );
+
+      const state = await service.getAdlState(slabAddress, makeMarket() as any);
+      expect(state.adlNeeded).toBe(true);
+      expect(state.rankings).toHaveLength(2);
+      // Highest ratio first (idx 2, 60%).
+      expect(state.rankings[0]!.idx).toBe(2);
+      expect(state.rankings[0]!.pnlPctMillionths).toBe("600000");
+      expect(state.rankings[1]!.idx).toBe(1);
+      expect(state.rankings[1]!.pnlPctMillionths).toBe("300000");
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes **H1** from the internal pre-mainnet audit. Replaces the truncating fixed-point ADL ranking with an exact cross-multiplied comparator. Shipped as **defense-in-depth hardening** — the precision-loss class is closed permanently regardless of trading scale.

## Root cause

`rankProfitablePositions` in `adl.ts` computed:

```ts
const pnlPct = (pnlAbs * 1_000_000n) / capital; // BigInt floor division
profitable.sort((a, b) => {
  if (b.pnlPct !== a.pnlPct) return b.pnlPct > a.pnlPct ? 1 : -1;
  return b.pnlAbs > a.pnlAbs ? 1 : -1;
});
```

Two positions with materially different *true* ratios can share the same truncated `pnlPct`. The tie-break then ranks the position with the larger `pnlAbs` first, potentially placing an honest counterparty ahead of an attacker who tuned their position to bucket-collide with lower `pnlAbs`.

**Threat scope**: at realistic capital scales (≥ 1e6 base units) the collision granularity is `1 / capital`, so engineered collisions only produce sub-millionth true-ratio gaps in practice — limited exploit window. The fix is shipped to close the class permanently regardless of scale, not because a high-value exploit is currently constructible.

## Fix

Drop the stored `pnlPct` field. Sort with cross-multiplication — exact BigInt arithmetic, no truncation:

```ts
profitable.sort((a, b) => {
  const lhs = a.pnlAbs * b.capital;
  const rhs = b.pnlAbs * a.capital;
  if (lhs !== rhs) return rhs > lhs ? 1 : -1;
  if (b.pnlAbs !== a.pnlAbs) return b.pnlAbs > a.pnlAbs ? 1 : -1;
  return a.idx - b.idx;
});
```

- **Primary**: descending by true ratio (`a.pnl / a.cap` vs `b.pnl / b.cap`).
- **Tie-break 1**: descending by `pnlAbs` (preserved from original).
- **Tie-break 2**: ascending by `idx` — deterministic and attacker-neutral.

## API contract preserved

`/api/adl/rankings` still surfaces `pnlPctMillionths`, now computed inline from `(pnlAbs, capital)` instead of read from the dropped struct field. Same string value — byte-identical response.

## Files touched

- `src/services/adl.ts` — `RankedPosition` no longer carries `pnlPct`; new sort comparator; `getAdlState` and log line compute `pnlPctMillionths` inline.
- `tests/services/adl.test.ts` — 4 new tests.

## Test plan

- [x] **H1 collision regression**: `(pnl=1000, cap=200M)` vs `(pnl=1, cap=170k)` — both truncate to the same `pnlPct=5` under the old code; new code correctly targets the position with the higher true ratio (`idx 22`).
- [x] **Equal-ratio tie-break preserved**: 30% positions of different sizes — higher `pnlAbs` ranks first.
- [x] **Final deterministic tie-break**: identical `pnlAbs` AND ratio — lower `idx` wins.
- [x] **API contract regression**: `getAdlState` rankings still report `pnlPctMillionths` correctly.
- [x] ADL test suite: 21 passed (was 17 before).
- [x] Full vitest suite: **622 passed / 26 skipped** — no regressions.
- [x] `pnpm build` clean.

## Risk

- **Backward-compatible** at the API contract (`/api/adl/rankings`) and at the on-chain integration (`ExecuteAdl` instruction unchanged).
- **Behavior change**: rankings for positions that previously bucket-collided now order strictly by true ratio. In production this affects edge cases only — positions with same truncated bucket but different real ratios — which is exactly the desired correction.

## Scope note

ADL is currently behind `ADL_ENABLED=true` env flag, planned to enable on mainnet once on-chain anchors T8/T10 land (CONTEXT.md lines 10, 27). In scope for the pre-mainnet audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision of ADL position ranking calculations to ensure consistent and accurate target selection across all market conditions.
  * Enhanced position comparison logic with more deterministic tie-breaking when positions have equivalent rankings.

* **Tests**
  * Added regression tests to validate ranking accuracy and prevent future calculation regressions.
  * Added validation tests for the ADL rankings API response format and computational accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->