### PR TITLE
fix(crank): H4 — watchdog must not flip _cycling while crankAll is in-flight

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -183,6 +183,16 @@ export class CrankService {
   private _isRunning = false;
   private _cycling = false;
   private _cycleStartedAt = 0;
+  // H4 (HIGH): wall-clock timestamp (ms) at which the watchdog first observed
+  // the current cycle exceeding MAX_CYCLE_MS. 0 when the watchdog is disarmed.
+  // The watchdog arms once, alerts once, and waits WATCHDOG_GRACE_MS before
+  // calling process.exit(1) for supervisor restart. It does NOT reset
+  // `_cycling` directly — flipping that flag while the in-flight cycle's
+  // Promise.all is still awaiting allows the next interval tick to launch a
+  // SECOND concurrent crankAll(), producing duplicate KeeperCrank txs +
+  // doubled funding accrual + RPC storms. Cleared on natural cycle recovery
+  // (the finally block) so transient slow cycles don't kill the process.
+  private _watchdogArmedAt = 0;
   private _stalePauseCheck?: (slabAddress: string) => boolean;
   // P1 FIX: Cache keypair at construction — was reading from disk on every crank cycle (every 30s)
   private readonly _keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
@@ -1263,24 +1273,50 @@ export class CrankService {
     // above the worst normal Sender retry window.
     const MAX_CYCLE_MS = Math.max(this.intervalMs * 10, 4 * 60_000);
 
+    // H4 (HIGH): when the watchdog observes a cycle exceeding MAX_CYCLE_MS we
+    // give it `WATCHDOG_GRACE_MS` more before exiting the process. A slow but
+    // recovering cycle clears its own _cycling/_watchdogArmedAt via the
+    // finally block; a truly hung cycle hits process.exit and the supervisor
+    // restarts. Critically we never flip `_cycling=false` here — that was the
+    // pre-fix bug that let the next interval tick start a second crankAll()
+    // while the first was still mid-Sender-retry. See the field-comment on
+    // `_watchdogArmedAt` for the full rationale.
+    const WATCHDOG_GRACE_MS = 30_000;
+
     this.timer = setInterval(async () => {
       if (this._cycling) {
         const elapsed = Date.now() - this._cycleStartedAt;
         if (elapsed > MAX_CYCLE_MS) {
-          logger.error("Crank cycle watchdog: cycle exceeded max duration, force-resetting", {
-            elapsedMs: elapsed,
-            maxCycleMs: MAX_CYCLE_MS,
-          });
-          sendCriticalAlert("Crank cycle hung — watchdog reset", [
-            { name: "Elapsed", value: `${Math.round(elapsed / 1000)}s`, inline: true },
-            { name: "Max", value: `${Math.round(MAX_CYCLE_MS / 1000)}s`, inline: true },
-          ])?.catch(() => {});
-          this._cycling = false;
+          if (this._watchdogArmedAt === 0) {
+            // First tick observing the hang — alert once, start grace timer.
+            this._watchdogArmedAt = Date.now();
+            logger.error("Crank cycle watchdog: cycle hung, grace period started before process exit", {
+              elapsedMs: elapsed,
+              maxCycleMs: MAX_CYCLE_MS,
+              graceMs: WATCHDOG_GRACE_MS,
+            });
+            sendCriticalAlert("Crank cycle hung — supervisor restart pending", [
+              { name: "Elapsed", value: `${Math.round(elapsed / 1000)}s`, inline: true },
+              { name: "Max", value: `${Math.round(MAX_CYCLE_MS / 1000)}s`, inline: true },
+              { name: "Grace", value: `${Math.round(WATCHDOG_GRACE_MS / 1000)}s`, inline: true },
+            ])?.catch(() => {});
+          } else if (Date.now() - this._watchdogArmedAt > WATCHDOG_GRACE_MS) {
+            // Grace expired, in-flight cycle did not recover — exit for supervisor restart.
+            // This is safer than flipping _cycling=false (which would double-execute) and
+            // safer than indefinite stall (which would silently halt the keeper).
+            logger.error("Crank cycle still hung after grace period — exiting for supervisor restart", {
+              elapsedMs: elapsed,
+              graceElapsedMs: Date.now() - this._watchdogArmedAt,
+            });
+            process.exit(1);
+          }
+          // NOTE: do NOT reset _cycling here. See field-comment on _watchdogArmedAt.
         }
         return;
       }
       this._cycling = true;
       this._cycleStartedAt = Date.now();
+      this._watchdogArmedAt = 0;
       try {
         // Only rediscover periodically (default 5min) to avoid RPC rate limits
         // PERC-8235: Don't use markets.size===0 as a trigger to rediscover every tick.
@@ -1310,6 +1346,9 @@ export class CrankService {
         logger.error("Crank cycle failed", { error: err });
       } finally {
         this._cycling = false;
+        // H4: disarm the watchdog on natural recovery so a transient slow
+        // cycle doesn't carry a pending kill timer into the next cycle.
+        this._watchdogArmedAt = 0;
       }
     }, this.intervalMs);
   }

--- a/tests/poc/h4.poc.test.ts
+++ b/tests/poc/h4.poc.test.ts
@@ -1,0 +1,127 @@
+/**
+ * H4 PoC — crank watchdog allows a second crankAll() to run concurrently.
+ *
+ * THE BUG (pre-fix):
+ *   The setInterval watchdog set `_cycling = false` whenever elapsed cycle
+ *   time exceeded MAX_CYCLE_MS. But the original crankAll() invocation was
+ *   still awaiting Promise.all — the watchdog merely cleared the in-flight
+ *   guard, it did NOT cancel anything. The next interval tick saw
+ *   `_cycling === false` and launched a SECOND crankAll() concurrently.
+ *
+ * THE FIX (this PR):
+ *   The watchdog now arms a grace timer + alerts once, never flips _cycling.
+ *   If the cycle recovers within WATCHDOG_GRACE_MS, normal recovery; if it
+ *   stays hung past the grace, process.exit(1) lets the supervisor restart.
+ *
+ * This PoC demonstrates: under the OLD code path, an interval tick after a
+ * watchdog reset would happily start a second cycle while the first is still
+ * mid-flight. Under the NEW code path, the second cycle is suppressed.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+interface CrankState {
+  _cycling: boolean;
+  _cycleStartedAt: number;
+  _watchdogArmedAt: number;
+  startedCount: number;
+}
+
+const MAX_CYCLE_MS = 5 * 60_000;
+const WATCHDOG_GRACE_MS = 30_000;
+
+// OLD watchdog body — buggy: flips _cycling, allowing next tick to start another.
+function tickOld(state: CrankState, nowMs: number): { exited: boolean } {
+  if (state._cycling) {
+    const elapsed = nowMs - state._cycleStartedAt;
+    if (elapsed > MAX_CYCLE_MS) {
+      state._cycling = false; // ← THE BUG
+    }
+    return { exited: false };
+  }
+  state._cycling = true;
+  state._cycleStartedAt = nowMs;
+  state.startedCount++;
+  return { exited: false };
+}
+
+// NEW watchdog body — fix: arm grace timer, do not flip _cycling.
+function tickNew(
+  state: CrankState,
+  nowMs: number,
+  alertSpy: () => void,
+): { exited: boolean } {
+  if (state._cycling) {
+    const elapsed = nowMs - state._cycleStartedAt;
+    if (elapsed > MAX_CYCLE_MS) {
+      if (state._watchdogArmedAt === 0) {
+        state._watchdogArmedAt = nowMs;
+        alertSpy();
+      } else if (nowMs - state._watchdogArmedAt > WATCHDOG_GRACE_MS) {
+        return { exited: true }; // process.exit(1) — supervisor restarts
+      }
+    }
+    return { exited: false };
+  }
+  state._cycling = true;
+  state._cycleStartedAt = nowMs;
+  state._watchdogArmedAt = 0;
+  state.startedCount++;
+  return { exited: false };
+}
+
+describe("H4 PoC — watchdog double-execution guard", () => {
+  it("OLD path: hung cycle is force-reset → next tick starts a SECOND crankAll", () => {
+    const state: CrankState = { _cycling: true, _cycleStartedAt: 0, _watchdogArmedAt: 0, startedCount: 1 };
+
+    // Tick 1: at 6 min — exceeds MAX_CYCLE_MS (5 min). OLD code flips _cycling=false.
+    tickOld(state, 6 * 60_000);
+    expect(state._cycling).toBe(false); // ← guard down
+
+    // Tick 2: at 6:30 min — _cycling=false, so a SECOND cycle starts while
+    // the original crankAll is still awaiting Promise.all results.
+    tickOld(state, 6.5 * 60_000);
+    expect(state.startedCount).toBe(2); // ← DOUBLE EXECUTION
+  });
+
+  it("NEW path: hung cycle is NOT force-reset → second cycle cannot launch", () => {
+    const state: CrankState = { _cycling: true, _cycleStartedAt: 0, _watchdogArmedAt: 0, startedCount: 1 };
+    const alertSpy = vi.fn();
+
+    // Tick 1: at 6 min — watchdog arms but DOES NOT flip _cycling.
+    tickNew(state, 6 * 60_000, alertSpy);
+    expect(state._cycling).toBe(true); // ← guard still up
+    expect(state._watchdogArmedAt).toBeGreaterThan(0);
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+
+    // Tick 2: at 6:20 min — still within grace, still _cycling=true.
+    tickNew(state, 6 * 60_000 + 20_000, alertSpy);
+    expect(state._cycling).toBe(true);
+    expect(state.startedCount).toBe(1); // ← NO double execution
+    expect(alertSpy).toHaveBeenCalledTimes(1); // alerts once, not every tick
+  });
+
+  it("NEW path: after grace expires, process.exit(1) is signalled", () => {
+    const state: CrankState = { _cycling: true, _cycleStartedAt: 0, _watchdogArmedAt: 0, startedCount: 1 };
+    const alertSpy = vi.fn();
+
+    tickNew(state, 6 * 60_000, alertSpy); // arm
+    const result = tickNew(state, 6 * 60_000 + 31_000, alertSpy); // past 30s grace
+    expect(result.exited).toBe(true);
+  });
+
+  it("NEW path: cycle recovers within grace → watchdog disarms cleanly", () => {
+    const state: CrankState = { _cycling: true, _cycleStartedAt: 0, _watchdogArmedAt: 0, startedCount: 1 };
+    const alertSpy = vi.fn();
+    tickNew(state, 6 * 60_000, alertSpy); // arm
+    expect(state._watchdogArmedAt).toBeGreaterThan(0);
+
+    // Simulate the original cycle's finally block running:
+    state._cycling = false;
+    state._watchdogArmedAt = 0;
+
+    // Next interval tick starts a fresh cycle normally.
+    tickNew(state, 7 * 60_000, alertSpy);
+    expect(state.startedCount).toBe(2);
+    expect(state._cycling).toBe(true);
+  });
+});

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -1019,6 +1019,122 @@ describe('CrankService', () => {
     });
   });
 
+  // ─── H4 (HIGH): watchdog must not let a second crank cycle launch while the first ──
+  // ─── is still in-flight, and must trigger supervisor restart on a genuine hang.   ──
+  // Pre-fix bug: watchdog set `_cycling=false` when elapsed > MAX_CYCLE_MS, letting
+  // the next interval tick run `crankAll()` concurrently with the in-flight one →
+  // duplicate KeeperCrank txs, doubled funding, RPC storms.
+  describe('H4: watchdog double-execution guard', () => {
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // Mock process.exit so the test doesn't actually kill vitest. The fix calls
+      // process.exit(1) when a cycle hangs beyond MAX_CYCLE_MS + WATCHDOG_GRACE_MS.
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => undefined) as never);
+    });
+
+    afterEach(() => {
+      // Stop the keeper + restore timers + restore process.exit BEFORE the next
+      // test, even if this one timed out — otherwise the leftover setInterval
+      // leaks fake-timer state into subsequent describe blocks.
+      crankService.stop();
+      vi.useRealTimers();
+      exitSpy.mockRestore();
+    });
+
+    // Pre-populates a single dummy market so start() bypasses its initial
+    // `await this.discover()` (which hangs under fake timers when called
+    // before discoverMarkets() resolves). Then under fake timers we can
+    // observe the setInterval ticks directly.
+    function prepStartedService(): void {
+      (crankService as any).markets.set('dummy-slab', {
+        slabAddress: 'dummy-slab',
+        market: {},
+        lastCrankTime: Date.now(),
+        successCount: 0,
+        failureCount: 0,
+        isActive: true,
+        consecutiveErrors: 0,
+      });
+    }
+
+    // Pump the interval into the watchdog branch. _cycling is pre-staged so
+    // the watchdog branch runs synchronously and we never enter the
+    // crankAll/discover path (which would await mocked RPCs and stall the
+    // fake-timer scheduler).
+    function setCyclingHung(elapsedMs: number = 6 * 60_000) {
+      (crankService as any)._cycling = true;
+      (crankService as any)._cycleStartedAt = Date.now() - elapsedMs;
+    }
+
+    it('H4: does NOT reset _cycling when watchdog observes a hung cycle', async () => {
+      prepStartedService();
+      vi.useFakeTimers();
+      void crankService.start(); // sync return — markets is non-empty so discover is skipped
+      setCyclingHung(); // 6 min elapsed > 5 min MAX_CYCLE_MS
+
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      expect((crankService as any)._cycling).toBe(true);
+      expect((crankService as any)._watchdogArmedAt).toBeGreaterThan(0);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('H4: alerts once even across multiple watchdog ticks within grace', async () => {
+      prepStartedService();
+      vi.useFakeTimers();
+      void crankService.start();
+      setCyclingHung();
+      const alertSpy = vi.mocked(shared.sendCriticalAlert);
+      alertSpy.mockClear();
+
+      await vi.advanceTimersByTimeAsync(31_000);
+      // Re-stage so _cycling stays true and elapsed stays > MAX_CYCLE_MS for the next tick.
+      setCyclingHung();
+      await vi.advanceTimersByTimeAsync(15_000); // still inside grace
+
+      expect(alertSpy).toHaveBeenCalledTimes(1);
+      const [title] = alertSpy.mock.calls[0]!;
+      expect(title).toContain('hung');
+    });
+
+    it('H4: process.exit(1) fires after grace period if cycle stays hung', async () => {
+      prepStartedService();
+      vi.useFakeTimers();
+      void crankService.start();
+      setCyclingHung();
+
+      await vi.advanceTimersByTimeAsync(31_000);
+      expect(exitSpy).not.toHaveBeenCalled();
+
+      setCyclingHung();
+      // Advance well past the 30s grace boundary (>= 31s + small slop). The check
+      // is strictly >, so being inside the same fake-time tick that equals exactly
+      // 30s wouldn't fire — give it a comfortable margin.
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('H4: watchdog disarms cleanly when cycle is no longer hung', async () => {
+      prepStartedService();
+      vi.useFakeTimers();
+      void crankService.start();
+      setCyclingHung();
+
+      await vi.advanceTimersByTimeAsync(31_000);
+      expect((crankService as any)._watchdogArmedAt).toBeGreaterThan(0);
+
+      // Simulate the in-flight cycle recovering: _cycling=true with elapsed
+      // under MAX_CYCLE_MS means the watchdog skips the hung branch entirely.
+      setCyclingHung(1_000); // 1s elapsed, well under 5min cap
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      // Next watchdog tick should NOT fire process.exit, because elapsed is now < MAX_CYCLE_MS.
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
+
   // PERC-1650: Keeper RPC 429 retry + sequential mode
   describe('PERC-1650: discover() 429 retry', () => {
     it('calls discoverMarkets with connection and program id', async () => {


### PR DESCRIPTION
## Summary

Fixes **H4** from the internal pre-mainnet audit. The CrankService watchdog could allow a second `crankAll()` invocation to launch concurrently with the in-flight one, producing duplicate `KeeperCrank` txs, double-bumped funding accrual, and RPC storms.

## Root cause

```ts
this.timer = setInterval(async () => {
  if (this._cycling) {
    const elapsed = Date.now() - this._cycleStartedAt;
    if (elapsed > MAX_CYCLE_MS) {
      logger.error(...);
      sendCriticalAlert(...).catch(() => {});
      this._cycling = false;  // ← THE BUG
    }
    return;
  }
  this._cycling = true;
  // ...crankAll()...
}, this.intervalMs);
```

When elapsed cycle time exceeded `MAX_CYCLE_MS` (= `max(intervalMs * 10, 4 min)`), the watchdog cleared `_cycling = false`. But the original `crankAll()` invocation was still awaiting Promise.all results — the watchdog never cancels anything, it just clears the in-flight guard. The next interval tick saw `_cycling === false` and launched a **second** `crankAll()` concurrently with the first.

## Consequences

- **Duplicate `KeeperCrank` txs per market.** Each cycle builds a fresh blockhash and signs independently, producing distinct signatures — Solana's signature-based dedup does NOT apply.
- **Doubled funding accrual** within one window.
- **Doubled Jito tips** on the sender lane (up to 200k lamports each).
- **RPC status-poll storms** — exactly what the watchdog comment said it was added to prevent.
- **Cascading race**: the original cycle's `finally { _cycling=false }` later clobbers the second cycle's `_cycling=true`, letting a third cycle start while the second is still running.

## Fix (Option E from 3-agent design)

Watchdog **logs + alerts + arms a hard-kill timer** but never flips `_cycling`:

```ts
const WATCHDOG_GRACE_MS = 30_000;

if (this._cycling) {
  const elapsed = Date.now() - this._cycleStartedAt;
  if (elapsed > MAX_CYCLE_MS) {
    if (this._watchdogArmedAt === 0) {
      // First tick observing the hang — alert once, arm grace timer.
      this._watchdogArmedAt = Date.now();
      sendCriticalAlert("Crank cycle hung — supervisor restart pending", ...);
    } else if (Date.now() - this._watchdogArmedAt > WATCHDOG_GRACE_MS) {
      // Grace expired — exit for supervisor restart.
      process.exit(1);
    }
    // NOTE: do NOT reset _cycling here — prevents the double-execution race.
  }
  return;
}
// healthy tick path:
this._cycling = true;
this._cycleStartedAt = Date.now();
this._watchdogArmedAt = 0;
```

Natural recovery: the original cycle's `finally` block clears both `_cycling` and `_watchdogArmedAt`. A transient slow cycle recovers within grace; a truly hung cycle hits `process.exit(1)` and the supervisor restarts.

## Why Option E over alternatives

- **(A) Cycle-generation token** — pure bookkeeping; both cycles still run. Rejected.
- **(B) AbortController plumbing** — invasive; touches `sharedTxQueue`, `keeperSend`, `withTimeout`, RPC layers. Violates "1 fix = 1 PR".
- **(C) Log-only watchdog** — risks indefinite stall on genuine hangs.
- **(D) Immediate process.exit** — discards chance of natural recovery from a transient slow cycle.
- **(E) Hybrid (this fix)** — minimal-blast, single-file, preserves alert semantics, gives slow cycles a 30s recovery window, falls back to clean supervisor restart on real hangs. **2-of-3 agents recommended it.**

## Files touched

- `src/services/crank.ts` — add `_watchdogArmedAt` field; replace flag-flip with arm-then-exit logic; reset on healthy tick + natural recovery.
- `tests/services/crank.test.ts` — 4 new H4 tests.

## Test plan

- [x] **`_cycling` is NOT reset when watchdog observes a hung cycle** — regression guard for the double-execution bug.
- [x] **`sendCriticalAlert` fires exactly once across multiple ticks within grace** — anti-spam.
- [x] **`process.exit(1)` fires after the grace period if the cycle stays hung**.
- [x] **Watchdog disarms cleanly when the cycle is no longer hung** — natural recovery path.
- [x] Crank suite: **29 passed** (was 25).
- [x] Full vitest suite: **620 passed / 26 skipped** — no regressions.
- [x] `pnpm build` clean.

## Risk

- **Backward-compatible at the deployment layer.** Requires a process supervisor (Railway/PM2/k8s) — already the default deployment pattern for this stack.
- **Defaults are sane**: 30s grace before process exit.
- **No false-positive restarts**: the natural `finally` block always clears the watchdog state on cycle completion, so a transient slow cycle doesn't kill the process.

## Deferred to a separate PR (per "1 fix = 1 PR")

Agent C proposed a complementary **per-market in-flight guard** (`_inflightMarkets: Set<string>` checked at `crankMarket()` entry). That would add defense-in-depth against any future cause of accidental double-send, not just the watchdog race. Worth shipping as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced watchdog mechanism for cycle monitoring. The service now implements a grace-period approach before restarting if a cycle exceeds maximum duration, with critical alerts to notify operators during issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->