### PR TITLE
fix(keeper): make ADL observe-only to align with admin-gated ExecuteAdl

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,14 +57,17 @@ const liquidationService = new LiquidationService(oracleService);
 const monitorService = new MonitorService();
 const fraudDetector = new FraudDetectorService(oracleService, () => crankService.getMarkets());
 
-// ADL service — gated by ADL_ENABLED=true env var until on-chain instruction
-// (PERC-8273 T8) is live and T10 devnet upgrade is done (PERC-8275).
+// ADL service — OBSERVE-ONLY, gated by ADL_ENABLED=true.
+// ExecuteAdl is admin/multisig-gated on-chain (require_admin + insurance must be
+// fully depleted); the keeper does NOT send it. Protective deleveraging happens
+// permissionlessly inside KeeperCrank/LiquidateAtOracle. This service only reports
+// when on-chain ADL preconditions are met. See services/adl.ts header.
 const adlEnabled = process.env.ADL_ENABLED === "true";
 const adlService = adlEnabled ? new AdlService() : null;
 if (adlEnabled) {
-  logger.info("ADL service enabled (ADL_ENABLED=true)");
+  logger.info("ADL service enabled (observe-only — ExecuteAdl is admin/multisig-gated)");
 } else {
-  logger.info("ADL service disabled — set ADL_ENABLED=true to enable (requires T8+T10)");
+  logger.info("ADL service disabled — set ADL_ENABLED=true for observe-only ADL monitoring");
 }
 
 // HA leader lock — null when HA_ENABLED is not set or KEEPER_REDIS_URL is absent
@@ -453,17 +456,15 @@ res.writeHead(401, secureJsonHeaders);
       }
     }
     
-    // ADL stats
+    // ADL stats — observe-only (ExecuteAdl is admin/multisig-gated; keeper does not send)
     let adlStats: Record<string, unknown> | null = null;
     if (adlService) {
       const stats = adlService.getStats();
-      let totalAdlTxSent = 0;
-      let activeMarkets = 0;
+      let marketsNeedingAdl = 0;
       for (const [, s] of stats) {
-        totalAdlTxSent += s.adlTxSent;
-        if (s.adlTxSent > 0) activeMarkets++;
+        if (s.adlNeeded) marketsNeedingAdl++;
       }
-      adlStats = { enabled: true, totalAdlTxSent, activeMarkets };
+      adlStats = { enabled: true, mode: "observe-only", marketsNeedingAdl };
     } else {
       adlStats = { enabled: false };
     }
@@ -649,7 +650,7 @@ async function start() {
 
     if (adlService) {
       adlService.start(() => crankService.getMarkets());
-      logger.info("ADL service started");
+      logger.info("ADL service started (observe-only)");
     }
   }
 

--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -1,61 +1,43 @@
 /**
- * ADL Service — PERC-8293 (T11): Auto-Deleverage crank loop
+ * ADL Service — OBSERVABILITY ONLY.
  *
- * Originally scaffolded as PERC-8276. Updated in T11 to add:
- *   - Insurance fund utilization BPS threshold check
- *   - Two-phase dispatch comments / scaffolding for T5 (PERC-8270)
+ * Alignment with dcccrypto/percolator-prog `main` (verified against src/percolator.rs):
+ *   `ExecuteAdl` (tag 50) is ADMIN-GATED on-chain. `handle_execute_adl`:
+ *     - percolator.rs:14537  require_admin(header.admin, accounts[0])     → signer MUST be the market admin (else EngineUnauthorized 0xf)
+ *     - percolator.rs:14590  if insurance_fund.balance != 0 → InsuranceFundNotDepleted (0x2f)
+ *     - percolator.rs:14604  if max_pnl_cap > 0 && pnl_pos_tot <= cap → InvalidArgument
  *
- * Feature-flagged via env var `ADL_ENABLED=true` so it can run alongside
- * the existing crank service without affecting production behaviour until
- * the on-chain instruction is live.
+ *   The keeper's crank key is an unprivileged operational hot wallet, NOT the market
+ *   admin — so the keeper MUST NOT send ExecuteAdl (every send would revert), and we
+ *   will NOT put an admin key on the keeper (admin also controls pause / withdraw-insurance
+ *   / resolve — unacceptable blast radius on an always-online process).
  *
- * Responsibilities:
- *  1. Per-market: fetch slab data, check `pnl_pos_tot > max_pnl_cap` OR
- *     insurance fund utilization BPS > ADL_INSURANCE_UTIL_THRESHOLD_BPS
- *  2. When ADL is needed: rank all profitable positions by PnL%
- *  3. Call ExecuteAdl (tag 50) on the top-ranked position
- *  4. Repeat until pnl_pos_tot ≤ max_pnl_cap or no profitable positions remain
+ *   Routine, protective deleveraging already happens PERMISSIONLESSLY inside
+ *   `KeeperCrank` (tag 5 → permissionless_progress_not_atomic) and `LiquidateAtOracle`
+ *   (tag 7), both already sent by the keeper. Targeted ExecuteAdl is an admin / multisig
+ *   governance action and is intentionally NOT automated here.
  *
- * Two-phase crank note (T5/PERC-8270):
- *  The on-chain two-phase split (prepare + execute) lives in the Rust program.
- *  From the keeper's perspective the call signature is unchanged — we send a
- *  single KeeperCrank transaction. When T5 lands, update the
- *  `PrepareAdlResult` / `PhaseOneKeeperArgs` types in crank-types.ts and wire
- *  the prepare step here before the ExecuteAdl dispatch.
+ * Responsibilities (read-only):
+ *  1. Per-market: fetch slab, evaluate whether the on-chain ADL preconditions are met
+ *     (insurance fully depleted AND profit above the PnL cap).
+ *  2. Expose that state + a PnL%-ranked deleverage list via getAdlState()/getStats()
+ *     for the /api/adl/rankings endpoint and the MonitorService alert.
+ *  This service sends NO transactions. Feature-flagged via `ADL_ENABLED=true`.
  *
  * Dependency surface:
- *  - @percolator/sdk:  fetchSlab, parseEngine, parseConfig, parseAllAccounts,
- *                      encodeExecuteAdl, ACCOUNTS_EXECUTE_ADL, buildAccountMetas,
- *                      buildIx, derivePythPushOraclePDA
- *  - @percolatorct/shared: getConnection, loadKeypair, sendWithRetryKeeper,
- *                        createLogger, sendWarningAlert, sendCriticalAlert
+ *  - @percolatorct/sdk:  fetchSlab, parseEngine, parseConfig, parseAllAccounts
+ *  - @percolatorct/shared: getConnection, createLogger, sendWarningAlert
  */
 
-import { PublicKey, SYSVAR_CLOCK_PUBKEY } from "@solana/web3.js";
 import {
   fetchSlab,
   parseEngine,
   parseConfig,
   parseAllAccounts,
-  encodeExecuteAdl,
-  ACCOUNTS_EXECUTE_ADL,
-  buildAccountMetas,
-  buildIx,
-  derivePythPushOraclePDA,
   type DiscoveredMarket,
 } from "@percolatorct/sdk";
-import {
-  getConnection,
-  loadKeypair,
-  createLogger,
-  sendWarningAlert,
-  sendCriticalAlert,
-} from "@percolatorct/shared";
+import { getConnection, createLogger, sendWarningAlert } from "@percolatorct/shared";
 import type { MarketCrankState } from "./crank-types.js";
-import { recordAttempt, recordLanded, recordFailed } from "../lib/sender-metrics.js";
-import { txSentTotal, solSpentLamportsTotal, txLandTimeSeconds } from "../lib/metrics.js";
-import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
-import { sharedTxQueue } from "../lib/tx-queue.js";
 
 const logger = createLogger("keeper:adl");
 
@@ -85,49 +67,29 @@ function parseBigIntEnv(name: string, fallback: string): bigint {
 }
 
 /**
- * How often to run the ADL scan loop in milliseconds.
- * Default 10 s — fast enough to clear excess PnL promptly; slow enough to
- * avoid hammering RPC on quiet markets.
+ * How often to run the ADL observation loop in milliseconds.
+ * Default 10 s.
  */
 const ADL_INTERVAL_MS = parseIntEnv("ADL_INTERVAL_MS", 10_000, 1000);
 
 /**
- * Maximum number of ExecuteAdl transactions sent per market per ADL scan.
- * Guards against runaway loops if on-chain state is not updating between cycles.
- */
-const ADL_MAX_TX_PER_SCAN = parseIntEnv("ADL_MAX_TX_PER_SCAN", 10, 1);
-
-/**
- * Insurance fund balance threshold below which ADL kicks in (raw lamports).
- * Set to 0 to rely solely on pnl_pos_tot > max_pnl_cap.
+ * Insurance fund utilization BPS threshold — INFORMATIONAL ONLY.
  *
- * Per PERC-305 spec: ADL is triggered when pnl_pos_tot > max_pnl_cap,
- * which is itself a proxy for insurance fund stress.  This extra guard
- * allows ops to tune ADL sensitivity independently.
+ * utilization_bps = (fee_revenue - balance) * 10_000 / max(fee_revenue, 1)
  *
- * Unit: raw lamports (bigint).  Default 0 = disabled.
- */
-const ADL_INSURANCE_THRESHOLD = parseBigIntEnv(
-  "ADL_INSURANCE_THRESHOLD_LAMPORTS", "0"
-);
-
-/**
- * PERC-8293 (T11): Insurance fund utilization BPS threshold.
- *
- * ADL also triggers when the insurance fund is sufficiently drawn down,
- * measured as:
- *   utilization_bps = (fee_revenue - balance) * 10_000 / max(fee_revenue, 1)
- *
- * This captures the fraction of lifetime fee revenue that has been consumed
- * by socialised losses.  When fee_revenue == 0 (fresh market), utilization is
- * treated as 0 (not triggered).
- *
- * Default 8000 BPS = 80% utilization triggers ADL even before pnl_pos_tot
- * exceeds max_pnl_cap.  Set to 0 to disable the utilization gate.
+ * The on-chain ADL gate is `balance == 0` (full depletion), NOT a utilization
+ * ratio, so this is exposed for dashboards/early-warning but is NOT part of the
+ * adlNeeded decision. Default 8000 BPS = 80%.
  */
 const ADL_INSURANCE_UTIL_THRESHOLD_BPS = parseBigIntEnv(
   "ADL_INSURANCE_UTIL_THRESHOLD_BPS", "8000"
 );
+
+/**
+ * Minimum gap between repeated "ADL conditions met" warning alerts per market.
+ * Avoids alert spam while conditions persist (admin/multisig action is manual).
+ */
+const ADL_ALERT_COOLDOWN_MS = parseIntEnv("ADL_ALERT_COOLDOWN_MS", 30 * 60_000, 1000);
 
 // ─── types ─────────────────────────────────────────────────────────────────
 
@@ -141,6 +103,9 @@ interface RankedPosition {
 /**
  * Result of the ADL trigger-check for a market.
  * Exposed on the /api/adl/rankings endpoint for observability.
+ *
+ * `adlNeeded` mirrors the program's ExecuteAdl preconditions: insurance fully
+ * depleted (balance == 0) AND (cap disabled with profit to shed, or pnl > cap).
  */
 export interface AdlTriggerState {
   slabAddress: string;
@@ -150,7 +115,9 @@ export interface AdlTriggerState {
   insuranceFundFeeRevenue: string;
   insuranceUtilizationBps: number;
   capExceeded: boolean;
+  /** True iff insurance_fund.balance == 0 (the program's hard ADL precondition). */
   insuranceDepleted: boolean;
+  /** Informational only — utilization >= threshold. NOT part of adlNeeded. */
   utilizationTriggered: boolean;
   adlNeeded: boolean;
   rankings: Array<{
@@ -164,8 +131,12 @@ export interface AdlTriggerState {
 
 interface AdlMarketState {
   lastScanTime: number;
-  adlTxSent: number;
-  consecutiveErrors: number;
+  /** Whether the on-chain ADL preconditions were met at the last scan. */
+  adlNeeded: boolean;
+  /** Last time (ms) adlNeeded was observed true. */
+  lastAdlNeededTime: number;
+  /** Last time (ms) an "ADL conditions met" alert was emitted for this market. */
+  lastAlertTime: number;
 }
 
 // ─── helpers ───────────────────────────────────────────────────────────────
@@ -187,35 +158,43 @@ function computeInsuranceUtilizationBps(
   return bps > 10_000n ? 10_000n : bps;
 }
 
-/** Returns a structured trigger state for a market. */
+/**
+ * Evaluate the program's ExecuteAdl preconditions for a market.
+ *
+ * Mirrors handle_execute_adl (percolator.rs:14588-14612):
+ *   adlNeeded ⇔ insurance_fund.balance == 0
+ *               AND (max_pnl_cap == 0 ? pnl_pos_tot > 0 : pnl_pos_tot > max_pnl_cap)
+ */
 function checkAdlTrigger(
   pnlPosTot: bigint,
   maxPnlCap: bigint,
   insuranceFundBalance: bigint,
   insuranceFundFeeRevenue: bigint,
   slabAddress: string,
-  data: Uint8Array
 ): Omit<AdlTriggerState, "rankings"> & { excess: bigint } {
+  // Program gate (percolator.rs:14590): insurance must be FULLY depleted.
+  const insuranceDepleted = insuranceFundBalance === 0n;
+  // Program cap pre-check (percolator.rs:14604): with a cap set, pnl must exceed it.
   const capExceeded = maxPnlCap > 0n && pnlPosTot > maxPnlCap;
-  const insuranceDepleted =
-    ADL_INSURANCE_THRESHOLD > 0n &&
-    insuranceFundBalance < ADL_INSURANCE_THRESHOLD;
+
   const utilizationBps = computeInsuranceUtilizationBps(
     insuranceFundBalance,
     insuranceFundFeeRevenue
   );
+  // Informational only — the program keys off balance == 0, not a ratio.
   const utilizationTriggered =
     ADL_INSURANCE_UTIL_THRESHOLD_BPS > 0n &&
     utilizationBps >= ADL_INSURANCE_UTIL_THRESHOLD_BPS;
 
-  // ADL disabled if max_pnl_cap == 0 UNLESS insurance utilization gate fires
+  // ADL is admissible on-chain only when insurance is fully depleted AND either
+  // the cap is disabled (any profit can be shed) or profit exceeds the cap.
   const adlNeeded =
-    capExceeded || insuranceDepleted || utilizationTriggered;
+    insuranceDepleted && (maxPnlCap === 0n ? pnlPosTot > 0n : capExceeded);
 
   const excess =
-    capExceeded && maxPnlCap > 0n
-      ? pnlPosTot - maxPnlCap
-      : pnlPosTot; // Use full pnlPosTot as excess when triggered by insurance
+    maxPnlCap > 0n
+      ? (pnlPosTot > maxPnlCap ? pnlPosTot - maxPnlCap : 0n)
+      : pnlPosTot;
 
   return {
     slabAddress,
@@ -233,34 +212,11 @@ function checkAdlTrigger(
 }
 
 /**
- * @deprecated Use checkAdlTrigger instead.
- * Returns true when ADL should run for this market given engine state.
- */
-function isAdlNeeded(
-  pnlPosTot: bigint,
-  maxPnlCap: bigint,
-  insuranceFundBalance: bigint
-): boolean {
-  if (maxPnlCap === 0n) return false; // ADL disabled on market (max_pnl_cap=0)
-
-  const capExceeded = pnlPosTot > maxPnlCap;
-
-  // Optional insurance fund gate (operator configurable)
-  const insuranceDepleted =
-    ADL_INSURANCE_THRESHOLD > 0n &&
-    insuranceFundBalance < ADL_INSURANCE_THRESHOLD;
-
-  return capExceeded || insuranceDepleted;
-}
-
-/**
- * Rank all profitable positions by PnL% (descending).
+ * Rank all profitable positions by PnL% (descending) — the order an admin/multisig
+ * would deleverage in. Read-only; exposed via getAdlState() for tooling.
  * Uses capital as denominator; positions with zero capital are excluded.
  */
-function rankProfitablePositions(
-  data: Uint8Array,
-  excess: bigint
-): RankedPosition[] {
+function rankProfitablePositions(data: Uint8Array): RankedPosition[] {
   const allAccounts = parseAllAccounts(data);
   const profitable: RankedPosition[] = [];
 
@@ -286,7 +242,7 @@ function rankProfitablePositions(
   return profitable;
 }
 
-// ─── ADL service class ─────────────────────────────────────────────────────
+// ─── ADL service class (observe-only) ────────────────────────────────────────
 
 export class AdlService {
   private markets = new Map<string, AdlMarketState>();
@@ -294,8 +250,6 @@ export class AdlService {
   private _getMarkets: (() => Map<string, MarketCrankState>) | null = null;
   private _isRunning = false;
   private _cycling = false;
-  // Cache keypair at construction — avoids re-parsing from env on every scanMarket() call
-  private readonly _keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
   private _cycleStartedAt = 0;
 
   /** Inject the crank service's market map so ADL can iterate tracked markets. */
@@ -308,10 +262,8 @@ export class AdlService {
   }
 
   /**
-   * PERC-8293 (T11): Fetch on-chain state and return ADL trigger info + position
-   * rankings for a single market without sending any transactions.
-   *
-   * Used by the /api/adl/rankings API endpoint.
+   * Fetch on-chain state and return ADL trigger info + position rankings for a
+   * single market. Read-only — sends nothing. Used by /api/adl/rankings.
    */
   async getAdlState(slabAddress: string, market: DiscoveredMarket): Promise<AdlTriggerState> {
     const connection = getConnection();
@@ -332,12 +284,11 @@ export class AdlService {
       engine.insuranceFund.balance,
       engine.insuranceFund.feeRevenue,
       slabAddress,
-      data
     );
 
     let rankings: AdlTriggerState["rankings"] = [];
     if (trigger.adlNeeded) {
-      const ranked = rankProfitablePositions(data, trigger.excess);
+      const ranked = rankProfitablePositions(data);
       rankings = ranked.map((r, i) => ({
         rank: i + 1,
         idx: r.idx,
@@ -347,23 +298,21 @@ export class AdlService {
       }));
     }
 
-    return { ...trigger, rankings };
+    // Drop the internal-only `excess` field from the public shape.
+    const { excess: _excess, ...publicTrigger } = trigger;
+    return { ...publicTrigger, rankings };
   }
 
   /**
-   * Scan one market for ADL conditions.
-   * Returns number of ExecuteAdl transactions sent (0 if ADL not needed).
+   * Observe one market: evaluate the on-chain ADL preconditions and record state.
+   * Sends NO transactions (ExecuteAdl is admin/multisig-gated — see file header).
+   * Returns 1 if the market currently meets ADL preconditions, else 0.
    */
   async scanMarket(slabAddress: string, market: DiscoveredMarket): Promise<number> {
-    // B17: stamp lastScanTime on every scan so /status reports activity even
-    // when the trigger conditions are false. Without this the field stays at 0
-    // and looks like the ADL service has never run — operators can't tell
-    // "ADL is off" from "ADL is hung".
-    this._getOrCreateState(slabAddress).lastScanTime = Date.now();
+    const state = this._getOrCreateState(slabAddress);
+    state.lastScanTime = Date.now();
 
     const connection = getConnection();
-    const keypair = this._keypair;
-    const programId = market.programId;
 
     let data: Uint8Array;
     try {
@@ -385,181 +334,46 @@ export class AdlService {
       engine.insuranceFund.balance,
       engine.insuranceFund.feeRevenue,
       slabAddress,
-      data
     );
+
+    state.adlNeeded = trigger.adlNeeded;
 
     if (!trigger.adlNeeded) {
       return 0;
     }
 
-    const { excess } = trigger;
-    logger.info("ADL triggered for market", {
+    state.lastAdlNeededTime = Date.now();
+    logger.info("ADL conditions met (observe-only — ExecuteAdl is admin/multisig-gated)", {
       slabAddress,
       pnlPosTot: trigger.pnlPosTot,
       maxPnlCap: trigger.maxPnlCap,
-      excess: excess.toString(),
+      excess: trigger.excess.toString(),
       insuranceFundBalance: trigger.insuranceFundBalance,
       insuranceUtilizationBps: trigger.insuranceUtilizationBps,
-      capExceeded: trigger.capExceeded,
-      utilizationTriggered: trigger.utilizationTriggered,
     });
 
-    // ── T5 two-phase hook (PERC-8270) ─────────────────────────────────────
-    // When anchor T5 lands, add a PrepareAdl instruction dispatch here before
-    // executing ExecuteAdl. The prepare phase reads oracle/price state and
-    // writes a PrepareAdlResult PDA that the execute phase consumes.
-    //
-    // Pseudocode for when T5 is live:
-    //   const prepareData = encodePrepareAdl({ ...args });
-    //   const prepareSig = await sendWithRetryKeeper(conn, [buildIx(...)], [keypair]);
-    //   const prepareResult = await fetchPrepareAdlResult(conn, prepareResultPda);
-    //
-    // See crank-types.ts → PrepareAdlArgs / PrepareAdlResult for the scaffold.
-    // ──────────────────────────────────────────────────────────────────────
-
-    // Derive oracle key (same logic as crank.ts)
-    const pConfig = cfg;
-
-    // Rank profitable positions (reuse trigger.excess calculated above)
-    const ranked = rankProfitablePositions(data, excess);
-    if (ranked.length === 0) {
-      logger.warn("ADL: pnl_pos_tot exceeds cap but no profitable positions found — stale state?", {
-        slabAddress,
-      });
-      return 0;
+    // Rate-limited operator alert — the actual ExecuteAdl is a manual admin/multisig action.
+    const now = Date.now();
+    if (now - state.lastAlertTime > ADL_ALERT_COOLDOWN_MS) {
+      state.lastAlertTime = now;
+      sendWarningAlert("ADL conditions met — admin/multisig action required", [
+        { name: "Market", value: slabAddress.slice(0, 16) + "...", inline: false },
+        { name: "pnl_pos_tot", value: trigger.pnlPosTot, inline: true },
+        { name: "max_pnl_cap", value: trigger.maxPnlCap, inline: true },
+        { name: "insurance_balance", value: trigger.insuranceFundBalance, inline: true },
+      ])?.catch(() => {});
     }
 
-    // Determine oracle key (same logic as crank.ts)
-    const feedBytes = pConfig.indexFeedId.toBytes();
-    const isZeroFeed = feedBytes.every((b: number) => b === 0);
-    const isAdminOracle = !pConfig.oracleAuthority.equals(PublicKey.default);
-
-    let oracleKey: PublicKey;
-    if (isAdminOracle || isZeroFeed) {
-      // Admin-oracle or HYPERP mode: oracle account is the slab itself
-      oracleKey = market.slabAddress;
-    } else {
-      const feedHex = Array.from(feedBytes)
-        .map((b: number) => b.toString(16).padStart(2, "0"))
-        .join("");
-      oracleKey = derivePythPushOraclePDA(feedHex)[0];
-    }
-
-    let sent = 0;
-    let remainingExcess = excess;
-
-    for (const pos of ranked) {
-      if (sent >= ADL_MAX_TX_PER_SCAN) {
-        logger.warn("ADL: reached max tx cap per scan", {
-          slabAddress,
-          maxTxPerScan: ADL_MAX_TX_PER_SCAN,
-          remainingExcess: remainingExcess.toString(),
-        });
-        break;
-      }
-      if (remainingExcess <= 0n) break;
-
-      try {
-        const adlData = encodeExecuteAdl({ targetIdx: pos.idx });
-        const adlKeys = buildAccountMetas(ACCOUNTS_EXECUTE_ADL, [
-          keypair.publicKey,
-          market.slabAddress,
-          SYSVAR_CLOCK_PUBKEY,
-          oracleKey,
-        ]);
-        const ix = buildIx({ programId, keys: adlKeys, data: adlData });
-
-        const __t0 = Date.now();
-        recordAttempt();
-        let sig: string;
-        try {
-          // A.9: route ADL through the budget+priority-fee+CU pipeline. ADL
-          // was the only send-path that bypassed KeeperBudget; the cap that
-          // protects the keeper wallet from a runaway crank or liquidation
-          // loop did nothing for ADL until this fix.
-          // ADL is liquidation-priority — always dispatched from the liquidation lane.
-          const result = await sharedTxQueue.enqueue("liquidation", () =>
-            keeperSend(connection, [ix], [keypair], "adl", sharedBudget),
-          );
-          if (!result) {
-            logger.warn("ADL: budget gate refused send — skipping target", {
-              slabAddress,
-              targetIdx: pos.idx,
-              stats: sharedBudget.getStats(),
-            });
-            recordFailed();
-            break;
-          }
-          sig = result.signature;
-          const __tip = process.env.USE_HELIUS_SENDER === "true"
-            ? parseInt(process.env.JITO_TIP_LAMPORTS ?? "200000", 10)
-            : 0;
-          const __elapsed = Date.now() - __t0;
-          recordLanded(__elapsed, __tip);
-          txSentTotal.inc({ result: "success", type: "liquidation" });
-          txLandTimeSeconds.observe({ type: "liquidation", lane: __tip > 0 ? "jito" : "sender" }, __elapsed / 1000);
-          if (__tip > 0) solSpentLamportsTotal.inc({ type: "liquidation" }, __tip);
-        } catch (err) {
-          recordFailed();
-          txSentTotal.inc({ result: "fail", type: "liquidation" });
-          throw err;
-        }
-
-        logger.info("ADL tx sent", {
-          slabAddress,
-          targetIdx: pos.idx,
-          pnlPct: (Number(pos.pnlPct) / 1_000_000).toFixed(4) + "%",
-          sig,
-        });
-
-        sent++;
-        // Optimistic: reduce remaining excess by the position's PnL.
-        // On next cycle we re-fetch fresh state anyway.
-        remainingExcess =
-          remainingExcess > pos.pnlAbs ? remainingExcess - pos.pnlAbs : 0n;
-      } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
-        logger.error("ADL tx failed", {
-          slabAddress,
-          targetIdx: pos.idx,
-          error: errMsg,
-        });
-
-        const state = this._getOrCreateState(slabAddress);
-        state.consecutiveErrors++;
-
-        if (state.consecutiveErrors >= 3) {
-          await sendWarningAlert("ADL consecutive failures", [
-            { name: "Market", value: slabAddress.slice(0, 12), inline: true },
-            {
-              name: "Consecutive Errors",
-              value: state.consecutiveErrors.toString(),
-              inline: true,
-            },
-            { name: "Error", value: errMsg.slice(0, 100), inline: false },
-          ]).catch(() => {});
-        }
-        // Continue to next position — one failure shouldn't abort the whole run.
-      }
-    }
-
-    if (sent > 0) {
-      const state = this._getOrCreateState(slabAddress);
-      state.adlTxSent += sent;
-      state.consecutiveErrors = 0;
-    }
-
-    return sent;
+    return 1;
   }
 
-  /** Run ADL scan across all tracked markets. */
-  async scanAll(): Promise<{ scanned: number; triggered: number; txSent: number }> {
-    if (!this._getMarkets) return { scanned: 0, triggered: 0, txSent: 0 };
+  /** Observe all tracked markets for ADL conditions. */
+  async scanAll(): Promise<{ scanned: number; needingAdl: number }> {
+    if (!this._getMarkets) return { scanned: 0, needingAdl: 0 };
 
     const markets = this._getMarkets();
     let scanned = 0;
-    let triggered = 0;
-    let txSent = 0;
+    let needingAdl = 0;
 
     for (const [slabAddress, crankState] of markets) {
       // Skip permanently-skipped markets
@@ -567,12 +381,9 @@ export class AdlService {
       if (crankState.foreignOracleSkipped) continue;
 
       try {
-        const sent = await this.scanMarket(slabAddress, crankState.market);
+        const r = await this.scanMarket(slabAddress, crankState.market);
         scanned++;
-        if (sent > 0) {
-          triggered++;
-          txSent += sent;
-        }
+        if (r > 0) needingAdl++;
       } catch (err) {
         logger.error("ADL scanMarket threw unexpectedly", {
           slabAddress,
@@ -581,7 +392,7 @@ export class AdlService {
       }
     }
 
-    return { scanned, triggered, txSent };
+    return { scanned, needingAdl };
   }
 
   start(getMarkets: () => Map<string, MarketCrankState>): void {
@@ -589,7 +400,7 @@ export class AdlService {
     this._getMarkets = getMarkets;
     this._isRunning = true;
 
-    logger.info("ADL service starting", { intervalMs: ADL_INTERVAL_MS });
+    logger.info("ADL service starting (observe-only)", { intervalMs: ADL_INTERVAL_MS });
 
     const MAX_CYCLE_MS = ADL_INTERVAL_MS * 5;
 
@@ -613,8 +424,8 @@ export class AdlService {
       this._cycleStartedAt = Date.now();
       try {
         const result = await this.scanAll();
-        if (result.triggered > 0) {
-          logger.info("ADL scan complete", result);
+        if (result.needingAdl > 0) {
+          logger.info("ADL observation complete", result);
         }
       } catch (err) {
         logger.error("ADL scan cycle error", {
@@ -639,8 +450,9 @@ export class AdlService {
     if (!this.markets.has(slabAddress)) {
       this.markets.set(slabAddress, {
         lastScanTime: 0,
-        adlTxSent: 0,
-        consecutiveErrors: 0,
+        adlNeeded: false,
+        lastAdlNeededTime: 0,
+        lastAlertTime: 0,
       });
     }
     return this.markets.get(slabAddress)!;

--- a/src/services/crank-types.ts
+++ b/src/services/crank-types.ts
@@ -3,10 +3,6 @@
  *
  * Extracted from crank.ts so adl.ts can import MarketCrankState without
  * creating a circular dependency.
- *
- * PERC-8293 (T11): Two-phase ADL dispatch scaffolding added.
- * When anchor T5 (PERC-8270) ships, wire PrepareAdlArgs / PrepareAdlResult
- * into adl.ts scanMarket() — see the T5 hook comment there.
  */
 import type { DiscoveredMarket } from "@percolatorct/sdk";
 
@@ -26,48 +22,3 @@ export interface MarketCrankState {
   hyperpNoPriceSkipped?: boolean;
   dexPoolAddress?: string;
 }
-
-// =============================================================================
-// T5 / PERC-8270: Two-phase ADL dispatch scaffolding
-// These types are NOT yet used — they are ready for when anchor T5 merges.
-// Update adl.ts scanMarket() to send a PrepareAdl instruction and decode
-// the PrepareAdlResult PDA before dispatching ExecuteAdl.
-// =============================================================================
-
-/**
- * Arguments for the PrepareAdl on-chain instruction (T5 phase 1).
- *
- * Phase 1 reads oracle price and current slab state, then writes a
- * PrepareAdlResult PDA that phase 2 (ExecuteAdl) consumes atomically.
- * Sending both in the same transaction ensures a consistent price snapshot.
- */
-export interface PrepareAdlArgs {
-  /** Slab address of the market */
-  slabAddress: string;
-  /** Current oracle price in e6 format */
-  oraclePriceE6: bigint;
-  /** Slot at which the price was read */
-  priceSlot: bigint;
-}
-
-/**
- * Result decoded from the PrepareAdlResult PDA after phase 1 succeeds.
- * Passed to ExecuteAdl in phase 2.
- */
-export interface PrepareAdlResult {
-  /** PDA address of the PrepareAdlResult account */
-  resultPda: string;
-  /** Validated oracle price committed in phase 1 */
-  committedPriceE6: bigint;
-  /** Excess PnL above max_pnl_cap as computed on-chain in phase 1 */
-  excessPnl: bigint;
-  /** Slot the prepare was committed at */
-  commitSlot: bigint;
-}
-
-/**
- * Discriminator byte for the PrepareAdl instruction.
- * Placeholder — replace with actual tag once anchor T5 IDL is published.
- * @see PERC-8270
- */
-export const IX_TAG_PREPARE_ADL = 0xff; // TODO: replace with real tag from T5 IDL

--- a/src/services/monitor.ts
+++ b/src/services/monitor.ts
@@ -249,12 +249,17 @@ export class MonitorService {
         }
 
         // ── 6.3: ADL staleness ─────────────────────────────────────────────
-        // Check if ADL is needed by comparing pnl_pos_tot against max_pnl_cap.
+        // ADL is admissible on-chain ONLY when the insurance fund is fully
+        // depleted (percolator.rs:14590 InsuranceFundNotDepleted) AND profit
+        // exceeds the cap (percolator.rs:14604). Both conditions are required —
+        // gating on pnl>cap alone produced false "ADL needed" alerts for healthy
+        // markets whose insurance fund still held a balance.
         // We reuse the data already fetched above.
         const { pnlPosTot } = engine;
         // maxPnlCap lives on MarketConfig (parseConfig), already parsed above.
         const maxPnlCap = cfg.maxPnlCap;
-        const adlNeeded = maxPnlCap > 0n && pnlPosTot > maxPnlCap;
+        const insuranceDepleted = engine.insuranceFund.balance === 0n;
+        const adlNeeded = insuranceDepleted && maxPnlCap > 0n && pnlPosTot > maxPnlCap;
 
         const mState = this._getOrCreatePerMarket(slabAddress);
         const cyclesSinceLastAdl = adlNeeded
@@ -274,21 +279,26 @@ export class MonitorService {
         this._adlStalenessResults.set(slabAddress, adlResult);
 
         if (stale) {
-          logger.warn("ADL needed but no ADL tx sent recently", {
+          // ExecuteAdl is admin/multisig-gated on-chain — the keeper does NOT
+          // execute it (see services/adl.ts). A persistent adlNeeded means an
+          // admin/multisig deleverage action is overdue, not that the keeper stalled.
+          logger.warn("ADL conditions persist — admin/multisig action overdue", {
             slabAddress,
             pnlPosTot: pnlPosTot.toString(),
             maxPnlCap: maxPnlCap.toString(),
+            insuranceFundBalance: engine.insuranceFund.balance.toString(),
             cyclesSinceLastAdl,
             threshold: ADL_STALENESS_CYCLE_THRESHOLD,
           });
 
           if (now - mState.lastAdlStalenessAlert > ALERT_COOLDOWN_MS) {
             mState.lastAdlStalenessAlert = now;
-            sendWarningAlert("ADL needed but keeper has not executed it recently", [
+            sendWarningAlert("ADL conditions met — admin/multisig action required", [
               { name: "Market", value: slabAddress.slice(0, 16) + "...", inline: false },
               { name: "pnl_pos_tot", value: pnlPosTot.toString(), inline: true },
               { name: "max_pnl_cap", value: maxPnlCap.toString(), inline: true },
-              { name: "Cycles without ADL tx", value: cyclesSinceLastAdl.toString(), inline: true },
+              { name: "insurance_balance", value: engine.insuranceFund.balance.toString(), inline: true },
+              { name: "Cycles persisting", value: cyclesSinceLastAdl.toString(), inline: true },
             ]).catch(() => {});
           }
         }

--- a/tests/services/adl-poc-program-mismatch.test.ts
+++ b/tests/services/adl-poc-program-mismatch.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression for ADL-1 / ADL-2 (was the PoC that proved the finding).
+ *
+ * Original finding (against dcccrypto/percolator-prog main, src/percolator.rs handle_execute_adl):
+ *   - percolator.rs:14537  require_admin(header.admin, accounts[0])      → signer MUST be the market admin
+ *   - percolator.rs:14590  if insurance_fund.balance != 0 → InsuranceFundNotDepleted
+ *   The keeper signed ExecuteAdl with the (non-admin) CRANK_KEYPAIR and triggered while the
+ *   insurance fund still held a balance → every send reverted (0xf / 0x2f).
+ *
+ * Fix: ADL is now OBSERVE-ONLY. The keeper sends NO ExecuteAdl. These tests lock that in:
+ *   ADL-1 — adlNeeded is false unless insurance_fund.balance == 0.
+ *   ADL-2 — no ExecuteAdl is ever encoded/built/sent, even when ADL preconditions are met.
+ * If anyone re-introduces a keeper-side ADL send path, the ADL-2 spies below will fire.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Spies on every encode/build/send primitive a regression could use to send ExecuteAdl.
+// Created via vi.hoisted so they exist before the hoisted vi.mock factories run.
+const spies = vi.hoisted(() => ({
+  encodeExecuteAdl: vi.fn(() => Buffer.from([50, 0, 0])),
+  buildIx: vi.fn(() => ({ keys: [], data: Buffer.from([]) })),
+  buildAccountMetas: vi.fn(() => []),
+  sendWithRetryKeeper: vi.fn(async () => "sig"),
+}));
+
+vi.mock("@percolatorct/sdk", () => ({
+  fetchSlab: vi.fn(),
+  parseEngine: vi.fn(),
+  parseConfig: vi.fn(),
+  parseAllAccounts: vi.fn(() => []),
+  // present-but-must-never-be-called by the keeper's ADL path:
+  encodeExecuteAdl: spies.encodeExecuteAdl,
+  buildIx: spies.buildIx,
+  buildAccountMetas: spies.buildAccountMetas,
+  ACCOUNTS_EXECUTE_ADL: [],
+  derivePythPushOraclePDA: vi.fn(() => [{ toBase58: () => "x" }, 255]),
+}));
+
+vi.mock("@percolatorct/shared", () => ({
+  getConnection: vi.fn(() => ({})),
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  sendWarningAlert: vi.fn(async () => {}),
+  // must never be called by ADL:
+  sendWithRetryKeeper: spies.sendWithRetryKeeper,
+  loadKeypair: vi.fn(() => ({ publicKey: { toBase58: () => "crank" } })),
+}));
+
+import * as sdk from "@percolatorct/sdk";
+import { AdlService } from "../../src/services/adl.js";
+
+const slabKey = { toBase58: () => "slab", equals: () => false, toBytes: () => new Uint8Array(32) };
+const market: any = { slabAddress: slabKey, programId: { toBase58: () => "prog" } };
+
+function engine(pnlPosTot: bigint, balance: bigint) {
+  return { pnlPosTot, insuranceFund: { balance, feeRevenue: 0n, isolatedBalance: 0n, isolationBps: 0 } };
+}
+
+describe("regression: keeper ADL aligns with dcccrypto percolator-prog ExecuteAdl gates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+  });
+
+  it("ADL-1: does NOT flag adlNeeded while insurance_fund.balance > 0 (program requires balance==0)", async () => {
+    vi.mocked(sdk.parseEngine).mockReturnValue(engine(1_000_000n, 5_000_000n) as any);
+    vi.mocked(sdk.parseConfig).mockReturnValue({ maxPnlCap: 500_000n } as any);
+
+    const svc = new AdlService();
+    const state = await svc.getAdlState("slab", market);
+
+    expect(state.capExceeded).toBe(true); // profit IS above cap …
+    expect(state.insuranceDepleted).toBe(false); // … but fund is NOT depleted …
+    expect(state.adlNeeded).toBe(false); // … so ADL is NOT admissible. (ADL-1 fixed)
+  });
+
+  it("ADL-1: flags adlNeeded only once insurance_fund.balance == 0", async () => {
+    vi.mocked(sdk.parseEngine).mockReturnValue(engine(1_000_000n, 0n) as any);
+    vi.mocked(sdk.parseConfig).mockReturnValue({ maxPnlCap: 500_000n } as any);
+
+    const svc = new AdlService();
+    const state = await svc.getAdlState("slab", market);
+
+    expect(state.insuranceDepleted).toBe(true);
+    expect(state.adlNeeded).toBe(true);
+  });
+
+  it("ADL-2: even when ADL preconditions are met, the keeper encodes/builds/sends NOTHING", async () => {
+    // balance==0 && pnl>cap → ADL is admissible on-chain, the exact case that
+    // previously triggered a (doomed, non-admin) ExecuteAdl send.
+    vi.mocked(sdk.parseEngine).mockReturnValue(engine(1_000_000n, 0n) as any);
+    vi.mocked(sdk.parseConfig).mockReturnValue({ maxPnlCap: 500_000n } as any);
+
+    const svc = new AdlService();
+    const markets = new Map<string, any>([["slab", { market, permanentlySkipped: false }]]);
+    svc.setMarketSource(() => markets);
+    const result = await svc.scanAll();
+
+    expect(result.needingAdl).toBe(1); // observed as needing ADL …
+    // … but NO ExecuteAdl was encoded, built, or sent (admin/multisig action only).
+    expect(spies.encodeExecuteAdl).not.toHaveBeenCalled();
+    expect(spies.buildIx).not.toHaveBeenCalled();
+    expect(spies.buildAccountMetas).not.toHaveBeenCalled();
+    expect(spies.sendWithRetryKeeper).not.toHaveBeenCalled();
+  });
+});

--- a/tests/services/adl.test.ts
+++ b/tests/services/adl.test.ts
@@ -1,46 +1,25 @@
 /**
- * Unit tests for AdlService — PERC-8276
+ * Unit tests for AdlService — OBSERVE-ONLY.
+ *
+ * ExecuteAdl is admin/multisig-gated on dcccrypto/percolator-prog (require_admin +
+ * insurance must be fully depleted), so the keeper does NOT send it. This service
+ * only evaluates and reports the on-chain ADL preconditions. These tests assert
+ * that behaviour: it never sends, and adlNeeded matches the program's gate
+ * (insurance balance == 0 AND profit above the PnL cap).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// ─── mocks (factories — no top-level variable references) ────────────────────
-
-vi.mock("@solana/web3.js", async () => {
-  const actual = await vi.importActual("@solana/web3.js");
-  return {
-    ...actual,
-    SYSVAR_CLOCK_PUBKEY: {
-      toBase58: () => "SysvarC1ock11111111111111111111111111111111",
-      equals: () => false,
-    },
-  };
-});
+// ─── mocks ───────────────────────────────────────────────────────────────────
 
 vi.mock("@percolatorct/sdk", () => ({
   fetchSlab: vi.fn(),
   parseEngine: vi.fn(),
   parseConfig: vi.fn(),
-  parseAllAccounts: vi.fn(),
-  encodeExecuteAdl: vi.fn(() => Buffer.from([50, 0, 0])),
-  buildAccountMetas: vi.fn(() => []),
-  buildIx: vi.fn(() => ({ keys: [], data: Buffer.from([]) })),
-  derivePythPushOraclePDA: vi.fn(() => [
-    { toBase58: () => "pythOracle111111111111111111111111111111111" },
-    255,
-  ]),
-  ACCOUNTS_EXECUTE_ADL: {},
+  parseAllAccounts: vi.fn(() => []),
 }));
 
 vi.mock("@percolatorct/shared", () => ({
   getConnection: vi.fn(() => ({})),
-  loadKeypair: vi.fn(() => ({
-    publicKey: {
-      toBase58: () => "keeperPubkey1111111111111111111111111111111",
-      equals: (_other: unknown) => false,
-    },
-    secretKey: new Uint8Array(64),
-  })),
-  sendWithRetryKeeper: vi.fn(async () => "mockSig123"),
   createLogger: vi.fn(() => ({
     info: vi.fn(),
     warn: vi.fn(),
@@ -48,23 +27,13 @@ vi.mock("@percolatorct/shared", () => ({
     debug: vi.fn(),
   })),
   sendWarningAlert: vi.fn(async () => {}),
-  sendCriticalAlert: vi.fn(async () => {}),
 }));
-
-// ─── import (after mocks) ─────────────────────────────────────────────────────
 
 import * as sdk from "@percolatorct/sdk";
 import * as shared from "@percolatorct/shared";
 import { AdlService } from "../../src/services/adl.js";
 
-// ─── helpers ─────────────────────────────────────────────────────────────────
-
-const zeroKey = {
-  toBase58: () => "11111111111111111111111111111111",
-  equals: (other: { toBase58: () => string }) =>
-    other.toBase58() === "11111111111111111111111111111111",
-  toBytes: () => new Uint8Array(32),
-};
+// ─── helpers ───────────────────────────────────────────────────────────────
 
 const slabKey = {
   toBase58: () => "slabKey1111111111111111111111111111111111",
@@ -76,203 +45,158 @@ function makeMarket() {
   return {
     slabAddress: slabKey,
     programId: { toBase58: () => "progId1111111111111111111111111111111111111" },
-    config: {
-      oracleAuthority: zeroKey,
-      indexFeedId: {
-        toBase58: () => "feedId111111111111111111111111111111111111",
-        toBytes: () => new Uint8Array(32), // all zeros = HYPERP
-      },
-    },
-    engine: {},
-    params: {},
-    header: {},
   };
 }
 
-function makeEngine(overrides: Partial<{ pnlPosTot: bigint }> = {}) {
+function makeEngine(
+  overrides: Partial<{ pnlPosTot: bigint; balance: bigint; feeRevenue: bigint }> = {},
+) {
   return {
     pnlPosTot: overrides.pnlPosTot ?? 1_000_000n,
     insuranceFund: {
-      balance: 5_000_000n,
-      feeRevenue: 0n,
+      balance: overrides.balance ?? 0n, // depleted by default = ADL admissible
+      feeRevenue: overrides.feeRevenue ?? 0n,
       isolatedBalance: 0n,
       isolationBps: 0,
     },
   };
 }
 
-function makeConfig(overrides: Partial<{
-  maxPnlCap: bigint;
-  indexFeedId: { toBytes: () => Uint8Array };
-}> = {}) {
-  return {
-    maxPnlCap: overrides.maxPnlCap ?? 500_000n,
-    oracleAuthority: zeroKey,
-    indexFeedId: overrides.indexFeedId ?? { toBytes: () => new Uint8Array(32) },
-  };
+function makeConfig(overrides: Partial<{ maxPnlCap: bigint }> = {}) {
+  return { maxPnlCap: overrides.maxPnlCap ?? 500_000n };
 }
 
-function makeAccounts(entries: { idx: number; pnl: bigint; capital: bigint; positionSize: bigint }[]) {
+function makeAccounts(
+  entries: { idx: number; pnl: bigint; capital: bigint; positionSize: bigint }[],
+) {
   return entries.map(({ idx, pnl, capital, positionSize }) => ({
     idx,
-    account: {
-      pnl,
-      capital,
-      positionSize,
-      kind: 0,
-      accountId: BigInt(idx),
-      reservedPnl: 0n,
-      warmupStartedAtSlot: 0n,
-      warmupSlopePerStep: 0n,
-      entryPrice: 0n,
-      fundingIndex: 0n,
-      matcherProgram: zeroKey,
-      matcherContext: zeroKey,
-      owner: zeroKey,
-      feeCredits: 0n,
-      lastFeeSlot: 0n,
-    },
+    account: { pnl, capital, positionSize },
   }));
 }
 
-// ─── tests ────────────────────────────────────────────────────────────────────
+// ─── tests ───────────────────────────────────────────────────────────────────
 
-describe("AdlService", () => {
+describe("AdlService (observe-only)", () => {
   let service: AdlService;
   const slabAddress = "slabKey1111111111111111111111111111111111";
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.CRANK_KEYPAIR = "mock-keypair";
   });
 
   afterEach(() => {
     service?.stop();
-    delete process.env.ADL_INSURANCE_THRESHOLD_LAMPORTS;
-    delete process.env.ADL_MAX_TX_PER_SCAN;
   });
 
-  describe("scanMarket — ADL not needed", () => {
-    beforeEach(() => {
-      service = new AdlService();
-    });
-
-    it("returns 0 when pnl_pos_tot <= max_pnl_cap", async () => {
-      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
-      vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 400_000n }) as any);
-      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
-
-      const result = await service.scanMarket(slabAddress, makeMarket() as any);
-      expect(result).toBe(0);
-      expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
-    });
-
-    it("returns 0 when max_pnl_cap is 0 (ADL disabled on market)", async () => {
-      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
-      vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 9_999_999n }) as any);
-      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 0n }) as any);
-
-      const result = await service.scanMarket(slabAddress, makeMarket() as any);
-      expect(result).toBe(0);
-    });
-  });
-
-  describe("scanMarket — ADL triggered", () => {
+  describe("scanMarket — ADL preconditions NOT met", () => {
     beforeEach(() => {
       service = new AdlService();
       vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
-      vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 1_000_000n }) as any);
-      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
     });
 
-    it("sends one ADL tx for the top-ranked position", async () => {
-      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
-        makeAccounts([
-          { idx: 3, pnl: 600_000n, capital: 1_000_000n, positionSize: 100n },
-          { idx: 7, pnl: -100_000n, capital: 500_000n, positionSize: 50n }, // losing — skip
-        ]) as any
+    it("returns 0 when insurance fund is NOT depleted, even if pnl > cap (ADL-1 fix)", async () => {
+      vi.mocked(sdk.parseEngine).mockReturnValue(
+        makeEngine({ pnlPosTot: 1_000_000n, balance: 5_000_000n }) as any,
       );
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
+
+      const result = await service.scanMarket(slabAddress, makeMarket() as any);
+      expect(result).toBe(0);
+      expect(service.getStats().get(slabAddress)?.adlNeeded).toBe(false);
+    });
+
+    it("returns 0 when pnl <= cap (insurance depleted)", async () => {
+      vi.mocked(sdk.parseEngine).mockReturnValue(
+        makeEngine({ pnlPosTot: 400_000n, balance: 0n }) as any,
+      );
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
+
+      const result = await service.scanMarket(slabAddress, makeMarket() as any);
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("scanMarket — ADL preconditions met", () => {
+    beforeEach(() => {
+      service = new AdlService();
+      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+    });
+
+    it("returns 1 when insurance depleted AND pnl > cap, and SENDS NOTHING", async () => {
+      vi.mocked(sdk.parseEngine).mockReturnValue(
+        makeEngine({ pnlPosTot: 1_000_000n, balance: 0n }) as any,
+      );
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
 
       const result = await service.scanMarket(slabAddress, makeMarket() as any);
       expect(result).toBe(1);
-      expect(sdk.encodeExecuteAdl).toHaveBeenCalledWith({ targetIdx: 3 });
-      expect(shared.sendWithRetryKeeper).toHaveBeenCalledTimes(1);
+      expect(service.getStats().get(slabAddress)?.adlNeeded).toBe(true);
+      // observe-only: a rate-limited operator alert may fire, but nothing is signed/sent.
     });
 
-    it("targets the highest PnL% position first (not highest abs PnL)", async () => {
+    it("returns 1 when cap is disabled (cap==0) AND insurance depleted AND profit exists", async () => {
+      vi.mocked(sdk.parseEngine).mockReturnValue(
+        makeEngine({ pnlPosTot: 9_999_999n, balance: 0n }) as any,
+      );
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 0n }) as any);
+
+      const result = await service.scanMarket(slabAddress, makeMarket() as any);
+      expect(result).toBe(1);
+    });
+
+    it("emits a rate-limited 'admin/multisig action required' alert (not a tx)", async () => {
+      vi.mocked(sdk.parseEngine).mockReturnValue(
+        makeEngine({ pnlPosTot: 1_000_000n, balance: 0n }) as any,
+      );
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
+
+      await service.scanMarket(slabAddress, makeMarket() as any);
+      await service.scanMarket(slabAddress, makeMarket() as any); // cooldown — second is suppressed
+
+      expect(shared.sendWarningAlert).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(shared.sendWarningAlert).mock.calls[0][0]).toBe(
+        "ADL conditions met — admin/multisig action required",
+      );
+    });
+  });
+
+  describe("getAdlState — read-only", () => {
+    beforeEach(() => {
+      service = new AdlService();
+      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+    });
+
+    it("reports adlNeeded=false with a non-zero insurance balance", async () => {
+      vi.mocked(sdk.parseEngine).mockReturnValue(
+        makeEngine({ pnlPosTot: 1_000_000n, balance: 5_000_000n }) as any,
+      );
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
+
+      const state = await service.getAdlState(slabAddress, makeMarket() as any);
+      expect(state.adlNeeded).toBe(false);
+      expect(state.insuranceDepleted).toBe(false);
+      expect(state.capExceeded).toBe(true);
+      expect(state.rankings).toEqual([]);
+    });
+
+    it("returns PnL%-ranked positions when ADL is admissible", async () => {
+      vi.mocked(sdk.parseEngine).mockReturnValue(
+        makeEngine({ pnlPosTot: 1_000_000n, balance: 0n }) as any,
+      );
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
       vi.mocked(sdk.parseAllAccounts).mockReturnValue(
         makeAccounts([
           { idx: 5, pnl: 800_000n, capital: 10_000_000n, positionSize: 200n }, // 8%
           { idx: 2, pnl: 300_000n, capital: 1_000_000n, positionSize: 100n }, // 30%
-        ]) as any
+        ]) as any,
       );
 
-      await service.scanMarket(slabAddress, makeMarket() as any);
-
-      // First call should target idx 2 (highest PnL%)
-      expect(sdk.encodeExecuteAdl).toHaveBeenNthCalledWith(1, { targetIdx: 2 });
-    });
-
-    it("returns 0 when no profitable positions exist", async () => {
-      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
-        makeAccounts([
-          { idx: 1, pnl: -500_000n, capital: 1_000_000n, positionSize: 100n },
-          { idx: 2, pnl: 0n, capital: 500_000n, positionSize: 50n },
-        ]) as any
-      );
-
-      const result = await service.scanMarket(slabAddress, makeMarket() as any);
-      expect(result).toBe(0);
-      expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
-    });
-
-    it("skips positions with zero positionSize", async () => {
-      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
-        makeAccounts([
-          { idx: 9, pnl: 999_999n, capital: 1_000n, positionSize: 0n }, // no open position
-        ]) as any
-      );
-
-      const result = await service.scanMarket(slabAddress, makeMarket() as any);
-      expect(result).toBe(0);
-    });
-  });
-
-  describe("scanMarket — oracle key selection", () => {
-    beforeEach(() => {
-      service = new AdlService();
-      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
-      vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 1_000_000n }) as any);
-      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
-        makeAccounts([{ idx: 0, pnl: 600_000n, capital: 500_000n, positionSize: 100n }]) as any
-      );
-    });
-
-    it("uses slab as oracle for HYPERP market (indexFeedId=zeros, oracleAuthority=zeros)", async () => {
-      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({
-        maxPnlCap: 500_000n,
-        indexFeedId: { toBytes: () => new Uint8Array(32) }, // all zeros
-      }) as any);
-
-      await service.scanMarket(slabAddress, makeMarket() as any);
-
-      expect(sdk.buildAccountMetas).toHaveBeenCalled();
-      const callArgs = vi.mocked(sdk.buildAccountMetas).mock.calls[0];
-      // 4th key is oracle — for HYPERP it should be the slab
-      expect(callArgs[1][3]).toBe(slabKey);
-    });
-
-    it("derives Pyth oracle PDA for non-zero indexFeedId", async () => {
-      const nonZeroFeed = new Uint8Array(32);
-      nonZeroFeed[0] = 0xab;
-      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({
-        maxPnlCap: 500_000n,
-        indexFeedId: { toBytes: () => nonZeroFeed },
-      }) as any);
-
-      await service.scanMarket(slabAddress, makeMarket() as any);
-
-      expect(sdk.derivePythPushOraclePDA).toHaveBeenCalled();
+      const state = await service.getAdlState(slabAddress, makeMarket() as any);
+      expect(state.adlNeeded).toBe(true);
+      // highest PnL% ranked first
+      expect(state.rankings[0].idx).toBe(2);
+      expect(state.rankings[1].idx).toBe(5);
     });
   });
 
@@ -283,30 +207,8 @@ describe("AdlService", () => {
 
     it("returns 0 and logs when fetchSlab fails", async () => {
       vi.mocked(sdk.fetchSlab).mockRejectedValue(new Error("RPC timeout"));
-
       const result = await service.scanMarket(slabAddress, makeMarket() as any);
       expect(result).toBe(0);
-    });
-
-    it("continues to next position when a tx fails (partial success)", async () => {
-      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
-      vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 2_000_000n }) as any);
-      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
-      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
-        makeAccounts([
-          { idx: 1, pnl: 900_000n, capital: 1_000_000n, positionSize: 100n }, // 90% PnL
-          { idx: 2, pnl: 600_000n, capital: 1_000_000n, positionSize: 100n }, // 60% PnL
-        ]) as any
-      );
-
-      // First tx (highest PnL%) fails, second succeeds
-      vi.mocked(shared.sendWithRetryKeeper)
-        .mockRejectedValueOnce(new Error("tx failed"))
-        .mockResolvedValueOnce("sig2");
-
-      const result = await service.scanMarket(slabAddress, makeMarket() as any);
-      // Should have sent 1 successfully (idx 2)
-      expect(result).toBe(1);
     });
   });
 
@@ -321,55 +223,31 @@ describe("AdlService", () => {
     });
 
     it("resets _cycling flag when cycle exceeds MAX_CYCLE_MS (5x interval)", async () => {
-      // Setup: start the service with a market source
       const markets = new Map();
       service.start(() => markets);
 
-      // Simulate a stuck cycle: manually set _cycling=true with an old timestamp
-      // Access internal state for testing
       (service as any)._cycling = true;
-      (service as any)._cycleStartedAt = Date.now() - 60_000; // 60s ago (> 5 * 10s default)
+      (service as any)._cycleStartedAt = Date.now() - 60_000; // > 5 * 10s default
 
-      // Advance timer to trigger the next interval tick
       await vi.advanceTimersByTimeAsync(10_001);
 
-      // The watchdog should have reset _cycling to false
       expect((service as any)._cycling).toBe(false);
-      // Should have sent a warning alert about the hung cycle
       expect(shared.sendWarningAlert).toHaveBeenCalledWith(
         "ADL cycle hung — watchdog reset",
         expect.any(Array),
       );
     });
 
-    it("does not trigger watchdog when cycle completes within MAX_CYCLE_MS", async () => {
+    it("skips a new cycle when the previous one is still running (within timeout)", async () => {
       const markets = new Map();
       service.start(() => markets);
 
-      // Advance timer — scanAll returns immediately (no markets), well within limit
-      await vi.advanceTimersByTimeAsync(10_001);
-
-      // Watchdog alert should NOT have been sent
-      expect(shared.sendWarningAlert).not.toHaveBeenCalledWith(
-        "ADL cycle hung — watchdog reset",
-        expect.any(Array),
-      );
-    });
-
-    it("skips new cycle when previous cycle is still running (within timeout)", async () => {
-      const markets = new Map();
-      service.start(() => markets);
-
-      // Simulate a running cycle that hasn't exceeded MAX_CYCLE_MS
       (service as any)._cycling = true;
-      (service as any)._cycleStartedAt = Date.now(); // just started
+      (service as any)._cycleStartedAt = Date.now();
 
-      // Advance timer — should skip (not reset, not run new cycle)
       await vi.advanceTimersByTimeAsync(10_001);
 
-      // _cycling should still be true (not reset by watchdog, not cleared by new cycle)
       expect((service as any)._cycling).toBe(true);
-      // No watchdog alert
       expect(shared.sendWarningAlert).not.toHaveBeenCalledWith(
         "ADL cycle hung — watchdog reset",
         expect.any(Array),
@@ -380,87 +258,20 @@ describe("AdlService", () => {
   describe("getStats", () => {
     beforeEach(() => {
       service = new AdlService();
+      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
     });
 
-    it("tracks adlTxSent per market", async () => {
-      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
-      vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 1_000_000n }) as any);
-      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
-      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
-        makeAccounts([{ idx: 0, pnl: 600_000n, capital: 500_000n, positionSize: 100n }]) as any
+    it("tracks adlNeeded per market", async () => {
+      vi.mocked(sdk.parseEngine).mockReturnValue(
+        makeEngine({ pnlPosTot: 1_000_000n, balance: 0n }) as any,
       );
+      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
 
       await service.scanMarket(slabAddress, makeMarket() as any);
 
-      const stats = service.getStats();
-      const marketStats = stats.get(slabAddress);
-      expect(marketStats?.adlTxSent).toBe(1);
-      expect(marketStats?.consecutiveErrors).toBe(0);
-    });
-
-    it("increments consecutiveErrors on tx failure", async () => {
-      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
-      vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 1_000_000n }) as any);
-      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
-      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
-        makeAccounts([{ idx: 0, pnl: 600_000n, capital: 500_000n, positionSize: 100n }]) as any
-      );
-      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValue(new Error("fail"));
-
-      await service.scanMarket(slabAddress, makeMarket() as any);
-
-      const stats = service.getStats();
-      const marketStats = stats.get(slabAddress);
-      expect(marketStats?.consecutiveErrors).toBeGreaterThan(0);
-    });
-  });
-
-  // A.9 (HIGH): ADL no longer bypasses KeeperBudget. The two behaviours
-  // that the budget should now guard:
-  //   1. budget halt blocks ADL from sending
-  //   2. successful ADL records to the budget (so cap math sees ADL spend)
-  describe("A.9: ADL through KeeperBudget + keeperSend", () => {
-    beforeEach(() => {
-      service = new AdlService();
-    });
-
-    it("does NOT send when sharedBudget is halted", async () => {
-      const { sharedBudget } = await import("../../src/lib/keeper-send.js");
-      sharedBudget.haltManually("A.9 test halt");
-
-      try {
-        vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
-        vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 1_000_000n }) as any);
-        vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
-        vi.mocked(sdk.parseAllAccounts).mockReturnValue(
-          makeAccounts([{ idx: 0, pnl: 600_000n, capital: 500_000n, positionSize: 100n }]) as any,
-        );
-
-        await service.scanMarket(slabAddress, makeMarket() as any);
-
-        expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
-      } finally {
-        sharedBudget.resume("a9-test-cleanup");
-      }
-    });
-
-    it("records a successful ADL tx to sharedBudget (cycleTxCount and cycleSpend both grow)", async () => {
-      const { sharedBudget } = await import("../../src/lib/keeper-send.js");
-      sharedBudget.resume("a9-pre-test"); // ensure not halted from a prior test
-      const before = sharedBudget.getStats();
-
-      vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array(1024));
-      vi.mocked(sdk.parseEngine).mockReturnValue(makeEngine({ pnlPosTot: 1_000_000n }) as any);
-      vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({ maxPnlCap: 500_000n }) as any);
-      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
-        makeAccounts([{ idx: 0, pnl: 600_000n, capital: 500_000n, positionSize: 100n }]) as any,
-      );
-
-      await service.scanMarket(slabAddress, makeMarket() as any);
-
-      const after = sharedBudget.getStats();
-      expect(after.cycleTxCount).toBe(before.cycleTxCount + 1);
-      expect(after.cycleSpend).toBeGreaterThan(before.cycleSpend);
+      const marketStats = service.getStats().get(slabAddress);
+      expect(marketStats?.adlNeeded).toBe(true);
+      expect(marketStats?.lastAdlNeededTime).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #133. Makes the keeper's ADL service **observe-only** to align with the current program, where `ExecuteAdl` (tag 50) is admin-gated and requires the insurance fund to be fully depleted.

## Background

`handle_execute_adl` enforces `require_admin(header.admin, accounts[0])` and rejects unless `insurance_fund.balance == 0`. The keeper signed `ExecuteAdl` with the operational crank key (not the admin) and triggered on PnL-cap / insurance-utilization without requiring `balance == 0` — so every send would revert (`EngineUnauthorized` / `InsuranceFundNotDepleted`). Protective deleveraging already happens permissionlessly inside `KeeperCrank` and `LiquidateAtOracle` (both already sent by the keeper), so targeted `ExecuteAdl` is an admin/multisig action. Because the keeper's `ExecuteAdl` sends always reverted, removing the path loses no protection.

## Changes

- **`src/services/adl.ts`** — remove the sign/send path and the crank-key signer. `AdlService` is now observe-only: it evaluates the on-chain ADL preconditions per market and exposes them via `getAdlState()`/`getStats()` (for `/api/adl/rankings`) plus a rate-limited "admin/multisig action required" alert. `adlNeeded` now mirrors the program: `balance == 0 && (cap == 0 ? pnl > 0 : pnl > cap)`. Utilization is informational only.
- **`src/services/monitor.ts`** — gate the ADL-staleness alert on `insurance_fund.balance == 0` and reword it to "admin/multisig action required" (the keeper no longer executes ADL).
- **`src/services/crank-types.ts`** — remove the unused two-phase `PrepareAdl` scaffolding (incl. the `0xff` placeholder tag) for an on-chain split that does not exist; the program's ADL is single-phase.
- **`src/index.ts`** — report ADL status as observe-only.
- **`tests/`** — rewrite the ADL suite for observe-only behavior and add a regression test asserting that (a) `adlNeeded` is false while `balance > 0`, and (b) no `ExecuteAdl` is ever encoded/built/sent even when preconditions are met.

## Verification

- `tsc --noEmit`: clean (exit 0).
- Full test suite: **609 passed, 26 skipped, 0 failed**.
- The regression spies on `encodeExecuteAdl` / `buildIx` / `buildAccountMetas` / `sendWithRetryKeeper` will fail if a keeper-side ADL send path is ever reintroduced.

## Notes

- No behavior change in production today — the service is gated behind `ADL_ENABLED`, which defaults to off.
- No protocol-safety loss: the removed sends always reverted; permissionless crank/liquidate paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ADL now operates in observe-only mode, providing enhanced market monitoring and automated alerts when critical conditions are detected.
  * Health endpoint updated to report ADL observe-only status and counts of markets requiring attention.

* **Bug Fixes**
  * Improved ADL trigger condition evaluation and updated alert behavior to accurately reflect system state.

* **Tests**
  * Added regression test suite validating observe-only ADL behavior and preventing unintended transaction execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->