### PR TITLE
fix(keeper): route all NETWORK checks through one canonical resolver

### DIFF
--- a/src/config/network.ts
+++ b/src/config/network.ts
@@ -2,8 +2,13 @@
  * Network helpers for mainnet/devnet detection.
  * The @percolatorct/shared networkValidation module handles FORCE_MAINNET guards;
  * this module provides a simple runtime check for keeper-specific logic.
+ *
+ * Delegates to the single canonical resolver in src/network.ts so this check is
+ * case/whitespace-insensitive and can never diverge from CURRENT_NETWORK, the
+ * env guards, or the HA lock key.
  */
+import { isMainnetNetwork } from "../network.js";
 
 export function isMainnet(): boolean {
-  return process.env.NETWORK === "mainnet";
+  return isMainnetNetwork(process.env.NETWORK);
 }

--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -1,8 +1,12 @@
+import { isMainnetNetwork, isKnownNetwork, normalizeNetwork } from "./network.js";
+
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]);
 const TEST_VALIDATOR_PORT = "8899";
 
+// Delegates to the canonical resolver — case/whitespace-insensitive, and always
+// agrees with isMainnet() / CURRENT_NETWORK / the HA lock key.
 function isMainnetEnv(env: NodeJS.ProcessEnv): boolean {
-  return env.NETWORK === "mainnet";
+  return isMainnetNetwork(env.NETWORK);
 }
 
 // A2: When NETWORK=mainnet, refuse any RPC URL that points at a local validator.
@@ -49,6 +53,16 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
   // unreachable — the hard-reject above already throws on any non-empty
   // service-role key. Deleted; the supabaseKey lookup that fed it is gone too.
 
+  // Fail fast on an explicitly-set NETWORK that isn't a recognized token, so a
+  // typo (e.g. "mainnnet") cannot silently resolve to devnet. Unset/empty is
+  // allowed (defaults to devnet for local dev).
+  if (!isKnownNetwork(env.NETWORK)) {
+    throw new Error(
+      `NETWORK='${(env.NETWORK ?? "").trim().slice(0, 20)}' is not a recognized network — ` +
+        "expected mainnet, devnet, or testnet (case-insensitive).",
+    );
+  }
+
   // Reject insecure (plaintext) RPC URLs unless explicitly allowed.
   // http:// and ws:// transmit signed transactions and account data unencrypted,
   // enabling MITM attacks on the network path.
@@ -59,15 +73,19 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
   // and could split-brain. Validate that NETWORK is set to a supported value
   // whenever HA is on.
   if (env.HA_ENABLED === "true") {
-    const network = env.NETWORK?.trim();
-    if (!network) {
+    const raw = env.NETWORK?.trim();
+    if (!raw) {
       throw new Error(
         "HA_ENABLED=true requires NETWORK to be set. Set NETWORK=mainnet or NETWORK=devnet.",
       );
     }
-    if (network !== "mainnet" && network !== "devnet") {
+    // Normalized so "Mainnet"/" mainnet " are accepted consistently; the HA lock
+    // key (index.ts) uses the same normalized value, so two nodes that differ
+    // only by case/whitespace share one lock instead of splitting the brain.
+    const net = normalizeNetwork(env.NETWORK);
+    if (net !== "mainnet" && net !== "devnet") {
       throw new Error(
-        `HA_ENABLED=true: NETWORK must be 'mainnet' or 'devnet' (got '${network.slice(0, 20)}').`,
+        `HA_ENABLED=true: NETWORK must resolve to 'mainnet' or 'devnet' (got '${raw.slice(0, 20)}').`,
       );
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { MonitorService } from "./services/monitor.js";
 import { FraudDetectorService } from "./services/fraud-detector.js";
 import { validateKeeperEnvGuards } from "./env-guards.js";
 import { isMainnet } from "./config/network.js";
+import { CURRENT_NETWORK } from "./network.js";
 import { assertMainnetProgramId } from "./lib/boot-assertions.js";
 import { snapshotMetrics as snapshotSenderMetrics } from "./lib/sender-metrics.js";
 import { walletBalanceSol, activeMarketsCount, registerDefaultMetrics } from "./lib/metrics.js";
@@ -672,7 +673,10 @@ async function start() {
     // A.3: env-guards asserts NETWORK is set to mainnet|devnet whenever
     // HA_ENABLED=true, so the previous `?? "devnet"` fallback is gone —
     // a missing NETWORK would silently share a lock with the wrong cluster.
-    const network = process.env.NETWORK!;
+    // Use the normalized CURRENT_NETWORK (not raw process.env.NETWORK) so two
+    // nodes differing only by case/whitespace ("Mainnet" vs "mainnet") derive
+    // the SAME lock key and cannot both become leader.
+    const network = CURRENT_NETWORK;
     leaderLock.start({
       network,
       onPromote: () => {

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -8,6 +8,7 @@ import { HeliusPriorityFeeEstimator } from "./priority-fee.js";
 import type { PriorityFeeEstimator, PriorityFeeTier } from "./priority-fee.js";
 import { CuEstimator } from "./cu-estimator.js";
 import { sharedDecisionLog } from "./decision-log.js";
+import { isMainnetNetwork } from "../network.js";
 
 const logger = createLogger("keeper:send");
 
@@ -53,7 +54,7 @@ export const sharedBudget = new KeeperBudget();
 
 function isMainnetSender(): boolean {
   return (
-    process.env.NETWORK === "mainnet" &&
+    isMainnetNetwork(process.env.NETWORK) &&
     process.env.USE_HELIUS_SENDER === "true"
   );
 }

--- a/src/network.ts
+++ b/src/network.ts
@@ -6,11 +6,45 @@
  */
 export type NetworkType = "devnet" | "testnet" | "mainnet";
 
-function resolveNetwork(): NetworkType {
-  const n = (process.env.NETWORK ?? "devnet").toLowerCase().trim();
+/** Canonical network tokens the keeper recognizes (case/whitespace-insensitive). */
+const KNOWN_NETWORK_TOKENS = new Set(["mainnet", "testnet", "devnet"]);
+
+/**
+ * Single source of truth for interpreting the NETWORK env var.
+ * Case- and whitespace-insensitive; unset/empty/unrecognized → "devnet".
+ *
+ * Every network check in the keeper MUST go through this (isMainnet(), the env
+ * guards, the HA lock key, the send path) so they can never disagree on what
+ * NETWORK means. Divergent ad-hoc checks (e.g. `process.env.NETWORK === "mainnet"`)
+ * previously let a value like "Mainnet" or " mainnet " disable mainnet safety
+ * guards while the rest of the keeper still ran as mainnet.
+ */
+export function normalizeNetwork(raw: string | undefined): NetworkType {
+  const n = (raw ?? "devnet").toLowerCase().trim();
   if (n === "mainnet") return "mainnet";
   if (n === "testnet") return "testnet";
   return "devnet";
+}
+
+/** True iff NETWORK resolves to mainnet (case/whitespace-insensitive). */
+export function isMainnetNetwork(raw: string | undefined): boolean {
+  return normalizeNetwork(raw) === "mainnet";
+}
+
+/**
+ * Whether an explicitly-set NETWORK value is a recognized token. Unset/empty is
+ * considered known (callers default it to devnet). Used to fail fast on typos
+ * (e.g. "mainnnet") that would otherwise silently resolve to devnet.
+ */
+export function isKnownNetwork(raw: string | undefined): boolean {
+  if (raw === undefined) return true;
+  const n = raw.trim().toLowerCase();
+  if (n === "") return true;
+  return KNOWN_NETWORK_TOKENS.has(n);
+}
+
+function resolveNetwork(): NetworkType {
+  return normalizeNetwork(process.env.NETWORK);
 }
 
 /**

--- a/tests/network-guard-bypass.poc.test.ts
+++ b/tests/network-guard-bypass.poc.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression for the mainnet boot-guard bypass (HIGH) — was the PoC that proved it.
+ *
+ * Root cause: three+ independent NETWORK readers disagreed — isMainnet() and the
+ * env guards used an exact `=== "mainnet"` while CURRENT_NETWORK (and the HA lock
+ * key / send path) normalized. A value like "Mainnet" / " mainnet " was treated as
+ * mainnet by the resolver but not by the guards, silently disabling the
+ * wrong-program-id assertion and the local-RPC rejection.
+ *
+ * Fix: a single canonical resolver (src/network.ts) backs every check. These tests
+ * lock in that all readers now agree, and that unrecognized values fail fast.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isMainnet } from "../src/config/network.js";
+import { assertMainnetProgramId, MAINNET_PROGRAM_ID } from "../src/lib/boot-assertions.js";
+import { validateKeeperEnvGuards } from "../src/env-guards.js";
+import { isMainnetNetwork } from "../src/network.js";
+
+const ORIGINAL_NETWORK = process.env.NETWORK;
+
+afterEach(() => {
+  if (ORIGINAL_NETWORK === undefined) delete process.env.NETWORK;
+  else process.env.NETWORK = ORIGINAL_NETWORK;
+  vi.resetModules();
+});
+
+// Values that MEAN mainnet but aren't the exact lowercase string.
+const MAINNET_VARIANTS = ["mainnet", "Mainnet", "MAINNET", " mainnet ", "mainnet "];
+const NON_MAINNET = [undefined, "", "devnet", "Devnet", "DEVNET", " devnet ", "testnet"];
+
+describe("regression: all NETWORK readers agree via the canonical resolver", () => {
+  it("isMainnet() and CURRENT_NETWORK both classify case/whitespace variants as mainnet", async () => {
+    for (const value of MAINNET_VARIANTS) {
+      process.env.NETWORK = value;
+      expect(isMainnet(), `isMainnet() for ${JSON.stringify(value)}`).toBe(true);
+      expect(isMainnetNetwork(value)).toBe(true);
+
+      vi.resetModules();
+      const { CURRENT_NETWORK } = await import("../src/network.js");
+      expect(CURRENT_NETWORK, `CURRENT_NETWORK for ${JSON.stringify(value)}`).toBe("mainnet");
+    }
+  });
+
+  it("non-mainnet values are never treated as mainnet", () => {
+    for (const value of NON_MAINNET) {
+      if (value === undefined) delete process.env.NETWORK;
+      else process.env.NETWORK = value;
+      expect(isMainnet(), `isMainnet() for ${JSON.stringify(value)}`).toBe(false);
+      expect(isMainnetNetwork(value)).toBe(false);
+    }
+  });
+
+  it("FIXED: with NETWORK='Mainnet', a wrong program id now refuses to boot", () => {
+    process.env.NETWORK = "Mainnet";
+    const wrongProgramId = "WrongProg1111111111111111111111111111111111";
+    expect(wrongProgramId).not.toBe(MAINNET_PROGRAM_ID);
+
+    // Wired exactly as index.ts:47 — the guard now engages because isMainnet() is true.
+    expect(() =>
+      assertMainnetProgramId({ isMainnet: isMainnet(), programId: wrongProgramId }),
+    ).toThrow(/Refusing to boot/i);
+  });
+
+  it("FIXED: with NETWORK='Mainnet' (and ' mainnet '), a localhost RPC now refuses to boot", () => {
+    const base = { SOLANA_RPC_URL: "http://127.0.0.1:8899", ALLOW_INSECURE_RPC: "true" } as NodeJS.ProcessEnv;
+    for (const net of ["Mainnet", " mainnet ", "MAINNET"]) {
+      expect(() => validateKeeperEnvGuards({ ...base, NETWORK: net }), `NETWORK=${JSON.stringify(net)}`).toThrow(
+        /refusing to boot/i,
+      );
+    }
+  });
+
+  it("still allows localhost on devnet / local dev", () => {
+    const base = { SOLANA_RPC_URL: "http://127.0.0.1:8899", ALLOW_INSECURE_RPC: "true" } as NodeJS.ProcessEnv;
+    expect(() => validateKeeperEnvGuards({ ...base, NETWORK: "devnet" })).not.toThrow();
+    expect(() => validateKeeperEnvGuards({ ...base })).not.toThrow(); // unset → devnet
+  });
+
+  it("fails fast on an unrecognized NETWORK value (typo) instead of silently using devnet", () => {
+    expect(() => validateKeeperEnvGuards({ NETWORK: "mainnnet" } as NodeJS.ProcessEnv)).toThrow(
+      /not a recognized network/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #135. Routes every `NETWORK` check through a single canonical resolver so the mainnet safety guards can no longer disagree with the rest of the keeper over case/whitespace.

## Root cause

The guards compared `NETWORK` with an exact `=== "mainnet"`, while `CURRENT_NETWORK` (and Supabase filtering / the HA lock key) normalized case and whitespace. A value like `"Mainnet"` or `" mainnet "` was treated as mainnet by the resolver but not by the guards, silently disabling the mainnet program-id boot assertion and the local-RPC rejection while the keeper still ran as mainnet. The HA lock key was also built from the raw value (so case/whitespace variants split the brain), and the Helius Sender path used the same exact comparison.

## Changes

- **`src/network.ts`** — add `normalizeNetwork()`, `isMainnetNetwork()`, and `isKnownNetwork()` as the single source of truth (case/whitespace-insensitive); `resolveNetwork()` and `CURRENT_NETWORK` now delegate to them.
- **`src/config/network.ts`** — `isMainnet()` delegates to `isMainnetNetwork()`.
- **`src/env-guards.ts`** — `isMainnetEnv()` delegates to the canonical resolver; the HA check is normalized so `"Mainnet"`/`" mainnet "` are accepted consistently and match the lock key; and an explicitly-set unrecognized `NETWORK` (e.g. `"mainnnet"`) now fails fast at boot instead of silently resolving to devnet.
- **`src/index.ts`** — the HA lock key is derived from the normalized `CURRENT_NETWORK`, so two nodes differing only by case/whitespace share one lock and cannot both become leader.
- **`src/lib/keeper-send.ts`** — the mainnet send path is gated by `isMainnetNetwork()`.
- **`tests/network-guard-bypass.poc.test.ts`** — regression coverage: all readers agree on case/whitespace variants; a wrong program id and a localhost RPC now refuse to boot under `"Mainnet"` and `" mainnet "`; devnet/unset still allow local development; and an unrecognized `NETWORK` fails fast.

## Verification

- `tsc --noEmit`: clean (exit 0).
- Existing constraints preserved: HA still accepts only `mainnet`/`devnet` (`testnet` is rejected under HA, allowed when HA is off); localhost is still permitted on devnet and when `NETWORK` is unset.
- Full keeper test suite passes (`vitest run`).

## Notes

- No behavior change for correctly-configured deployments (`NETWORK=mainnet` / `NETWORK=devnet` / unset); the fix only affects previously-ambiguous values, which now resolve consistently or fail fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened environment validation to fail fast on unrecognized network configurations instead of silently defaulting.
  * Network detection is now case and whitespace-insensitive, preventing configuration errors from misclassification.
  * Improved High Availability lock key consistency with proper network normalization.

* **Tests**
  * Added regression test suite validating network detection behavior across case variants and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->