### PR TITLE
fix(keeper): make HA leader lock split-brain-safe via atomic CAS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { LeaderLock, makeIdentity } from "./lib/leader.js";
 import { captureAndExit } from "./lib/exit-handlers.js";
 import { StartupTracker } from "./lib/startup-tracker.js";
 import { sharedTxQueue, DRAIN_TIMEOUT_MS } from "./lib/tx-queue.js";
+import { setLeaderCheck } from "./lib/keeper-send.js";
 import { initSharedShadowHarness, sharedShadowHarness } from "./lib/shadow-harness.js";
 import { sharedDecisionLog } from "./lib/decision-log.js";
 
@@ -82,6 +83,10 @@ const leaderLock: LeaderLock | null =
 if (haEnabled && redisClient === null) {
   logger.warn("HA_ENABLED=true but KEEPER_REDIS_URL is unset — running as standalone leader");
 }
+
+// Single-writer guard for keeperSend: only land on-chain txs while we hold
+// leadership. Reads the live LeaderLock role (standalone / no-HA → always leader).
+setLeaderCheck(() => (leaderLock ? leaderLock.role() === "leader" : true));
 
 // A5: gate /health on real readiness — Railway otherwise marks the container
 // healthy the moment the HTTP server binds, well before start() finishes
@@ -681,6 +686,10 @@ async function start() {
       },
       onDemote: (reason) => {
         logger.warn("HA: demoted from leader — stopping services", { network, reason });
+        // role() is already "standby" here (LeaderLock flips it before onDemote),
+        // so the keeperSend single-writer guard is closed. Also drop any queued
+        // sends so this node runs no backlog after losing leadership.
+        sharedTxQueue.clearPending();
         stopAllServices();
       },
     });

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -11,6 +11,16 @@ import { sharedDecisionLog } from "./decision-log.js";
 
 const logger = createLogger("keeper:send");
 
+// Single-writer guard. In HA mode the keeper must only land on-chain txs while it
+// holds leadership; the on-chain programs are permissionless, so this host-local
+// gate is the actual barrier against a demoted node double-sending. Wired from
+// index.ts to read the live LeaderLock role. Defaults to always-leader so the
+// standalone (no-HA) path is unchanged.
+let _isLeader: () => boolean = () => true;
+export function setLeaderCheck(fn: () => boolean): void {
+  _isLeader = fn;
+}
+
 export const BASE_FEE_LAMPORTS = 5_000;
 
 const TIER_MAP: Record<TxType, PriorityFeeTier> = {
@@ -111,6 +121,15 @@ export async function keeperSend(
   maxRetries = 3,
   keeperOpts?: KeeperSendOptions,
 ): Promise<KeeperSendResult | null> {
+  // Single-writer guard (checked first, before any RPC). A node that lost
+  // leadership — including a task dequeued from sharedTxQueue after demotion —
+  // must not land a tx. Returns null, reusing the budget-exhausted "skip, not a
+  // failure" contract every caller already handles.
+  if (!_isLeader()) {
+    logger.warn("Single-writer guard: refusing send — node is not leader", { txType });
+    return null;
+  }
+
   const { estimatedCost, simulatedCu } = await estimateCost(connection, instructions, signers, txType);
 
   if (!budget.canSpend(estimatedCost, txType)) {

--- a/src/lib/leader.ts
+++ b/src/lib/leader.ts
@@ -6,10 +6,26 @@ const logger = createLogger("keeper:leader");
 
 export type LeaderRole = "leader" | "standby" | "starting";
 
+/**
+ * Atomic compare-and-set scripts. The lock VALUE is this node's identity, so
+ * these only mutate the key when the caller still owns it — closing the
+ * split-brain window where a stalled-then-resumed leader's blind `SET XX` renew
+ * (or unconditional `DEL`) would clobber a lock a standby legitimately took.
+ *
+ * Renew uses `pexpire` (refresh TTL, value untouched) so even renew can never
+ * rewrite a foreign value. Exported so test fakes execute the exact same logic.
+ */
+export const RENEW_SCRIPT =
+  "if redis.call('get', KEYS[1]) == ARGV[1] then redis.call('pexpire', KEYS[1], ARGV[2]); return 1 else return 0 end";
+export const RELEASE_SCRIPT =
+  "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
+
 export interface LeaderLockOptions {
   ttlMs?: number;
   renewMs?: number;
   pollMs?: number;
+  /** Per-call timeout for renew/release Redis ops; a hung Redis demotes instead of stranding a stale leader. */
+  renewTimeoutMs?: number;
 }
 
 export interface StartOptions {
@@ -24,6 +40,7 @@ export class LeaderLock {
   private readonly ttlMs: number;
   private readonly renewMs: number;
   private readonly pollMs: number;
+  private readonly renewTimeoutMs: number;
 
   private _role: LeaderRole = "starting";
   private _renewTimer: NodeJS.Timeout | null = null;
@@ -38,6 +55,22 @@ export class LeaderLock {
     this.ttlMs = opts.ttlMs ?? 30_000;
     this.renewMs = opts.renewMs ?? 10_000;
     this.pollMs = opts.pollMs ?? 5_000;
+    // Strictly below renewMs so a timed-out renew still leaves room for the
+    // 2-strike retry before the TTL lapses.
+    this.renewTimeoutMs = opts.renewTimeoutMs ?? Math.min(Math.floor(this.renewMs / 2), 5_000);
+  }
+
+  private async _withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`redis op timed out after ${ms}ms`)), ms);
+      timer.unref?.();
+    });
+    try {
+      return await Promise.race([p, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   role(): LeaderRole {
@@ -64,8 +97,16 @@ export class LeaderLock {
 
     if (this._role === "leader") {
       try {
-        await this.redis.del(this._lockKey);
-        logger.info("LeaderLock released (graceful stop)", { identity: this.identity });
+        // Compare-and-delete: release only if we still own the lock. An
+        // unconditional `del` from a stale leader would wipe a lock a new
+        // leader currently holds.
+        const deleted = Number(
+          await this._withTimeout(
+            this.redis.eval(RELEASE_SCRIPT, [this._lockKey], [this.identity]),
+            this.renewTimeoutMs,
+          ),
+        );
+        logger.info("LeaderLock released (graceful stop)", { identity: this.identity, deleted });
       } catch (err) {
         logger.warn("LeaderLock release failed during stop", {
           identity: this.identity,
@@ -115,23 +156,33 @@ export class LeaderLock {
   private async _renew(opts: StartOptions): Promise<void> {
     if (this._role !== "leader") return;
 
-    const ttlSec = Math.ceil(this.ttlMs / 1000);
-
     try {
-      const result = await this.redis.set(this._lockKey, this.identity, { ex: ttlSec, xx: true } as { ex: number; xx?: true });
+      // Compare-and-set: refresh the TTL only if we still own the key. A blind
+      // `SET XX` here would succeed against ANY holder and let a stalled-then-
+      // resumed leader silently steal the lock back (split-brain).
+      const owned = Number(
+        await this._withTimeout(
+          this.redis.eval(RENEW_SCRIPT, [this._lockKey], [this.identity, this.ttlMs]),
+          this.renewTimeoutMs,
+        ),
+      );
 
-      if (result === "OK") {
+      if (owned === 1) {
         this._renewFailures = 0;
         this._scheduleRenew(opts);
       } else {
-        this._renewFailures++;
-        logger.warn("LeaderLock renew returned null (lock lost)", {
+        // CAS proved we are NO LONGER the owner — a standby legitimately took the
+        // lock while we stalled. Definitive loss: demote immediately, do not
+        // retry, do not touch the key (the new leader owns it).
+        logger.warn("LeaderLock renew: no longer owner (lock lost) — demoting", {
           identity: this.identity,
-          renewFailures: this._renewFailures,
         });
         this._demote("redis-lock-lost");
       }
     } catch (err) {
+      // Transport error OR timeout — ambiguous (we may still own it). Keep the
+      // 2-strike tolerance so a single blip doesn't cause needless failover, but
+      // demote on the second so a hung Redis can't strand a stale leader past TTL.
       this._renewFailures++;
       logger.warn("LeaderLock renew error", {
         identity: this.identity,

--- a/src/lib/redis-client.ts
+++ b/src/lib/redis-client.ts
@@ -4,6 +4,12 @@ export interface RedisLike {
   set(key: string, value: string, opts: { ex: number; nx?: true } | { ex: number; xx?: true }): Promise<"OK" | null>;
   get(key: string): Promise<string | null>;
   del(...keys: string[]): Promise<number>;
+  /**
+   * Atomic server-side Lua script. Mirrors `@upstash/redis` `Redis.eval(script, keys, args)`.
+   * Used by the leader lock for compare-and-set renew/release so a stale node can
+   * never overwrite or delete a lock another node owns.
+   */
+  eval<T = unknown>(script: string, keys: string[], args: (string | number)[]): Promise<T>;
 }
 
 let _client: RedisLike | null | undefined = undefined;

--- a/src/lib/tx-queue.ts
+++ b/src/lib/tx-queue.ts
@@ -168,6 +168,19 @@ export class TxQueue {
     }
   }
 
+  /**
+   * Drop all queued-but-not-yet-started tasks across every lane. Used on
+   * involuntary HA demotion so a node that just lost leadership does not run a
+   * backlog of doomed sends. Tasks already in flight are not recalled — the
+   * single-writer guard in keeperSend() blocks those at send time.
+   */
+  clearPending(): void {
+    for (const lane of ALL_LANES) {
+      this._lanes[lane].clear();
+      txQueuePending.set({ lane }, 0);
+    }
+  }
+
   getStats(): Record<TxLane, TxLaneStats> {
     const result = {} as Record<TxLane, TxLaneStats>;
     for (const lane of ALL_LANES) {

--- a/tests/lib/keeper-send-leader-gate.test.ts
+++ b/tests/lib/keeper-send-leader-gate.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Single-writer guard: keeperSend must refuse to send when the node is not the
+ * leader (e.g. a task dequeued from sharedTxQueue after an HA demotion). This is
+ * the host-local barrier against a demoted node double-landing on-chain txs,
+ * since the on-chain programs are permissionless.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  sendWithRetryKeeper: vi.fn(async () => "mock-signature"),
+}));
+vi.mock("../../src/lib/priority-fee.js", () => {
+  class HeliusPriorityFeeEstimator { estimate = vi.fn(async () => 1_000); }
+  return { HeliusPriorityFeeEstimator };
+});
+vi.mock("../../src/lib/cu-estimator.js", () => {
+  class CuEstimator { estimate = vi.fn(async () => 200_000); }
+  return { CuEstimator };
+});
+
+import * as shared from "@percolatorct/shared";
+import { keeperSend, setLeaderCheck } from "../../src/lib/keeper-send.js";
+import { KeeperBudget } from "../../src/lib/budget.js";
+import { Keypair, TransactionInstruction, PublicKey } from "@solana/web3.js";
+
+function makeDummyIx(): TransactionInstruction {
+  return new TransactionInstruction({ programId: PublicKey.default, keys: [], data: Buffer.from([]) });
+}
+function makeConnection() {
+  return {
+    simulateTransaction: vi.fn(async () => ({ value: { unitsConsumed: 200_000, err: null, logs: [] } })),
+  } as any;
+}
+
+describe("keeperSend single-writer (leadership) gate", () => {
+  let budget: KeeperBudget;
+  let connection: ReturnType<typeof makeConnection>;
+  let keypair: Keypair;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000, maxTxPerCycle: 100 });
+    connection = makeConnection();
+    keypair = Keypair.generate();
+    process.env.NETWORK = "devnet";
+    process.env.USE_HELIUS_SENDER = "false";
+  });
+  afterEach(() => {
+    setLeaderCheck(() => true); // restore module default so other suites are unaffected
+    delete process.env.DRY_RUN;
+  });
+
+  it("returns null and does NOT send when the node is not leader", async () => {
+    setLeaderCheck(() => false);
+
+    const result = await keeperSend(connection, [makeDummyIx()], [keypair], "liquidation", budget);
+
+    expect(result).toBeNull();
+    expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+    expect(connection.simulateTransaction).not.toHaveBeenCalled(); // gated before any RPC
+    expect(budget.getStats().cycleTxCount).toBe(0); // budget not charged
+  });
+
+  it("sends normally when the node is leader", async () => {
+    setLeaderCheck(() => true);
+
+    const result = await keeperSend(connection, [makeDummyIx()], [keypair], "liquidation", budget);
+
+    expect(result).not.toBeNull();
+    expect(result?.signature).toBe("mock-signature");
+    expect(shared.sendWithRetryKeeper).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/lib/leader-split-brain.poc.test.ts
+++ b/tests/lib/leader-split-brain.poc.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression for the leader-lock split-brain (HIGH) — was the PoC that proved it.
+ *
+ * Before the fix: `_renew()` did a blind `SET key value XX` that renewed against
+ * ANY existing holder, so a stalled-then-resumed leader stole the lock back and
+ * both nodes stayed leader. `stop()` did an unconditional `DEL`.
+ *
+ * After the fix: renew/release are atomic compare-and-set scripts (renew only if
+ * value == identity; delete only if value == identity). These tests assert the
+ * scenario that previously split-brained now DEMOTES the stale node and leaves
+ * the rightful holder's lock intact.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+import { LeaderLock, RENEW_SCRIPT, RELEASE_SCRIPT } from "../../src/lib/leader.js";
+import type { RedisLike } from "../../src/lib/redis-client.js";
+
+/** Minimal Redis honoring nx/xx/ex + the lock's two CAS scripts. TTL is manual. */
+class FakeRedis implements RedisLike {
+  store = new Map<string, string>();
+
+  async set(
+    key: string,
+    value: string,
+    opts: { ex: number; nx?: true } | { ex: number; xx?: true },
+  ): Promise<"OK" | null> {
+    const exists = this.store.has(key);
+    if ("nx" in opts && opts.nx && exists) return null;
+    if ("xx" in opts && opts.xx && !exists) return null;
+    this.store.set(key, value);
+    return "OK";
+  }
+  async get(key: string): Promise<string | null> {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  async del(...keys: string[]): Promise<number> {
+    let n = 0;
+    for (const k of keys) if (this.store.delete(k)) n++;
+    return n;
+  }
+  async eval<T = unknown>(script: string, keys: string[], args: (string | number)[]): Promise<T> {
+    const key = keys[0];
+    const identity = String(args[0]);
+    const owns = this.store.get(key) === identity;
+    if (script === RENEW_SCRIPT) return (owns ? 1 : 0) as T;
+    if (script === RELEASE_SCRIPT) { if (owns) this.store.delete(key); return (owns ? 1 : 0) as T; }
+    throw new Error(`unexpected script: ${script}`);
+  }
+  /** Simulate the lock's TTL lapsing (Redis evicting the key) while a node stalls. */
+  expire(key: string): void {
+    this.store.delete(key);
+  }
+}
+
+const OPTS = { ttlMs: 30_000, renewMs: 10_000, pollMs: 5_000, renewTimeoutMs: 3_000 };
+const LOCK_KEY = "keeper:leader:test";
+
+describe("regression: leader lock no longer split-brains (CAS renew/release)", () => {
+  let redis: FakeRedis;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    redis = new FakeRedis();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("a stalled-then-resumed leader detects the loss and DEMOTES — no split-brain", async () => {
+    const demoteA = vi.fn();
+    const nodeA = new LeaderLock(redis, "node-A", OPTS);
+    const nodeB = new LeaderLock(redis, "node-B", OPTS);
+
+    nodeA.start({ network: "test", onPromote: () => {}, onDemote: demoteA });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(nodeA.role()).toBe("leader");
+
+    nodeB.start({ network: "test", onPromote: () => {}, onDemote: () => {} });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(nodeB.role()).toBe("standby");
+
+    // A stalls; its TTL lapses (Redis evicts the key) before its renew fires.
+    redis.expire(LOCK_KEY);
+
+    // B's poll legitimately acquires the lock.
+    await vi.advanceTimersByTimeAsync(OPTS.pollMs);
+    expect(nodeB.role()).toBe("leader");
+    expect(redis.store.get(LOCK_KEY)).toBe("node-B");
+
+    // A resumes; its renew CAS finds the value is "node-B" (not "node-A") → returns 0.
+    await vi.advanceTimersByTimeAsync(OPTS.renewMs - OPTS.pollMs);
+
+    // FIXED: A demotes instead of stealing the lock back.
+    expect(nodeA.role()).toBe("standby");
+    expect(demoteA).toHaveBeenCalledWith("redis-lock-lost");
+    // B keeps sole ownership — A never overwrote it.
+    expect(redis.store.get(LOCK_KEY)).toBe("node-B");
+    // And only one node is leader.
+    expect([nodeA, nodeB].filter((n) => n.role() === "leader")).toHaveLength(1);
+
+    await nodeA.stop();
+    await nodeB.stop();
+  });
+
+  it("stop() on a stale leader does NOT delete a lock another node owns", async () => {
+    const nodeA = new LeaderLock(redis, "node-A", OPTS);
+
+    nodeA.start({ network: "test", onPromote: () => {}, onDemote: () => {} });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(nodeA.role()).toBe("leader");
+
+    // A's TTL lapsed and node B legitimately took the lock.
+    redis.store.set(LOCK_KEY, "node-B");
+
+    // A is still a stale in-memory leader. CAS release deletes only if it still
+    // owns the key — so B's lock survives.
+    await nodeA.stop();
+    expect(redis.store.get(LOCK_KEY)).toBe("node-B");
+  });
+});

--- a/tests/lib/leader.test.ts
+++ b/tests/lib/leader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { LeaderLock } from "../../src/lib/leader.js";
+import { LeaderLock, RENEW_SCRIPT, RELEASE_SCRIPT } from "../../src/lib/leader.js";
 import type { RedisLike } from "../../src/lib/redis-client.js";
 
 // ─── Mock Redis ───────────────────────────────────────────────────────────────
@@ -9,11 +9,11 @@ type SetOpts = { ex: number; nx?: true } | { ex: number; xx?: true };
 function makeMockRedis(): {
   redis: RedisLike;
   store: Map<string, string>;
-  calls: { set: number; get: number; del: number };
+  calls: { set: number; get: number; del: number; eval: number };
   failNext: { set?: boolean; get?: boolean };
 } {
   const store = new Map<string, string>();
-  const calls = { set: 0, get: 0, del: 0 };
+  const calls = { set: 0, get: 0, del: 0, eval: 0 };
   const failNext = { set: false, get: false };
 
   const redis: RedisLike = {
@@ -39,6 +39,17 @@ function makeMockRedis(): {
         if (store.delete(k)) count++;
       }
       return count;
+    },
+    // Faithful CAS emulation of the two scripts the lock ships (matched by the
+    // exact exported strings, so the fake can't silently diverge from prod).
+    async eval<T = unknown>(script: string, keys: string[], args: (string | number)[]): Promise<T> {
+      calls.eval++;
+      const key = keys[0];
+      const identity = String(args[0]);
+      const owns = store.get(key) === identity;
+      if (script === RENEW_SCRIPT) return (owns ? 1 : 0) as T;           // TTL refresh is a no-op in the fake
+      if (script === RELEASE_SCRIPT) { if (owns) store.delete(key); return (owns ? 1 : 0) as T; }
+      throw new Error(`unexpected script in fake: ${script}`);
     },
   };
 
@@ -121,7 +132,7 @@ describe("LeaderLock state machine", () => {
     await lock.stop();
   });
 
-  it("leader renews lock on schedule", async () => {
+  it("leader renews lock on schedule (via CAS eval, not SET)", async () => {
     const { redis, calls } = makeMockRedis();
     const lock = new LeaderLock(redis, "test-id", { ttlMs: 30_000, renewMs: 10_000, pollMs: 5_000 });
     const onPromote = vi.fn();
@@ -130,29 +141,28 @@ describe("LeaderLock state machine", () => {
     lock.start({ network: "devnet", onPromote, onDemote });
     await vi.advanceTimersByTimeAsync(100);
 
+    const evalCountAfterPromote = calls.eval; // 0 — acquire uses SET NX, not eval
     const setCountAfterPromote = calls.set;
     expect(lock.role()).toBe("leader");
 
     await vi.advanceTimersByTimeAsync(10_100);
-    expect(calls.set).toBeGreaterThan(setCountAfterPromote);
+    expect(calls.eval).toBeGreaterThan(evalCountAfterPromote); // renew is a CAS eval
+    expect(calls.set).toBe(setCountAfterPromote);              // renew never re-SETs the value
     expect(lock.role()).toBe("leader");
 
     await lock.stop();
   });
 
   it("demotes after two consecutive renew failures", async () => {
-    let setCallCount = 0;
     const mockRedis: RedisLike = {
       async set(_key: string, _value: string, opts: SetOpts): Promise<"OK" | null> {
-        setCallCount++;
         const hasNx = "nx" in opts && opts.nx === true;
-        if (setCallCount === 1 && hasNx) {
-          return "OK";
-        }
-        throw new Error("Redis connection refused");
+        return hasNx ? "OK" : null; // acquire succeeds
       },
       async get(_key: string): Promise<string | null> { return null; },
       async del(..._keys: string[]): Promise<number> { return 0; },
+      // renew/release fail with a transport error (ambiguous → 2-strike demote)
+      async eval<T = unknown>(): Promise<T> { throw new Error("Redis connection refused"); },
     };
 
     const lock = new LeaderLock(mockRedis, "test-id", { ttlMs: 30_000, renewMs: 10_000, pollMs: 5_000 });
@@ -208,7 +218,7 @@ describe("LeaderLock state machine", () => {
     await lock.stop();
   });
 
-  it("stop() releases lock and DELs the key when leader", async () => {
+  it("stop() releases the key (via CAS) when leader", async () => {
     const { redis, store } = makeMockRedis();
     const lock = new LeaderLock(redis, "test-id", { ttlMs: 30_000, renewMs: 10_000, pollMs: 5_000 });
     const onPromote = vi.fn();
@@ -240,17 +250,16 @@ describe("LeaderLock state machine", () => {
     expect(calls.del).toBe(0);
   });
 
-  it("demotes when renew returns null (lock stolen)", async () => {
-    let setCallCount = 0;
+  it("demotes immediately when renew CAS reports not-owner (lock stolen)", async () => {
     const mockRedis: RedisLike = {
       async get(_key: string): Promise<string | null> { return null; },
       async del(..._keys: string[]): Promise<number> { return 0; },
       async set(_key: string, _value: string, opts: SetOpts): Promise<"OK" | null> {
-        setCallCount++;
         const hasNx = "nx" in opts && opts.nx === true;
-        if (setCallCount === 1 && hasNx) return "OK";
-        return null;
+        return hasNx ? "OK" : null; // acquire succeeds
       },
+      // CAS renew returns 0 = "not the owner" → definitive loss, demote at once.
+      async eval<T = unknown>(): Promise<T> { return 0 as T; },
     };
 
     const lock = new LeaderLock(mockRedis, "test-id", { ttlMs: 30_000, renewMs: 10_000, pollMs: 5_000 });
@@ -278,18 +287,23 @@ describe("LeaderLock state machine", () => {
     await lock.stop();
   });
 
-  it("uses XX flag on renewal (not NX)", async () => {
-    const setCalls: Array<SetOpts> = [];
+  it("renews via the CAS eval script (never a blind SET XX)", async () => {
+    const setOpts: Array<SetOpts> = [];
+    const evalScripts: string[] = [];
+    const store = new Map<string, string>();
     const mockRedis: RedisLike = {
-      async get(_key: string): Promise<string | null> { return null; },
+      async get(key: string): Promise<string | null> { return store.get(key) ?? null; },
       async del(..._keys: string[]): Promise<number> { return 0; },
-      async set(_key: string, _value: string, opts: SetOpts): Promise<"OK" | null> {
-        setCalls.push(opts);
+      async set(key: string, value: string, opts: SetOpts): Promise<"OK" | null> {
+        setOpts.push(opts);
         const hasNx = "nx" in opts && opts.nx === true;
-        const hasXx = "xx" in opts && (opts as { xx?: true }).xx === true;
-        if (setCalls.length === 1 && hasNx) return "OK";
-        if (hasXx) return "OK";
-        return null;
+        if (hasNx && store.has(key)) return null;
+        store.set(key, value);
+        return "OK";
+      },
+      async eval<T = unknown>(script: string, keys: string[], args: (string | number)[]): Promise<T> {
+        evalScripts.push(script);
+        return (store.get(keys[0]) === String(args[0]) ? 1 : 0) as T;
       },
     };
 
@@ -298,12 +312,37 @@ describe("LeaderLock state machine", () => {
     await vi.advanceTimersByTimeAsync(100);
     await vi.advanceTimersByTimeAsync(10_100);
 
-    const renewOpts = setCalls[1];
-    expect(renewOpts).toBeDefined();
-    expect("xx" in renewOpts!).toBe(true);
-    expect(!("nx" in renewOpts!) || (renewOpts as { nx?: true }).nx !== true).toBe(true);
+    // Acquire used SET NX exactly once; renew used the CAS eval, never an XX SET.
+    expect(evalScripts).toContain(RENEW_SCRIPT);
+    expect(setOpts.every((o) => !("xx" in o))).toBe(true);
 
     await lock.stop();
+  });
+
+  it("demotes when the renew Redis call hangs past renewTimeoutMs (liveness)", async () => {
+    const mockRedis: RedisLike = {
+      async get(): Promise<string | null> { return null; },
+      async del(): Promise<number> { return 0; },
+      async set(_key: string, _value: string, opts: SetOpts): Promise<"OK" | null> {
+        return "nx" in opts && opts.nx === true ? "OK" : null;
+      },
+      // renew/release never resolve — simulates a hung Upstash REST call.
+      eval<T = unknown>(): Promise<T> { return new Promise<T>(() => {}); },
+    };
+
+    const lock = new LeaderLock(mockRedis, "test-id", {
+      ttlMs: 30_000, renewMs: 10_000, pollMs: 5_000, renewTimeoutMs: 3_000,
+    });
+    const onDemote = vi.fn();
+    lock.start({ network: "devnet", onPromote: vi.fn(), onDemote });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(lock.role()).toBe("leader");
+
+    // Two renew cycles, each timing out at renewTimeoutMs → 2-strike demote.
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(lock.role()).toBe("standby");
+    expect(onDemote).toHaveBeenCalledWith("redis-renew-failed");
   });
 
   it("initial acquire error falls back to standby gracefully", async () => {

--- a/tests/lib/tx-queue-clear-pending.test.ts
+++ b/tests/lib/tx-queue-clear-pending.test.ts
@@ -1,0 +1,55 @@
+/**
+ * TxQueue.clearPending() drops queued-but-not-started tasks across all lanes.
+ * Used on involuntary HA demotion so a node that lost leadership does not run a
+ * backlog of doomed sends.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { TxQueue } from "../../src/lib/tx-queue.js";
+
+describe("TxQueue.clearPending", () => {
+  it("drops queued-but-not-started tasks; their fn never runs", async () => {
+    // concurrency 1 so only the first task starts; the rest sit pending.
+    const q = new TxQueue({
+      liquidation: { concurrency: 1, intervalCap: 100, interval: 1 },
+      oracle: { concurrency: 1, intervalCap: 100, interval: 1 },
+      crank: { concurrency: 1, intervalCap: 100, interval: 1 },
+    });
+
+    let releaseFirst!: () => void;
+    const block = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const ran: string[] = [];
+    // First task blocks until we release it — keeps the single slot busy.
+    const p1 = q.enqueue("liquidation", async () => { ran.push("first"); await block; });
+    // These queue behind it and must be dropped by clearPending(). Their promises
+    // never settle once cleared (p-queue drops them), so we don't await them.
+    for (const id of ["a", "b", "c"]) {
+      void q.enqueue("liquidation", async () => { ran.push(id); }).catch(() => {});
+    }
+
+    // Let the first task start (occupy the slot) so a,b,c are pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(q.getStats().liquidation.pending).toBeGreaterThan(0);
+
+    q.clearPending();
+
+    // Release the in-flight task and give the loop a few ticks — a,b,c must not run.
+    releaseFirst();
+    await p1;
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(ran).toEqual(["first"]); // only the already-started task ran
+    expect(q.getStats().liquidation.pending).toBe(0);
+  });
+
+  it("is a safe no-op on an empty queue", () => {
+    const q = new TxQueue();
+    expect(() => q.clearPending()).not.toThrow();
+    for (const lane of ["liquidation", "oracle", "crank"] as const) {
+      expect(q.getStats()[lane].pending).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #137. Makes the HA leader lock split-brain-safe by replacing the blind `SET … XX` renew and unconditional `DEL` with atomic compare-and-set operations, and adds a host-local single-writer gate so a demoted node cannot land on-chain transactions.

## Root cause

`_renew()` renewed the lock with a blind `SET key value XX` that succeeds against any existing holder, so a leader that stalled past the TTL stole the lock back on its next renew and both nodes stayed leader. `stop()` deleted the lock unconditionally. The keeper sends permissionless `KeeperCrank`/`LiquidateAtOracle`, so dual leadership means duplicate liquidations/cranks; the Redis lock is the only single-writer guarantee.

## Changes

- **`src/lib/redis-client.ts`** — add `eval` to the `RedisLike` contract (mirrors `@upstash/redis` `Redis.eval`; the real client already satisfies it).
- **`src/lib/leader.ts`** — renew/release are now atomic compare-and-set Lua scripts: renew via `pexpire` **only if** `value == identity` (the value is never rewritten), release via `del` **only if** `value == identity`. A CAS "not owner" result demotes immediately (definitive loss); transport errors/timeouts keep the existing 2-strike tolerance. Adds a per-call renew timeout (`renewTimeoutMs`, default `min(renewMs/2, 5000)`) so a hung Redis demotes the node before its TTL silently lapses.
- **`src/lib/keeper-send.ts`** — `setLeaderCheck()` plus a first-thing single-writer gate: `keeperSend` refuses to send when the node is not leader and returns `null` (the existing "skip, not a failure" contract every caller already handles). This is the actual barrier against a demoted node double-sending, since the on-chain programs are permissionless.
- **`src/lib/tx-queue.ts`** — `clearPending()` drops queued-but-not-started tasks across all lanes.
- **`src/index.ts`** — wires the live-role send gate (`() => leaderLock ? role() === "leader" : true`) and clears the queued backlog on involuntary demote.
- **tests** — the split-brain reproduction is flipped into a regression (the stalled node now demotes with `redis-lock-lost`, the lock is not stolen, and stale `stop()` no longer deletes another node's lock), plus tests for renew-timeout demotion, CAS-renew (never a blind `SET XX`), the send gate, and `clearPending()`.

## Verification

- `tsc --noEmit`: clean.
- Full test suite: **619 passed**, 0 failed.
- Leader chaos/failover suite (`STRESS=true`): **18 passed** (graceful + ungraceful failover, network-partition standby, concurrent-acquire).

## Notes

- No behavior change off the HA path: the send gate defaults to "leader" when no lock is configured, and acquire still uses `SET … NX` unchanged.
- No fencing token: the program is permissionless, so there is no on-chain validator for a token; the CAS lock plus the host-local send gate is the achievable single-writer guarantee. (On-chain fencing would require a program change and is out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * HA mode now enforces leadership-aware transaction sending—non-leader nodes skip transactions and automatically clear pending queues on demotion.
  * Leader election uses atomic operations to prevent split-brain conflicts and stale leaders overwriting newer locks.

* **Bug Fixes**
  * Improved timeout handling for leader operations with graceful demotion on failures.

* **Tests**
  * Added comprehensive test coverage for leadership-aware transaction behavior and split-brain prevention scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->