### PR TITLE
fix(keeper): align HYPERP detection with the program (drop stale oracle_authority gate)

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -557,13 +557,20 @@ export class CrankService {
   }
 
   /**
-   * True HYPERP mode: oracle_authority == [0;32] AND index_feed_id == [0;32].
-   * Uses toBytes() check — compatible with both real PublicKey and test mocks.
+   * HYPERP mode iff index_feed_id == [0;32], matching the program's
+   * `oracle::is_hyperp_mode` (percolator.rs:4156-4158), which keys ONLY off
+   * index_feed_id. The old extra `oracle_authority == 0` condition was a stale
+   * pre-Phase-G "admin oracle" artifact: post-Phase-G that field is
+   * `hyperp_authority` and is intentionally bootstrapped non-zero on HYPERP
+   * markets (UpdateAuthority HYPERP_MARK), yet `UpdateHyperpMark` is gated only
+   * on is_hyperp_mode and has no authority check — so requiring authority==0
+   * here misclassified bootstrapped HYPERP markets as non-hyperp and silently
+   * stopped refreshing their DEX-EMA mark.
+   * Uses toBytes() — compatible with both real PublicKey and test mocks.
    */
   private isHyperpOracle(market: DiscoveredMarket): boolean {
     const feedBytes = market.config.indexFeedId.toBytes();
-    const isZeroFeed = feedBytes.every((b: number) => b === 0);
-    return !this.isAdminOracle(market) && isZeroFeed;
+    return feedBytes.every((b: number) => b === 0);
   }
 
   private async resolveHyperpPoolRemainingAccounts(
@@ -989,34 +996,13 @@ export class CrankService {
       txSentTotal.inc({ result: "drop", type: "crank" });
       continue;
     }
-    // GH#1251: Live authority check — covers both the steady-state case (flag already set)
-    // and the post-discover() window where the flag was just reset.
-    // Any admin-oracle market where the keeper is NOT the oracle authority is always skipped.
-    if (
-      this.isAdminOracle(state.market) &&
-      !keeperKey.equals(state.market.config.oracleAuthority)
-    ) {
-      // Keep the flag in sync so crankMarket() also fast-paths correctly.
-      if (!state.foreignOracleSkipped) {
-        state.foreignOracleSkipped = true;
-        // GH#1748: Use WARN (not debug) on first detection, include both keys so ops can
-        // immediately diagnose a CRANK_KEYPAIR mismatch without reading the source.
-        logger.warn("crankAll: admin-oracle market skipped — keeper is NOT the oracle authority (key mismatch). " +
-          "Fix: set CRANK_KEYPAIR to the oracle authority key, or update the on-chain oracle authority.", {
-          slabAddress,
-          marketOracleAuthority: state.market.config.oracleAuthority.toBase58(),
-          keeperPublicKey: keeperKey.toBase58(),
-        });
-      } else {
-        logger.debug("crankAll: re-skipping foreign oracle market (flag was reset by discover)", {
-          slabAddress,
-          marketOracleAuthority: state.market.config.oracleAuthority.toBase58(),
-          keeperPublicKey: keeperKey.toBase58(),
-        });
-      }
-      skippedForeignOracle++;
-      continue;
-    }
+    // Post-Phase-G: the "foreign oracle" skip (admin-push oracle requiring the
+    // keeper to be the oracle authority) was removed. The program no longer has
+    // an admin-push oracle; `oracle_authority` is now `hyperp_authority`, which
+    // does NOT gate cranking — KeeperCrank/UpdateHyperpMark are permissionless.
+    // Skipping markets whose keeper != hyperp_authority false-skipped crankable
+    // markets, so the check is gone. (skippedForeignOracle stays 0.)
+
     // PERC-1254: Live Hyperp-no-price check.
     // Condition: admin-oracle market where keeper IS the authority, indexFeedId=all-zeros
     // (Hyperp mode), and on-chain authority_price_e6 is still 0.  Sending KeeperCrank in

--- a/tests/services/crank-hyperp-detection.poc.test.ts
+++ b/tests/services/crank-hyperp-detection.poc.test.ts
@@ -1,0 +1,89 @@
+/**
+ * PoC — proves the HYPERP-detection divergence (MEDIUM).
+ *
+ * Program ground truth (dcccrypto/percolator-prog, src/percolator.rs):
+ *   is_hyperp_mode(config) = (config.index_feed_id == [0u8;32])   // line 4156-4158
+ *   handle_update_hyperp_mark gates ONLY on is_hyperp_mode (16213) — NO hyperp_authority check.
+ *   A HYPERP market is intended to carry a non-zero hyperp_authority (UpdateAuthority
+ *   HYPERP_MARK bootstrap, percolator.rs:7949-8044). The SDK surfaces that field as
+ *   config.oracleAuthority (config offset 144 == hyperp_authority).
+ *
+ * Keeper bug: CrankService.isHyperpOracle requires index_feed_id==0 AND oracleAuthority==0
+ * (crank.ts:563-567). So a HYPERP market with a bootstrapped non-zero hyperp_authority is
+ * misclassified as NOT hyperp → the UpdateHyperpMark branch (crank.ts:691) is skipped → the
+ * on-chain DEX-EMA mark goes stale.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@solana/web3.js", async () => {
+  const actual = await vi.importActual("@solana/web3.js");
+  return { ...actual };
+});
+vi.mock("@percolatorct/sdk", () => ({
+  discoverMarkets: vi.fn(),
+  encodeKeeperCrank: vi.fn(() => Buffer.from([1])),
+  encodeUpdateHyperpMark: vi.fn(() => Buffer.from([7])),
+  buildAccountMetas: vi.fn(() => []),
+  buildIx: vi.fn(() => ({})),
+  derivePythPushOraclePDA: vi.fn(() => [{ toBase58: () => "11111111111111111111111111111111" }, 0]),
+  ACCOUNTS_KEEPER_CRANK: {},
+}));
+vi.mock("@percolatorct/shared", () => ({
+  config: { crankIntervalMs: 30000, crankInactiveIntervalMs: 120000, discoveryIntervalMs: 300000, allProgramIds: ["11111111111111111111111111111111"], crankKeypair: "mock" },
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  getConnection: vi.fn(() => ({})),
+  getFallbackConnection: vi.fn(() => ({})),
+  loadKeypair: vi.fn(() => ({ publicKey: { toBase58: () => "11111111111111111111111111111111", equals: () => false } })),
+  sendWithRetryKeeper: vi.fn(),
+  eventBus: { publish: vi.fn() },
+  getSupabase: vi.fn(),
+}));
+vi.mock("../../src/lib/keeper-send.js", async () => {
+  const { KeeperBudget } = await vi.importActual<typeof import("../../src/lib/budget.js")>("../../src/lib/budget.js");
+  return { keeperSend: vi.fn(), sharedBudget: new KeeperBudget() };
+});
+
+import { PublicKey } from "@solana/web3.js";
+import { CrankService } from "../../src/services/crank.js";
+
+const ZERO_FEED = { toBytes: () => new Uint8Array(32) };
+function nonZeroFeed() { const a = new Uint8Array(32); a[0] = 0xab; return { toBytes: () => a }; }
+
+// oracleAuthority.equals(PublicKey.default): zero → true (not admin); non-zero → false (admin).
+const ZERO_AUTH = { equals: (_o: PublicKey) => true, toBase58: () => "11111111111111111111111111111111" };
+const NONZERO_AUTH = { equals: (_o: PublicKey) => false, toBase58: () => "Auth1111111111111111111111111111111111111111" };
+
+/** The program's actual rule. */
+function programIsHyperp(market: any): boolean {
+  return market.config.indexFeedId.toBytes().every((b: number) => b === 0);
+}
+
+describe("PoC: keeper HYPERP detection diverges from the program", () => {
+  let crank: CrankService;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    crank = new CrankService({ pushPrice: vi.fn(), recordPushTime: vi.fn() } as any);
+  });
+  afterEach(() => crank.stop());
+
+  it("FIXED: a HYPERP market with a non-zero hyperp_authority is now classified as hyperp", () => {
+    const market = { slabAddress: { toBase58: () => "Slab" }, config: { indexFeedId: ZERO_FEED, oracleAuthority: NONZERO_AUTH } };
+
+    // Program: this IS a hyperp market (index_feed_id == 0) and needs UpdateHyperpMark.
+    expect(programIsHyperp(market)).toBe(true);
+    // Keeper now agrees (no longer gated on oracleAuthority) → UpdateHyperpMark is sent.
+    expect((crank as any).isHyperpOracle(market)).toBe(true);
+  });
+
+  it("a fresh HYPERP market (zero authority) is classified correctly", () => {
+    const market = { slabAddress: { toBase58: () => "Slab" }, config: { indexFeedId: ZERO_FEED, oracleAuthority: ZERO_AUTH } };
+    expect(programIsHyperp(market)).toBe(true);
+    expect((crank as any).isHyperpOracle(market)).toBe(true);
+  });
+
+  it("a real external-feed (Pyth) market is not hyperp on either side", () => {
+    const market = { slabAddress: { toBase58: () => "Slab" }, config: { indexFeedId: nonZeroFeed(), oracleAuthority: ZERO_AUTH } };
+    expect(programIsHyperp(market)).toBe(false);
+    expect((crank as any).isHyperpOracle(market)).toBe(false);
+  });
+});

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -685,128 +685,41 @@ describe('CrankService', () => {
       }
     });
 
-    it('crankAll should count foreignOracleSkipped markets in skipped total', async () => {
+    // Post-Phase-G: the "foreign oracle" skip (admin-push oracle requiring the keeper
+    // to be the oracle authority) was removed. A market with a non-zero oracle authority
+    // and index_feed_id == 0 is a normal HYPERP market and must be cranked, not skipped.
+    // (The two prior tests that asserted the skip behavior were deleted with this change.)
+    it('Post-Phase-G: a market with a non-zero (foreign) oracle authority is cranked as HYPERP, not skipped', async () => {
       const slabForeign = 'MarketFO3111111111111111111111111111111';
-      const slabNormal = 'MarketNorm111111111111111111111111111111';
-      const FOREIGN_AUTH = 'ForeignAuth31111111111111111111111111111';
       const mockForeignMarket = {
         slabAddress: { toBase58: () => slabForeign },
         programId: { toBase58: () => '11111111111111111111111111111111' },
         config: {
           collateralMint: { toBase58: () => 'MintFO31111111111111111111111111111111' },
-          // Non-default, non-keeper oracle authority → isAdminOracle=true, keeper≠authority
-          oracleAuthority: {
-            toBase58: () => FOREIGN_AUTH,
-            equals: (_other: any) => false, // not PublicKey.default AND not keeper key
-          },
-          indexFeedId: { toBytes: () => new Uint8Array(32) },
+          // Non-default, non-keeper oracle authority — the old "foreign oracle" case.
+          oracleAuthority: { toBase58: () => 'ForeignAuth31111111111111111111111111111', equals: (_o: any) => false },
+          indexFeedId: { toBytes: () => new Uint8Array(32) }, // index_feed_id == 0 → HYPERP
+          authorityPriceE6: BigInt(50_000_000), // mark already set → not hyperp-no-price-skipped
         },
         params: { maintenanceMarginBps: 500n },
         header: { admin: { toBase58: () => 'AdminFO31111111111111111111111111111111' } },
       };
-      const mockNormalMarket = {
-        slabAddress: { toBase58: () => slabNormal },
-        programId: { toBase58: () => '11111111111111111111111111111111' },
-        config: {
-          collateralMint: { toBase58: () => 'MintNorm1111111111111111111111111111111' },
-          oracleAuthority: { toBase58: () => '11111111111111111111111111111111', equals: () => true },
-          indexFeedId: { toBytes: () => new Uint8Array(32) },
-        },
-        params: { maintenanceMarginBps: 500n },
-        header: { admin: { toBase58: () => 'AdminNorm111111111111111111111111111111' } },
-      };
 
-      // GH#1251: crankAll now calls loadKeypair() for a live authority check.
-      // Keeper key must NOT match oracleAuthority so the foreign market is skipped.
+      // Keeper key does NOT match the foreign oracle authority — pre-fix this forced a skip.
       vi.mocked(shared.loadKeypair).mockReturnValue({
-        publicKey: {
-          toBase58: () => 'KeeperKey311111111111111111111111111111',
-          equals: (_other: any) => false, // keeper ≠ foreign oracle authority
-        },
+        publicKey: { toBase58: () => 'KeeperKey311111111111111111111111111111', equals: (_o: any) => false },
         secretKey: new Uint8Array(64),
       } as any);
 
-      vi.mocked(core.discoverMarkets).mockResolvedValue([mockForeignMarket, mockNormalMarket] as any);
+      vi.mocked(core.discoverMarkets).mockResolvedValue([mockForeignMarket] as any);
       await crankService.discover();
 
-      // Pre-mark the foreign oracle market as skipped (as crankMarket would do in steady state)
-      const foreignState = crankService.getMarkets().get(slabForeign)!;
-      foreignState.foreignOracleSkipped = true;
-
-      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'sig-normal', estimatedCost: 5000 } as any);
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'sig-foreign', estimatedCost: 5000 } as any);
       const result = await crankService.crankAll();
 
-      // Normal market cranked; foreign oracle market skipped → skipped >= 1
-      expect(result.skipped).toBeGreaterThanOrEqual(1);
-      expect(result.success).toBe(1);
-    });
-
-    it('GH#1251: crankAll should count foreign-oracle market as skipped (not failed) even after discover() resets the flag', async () => {
-      // Regression test: after discover() resets foreignOracleSkipped=false, crankAll used to
-      // enqueue the market, call crankMarket() which returned false → failed++ instead of skipped++.
-      // Fix: live authority check in crankAll before enqueue.
-      const slabForeign = 'MarketFO4111111111111111111111111111111';
-      const slabNormal  = 'MarketNorm2111111111111111111111111111111';
-
-      const FOREIGN_AUTHORITY = 'ForeignAuth41111111111111111111111111111';
-
-      const mockForeignMarket = {
-        slabAddress: { toBase58: () => slabForeign },
-        programId:   { toBase58: () => '11111111111111111111111111111111' },
-        config: {
-          collateralMint: { toBase58: () => 'MintFO41111111111111111111111111111111' },
-          // Non-default, non-keeper oracle authority
-          oracleAuthority: {
-            toBase58: () => FOREIGN_AUTHORITY,
-            equals: (_other: any) => false, // not PublicKey.default → isAdminOracle=true; not keeper → should skip
-          },
-          indexFeedId: { toBytes: () => new Uint8Array(32) },
-        },
-        params: { maintenanceMarginBps: 500n },
-        header: { admin: { toBase58: () => 'AdminFO41111111111111111111111111111111' } },
-      };
-      const mockNormalMarket = {
-        slabAddress: { toBase58: () => slabNormal },
-        programId:   { toBase58: () => '11111111111111111111111111111111' },
-        config: {
-          collateralMint: { toBase58: () => 'MintNorm2111111111111111111111111111111' },
-          oracleAuthority: { toBase58: () => '11111111111111111111111111111111', equals: () => true },
-          indexFeedId: { toBytes: () => new Uint8Array(32) },
-        },
-        params: { maintenanceMarginBps: 500n },
-        header: { admin: { toBase58: () => 'AdminNorm2111111111111111111111111111111' } },
-      };
-
-      // Keeper key does NOT match FOREIGN_AUTHORITY
-      vi.mocked(shared.loadKeypair).mockReturnValue({
-        publicKey: {
-          toBase58: () => 'KeeperKey411111111111111111111111111111',
-          equals: (_other: any) => false,
-        },
-        secretKey: new Uint8Array(64),
-      } as any);
-
-      vi.mocked(core.discoverMarkets).mockResolvedValue([mockForeignMarket, mockNormalMarket] as any);
-      await crankService.discover();
-
-      // Simulate what crankMarket() does: set foreignOracleSkipped=true
-      const foreignState = crankService.getMarkets().get(slabForeign)!;
-      foreignState.foreignOracleSkipped = true;
-
-      // Now simulate discover() resetting the flag (as it does on each cycle)
-      foreignState.foreignOracleSkipped = false;
-
-      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'sig-norm2', estimatedCost: 5000 } as any);
-      const result = await crankService.crankAll();
-
-      // The foreign oracle market should be SKIPPED, not failed
+      // No longer foreign-oracle-skipped: cranked as HYPERP, not skipped or failed.
       expect(result.failed).toBe(0);
-      expect(result.skipped).toBeGreaterThanOrEqual(1);
-      expect(result.success).toBe(1);
-
-      // Confirm the flag was re-set by crankAll's live check
-      const stateAfter = crankService.getMarkets().get(slabForeign)!;
-      expect(stateAfter.foreignOracleSkipped).toBe(true);
+      expect(result.success).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -936,6 +849,9 @@ describe('CrankService', () => {
           oracleAuthority: keeperOracleAuth2,
           authorityPriceE6: BigInt(0),
           lastEffectivePriceE6: BigInt(1_000_000),
+          // New model: a HYPERP market refreshes its mark from a pinned DEX pool
+          // (UpdateHyperpMark), not an off-chain fetchPrice.
+          dexPool: { toBase58: () => 'So11111111111111111111111111111111111111112' },
         },
         params: { maintenanceMarginBps: 500n },
         header: { admin: { toBase58: () => 'Admin311111111111111111111111111111111' } },
@@ -952,10 +868,11 @@ describe('CrankService', () => {
         const stateAfterSkip = localCrank.getMarkets().get(slabHyperp)!;
         expect(stateAfterSkip.hyperpNoPriceSkipped).toBe(true);
 
-        // Second cycle: price available — should clear flag and crank
-        mockOracleService.fetchPrice = vi.fn().mockResolvedValue({ priceE6: BigInt(75_000_000) });
-        // Simulate discovery reset (as discover() does)
+        // Second cycle: the pinned DEX pool is now resolved (cached), so
+        // UpdateHyperpMark can refresh the mark. Simulate discovery resetting the flag.
         stateAfterSkip.hyperpNoPriceSkipped = false;
+        stateAfterSkip.dexPoolResolvedAddress = 'So11111111111111111111111111111111111111112';
+        stateAfterSkip.dexPoolRemainingAccounts = [];
 
         const result2 = await localCrank.crankMarket(slabHyperp);
         expect(result2).toBe(true);


### PR DESCRIPTION
## Summary

Fixes #141. Aligns the keeper's HYPERP detection with the program and removes the stale "foreign oracle" skip, so a HYPERP market with a bootstrapped (non-zero) `hyperp_authority` is cranked instead of being silently dropped.

## Root cause

`CrankService.isHyperpOracle` required `index_feed_id == 0` **and** `oracle_authority == 0`. The program's `oracle::is_hyperp_mode` keys only off `index_feed_id == [0;32]` (percolator.rs:4156-4158), and `UpdateHyperpMark` has no `hyperp_authority` check (percolator.rs:16213). Post-Phase-G that field is `hyperp_authority`, which a HYPERP market is intended to carry non-zero (UpdateAuthority HYPERP_MARK bootstrap). So a bootstrapped HYPERP market was misclassified as non-hyperp and its `UpdateHyperpMark` was never sent → its DEX-EMA mark went stale.

The same stale predicate drove the `crankAll` "foreign oracle" skip (drop any market whose keeper isn't the admin-push oracle authority). Because that skip runs before `crankMarket`, fixing detection alone wouldn't help — both must change together.

## Changes

- **`src/services/crank.ts`**
  - `isHyperpOracle()` now returns `index_feed_id == [0;32]` only — matching `is_hyperp_mode`.
  - Removed the `crankAll` foreign-oracle skip block. The admin-push oracle it assumed no longer exists; `KeeperCrank`/`UpdateHyperpMark` are permissionless, so requiring `keeper == oracle_authority` only false-skipped crankable markets.
  - Left unchanged (separate concerns): the non-hyperp oracle-key derivation, and the narrower `crankAll` hyperp-no-price pre-skip (which only fires when `keeper == hyperp_authority`).

- **tests**
  - New `crank-hyperp-detection.poc.test.ts` proves the fix at the unit level (a HYPERP market with a non-zero authority is now classified as hyperp).
  - Replaced the two obsolete foreign-oracle-skip tests with one asserting such a market is cranked as HYPERP (not skipped).
  - Updated the `PERC-1254` test to the new DEX-pool model (HYPERP marks refresh from a pinned DEX pool via `UpdateHyperpMark`, not an off-chain `fetchPrice`).

## Verification

- `tsc --noEmit`: clean.
- Crank suites: 27 passed (3 pre-existing `.skip`).
- Full keeper test suite: **621 passed**, 0 failed.

## Notes

- No behavior change for external-feed (Pyth/Chainlink) markets or for fresh HYPERP markets whose authority is still zero. The fix only affects HYPERP markets with a non-zero `hyperp_authority`, which were previously dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HYPERP oracle classification logic to rely solely on feed ID validation.

* **Tests**
  * Added test coverage for HYPERP detection scenarios.
  * Updated existing tests to reflect oracle classification changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->