### PR TITLE
fix(keeper): fraud detector reads the real on-chain HYPERP mark + correct HYPERP gate

### DIFF
--- a/src/services/fraud-detector.ts
+++ b/src/services/fraud-detector.ts
@@ -6,9 +6,10 @@
  * affects any other code path. A divergence above the threshold fires a Discord
  * warning via sendWarningAlert and increments Prometheus counters only.
  *
- * On-chain mark source: engine.markPriceE6 (parsed from slab data by
- * parseEngine). This field is updated on-chain by UpdateHyperpMark and
- * represents the EMA mark price in E6 format (i.e. USD * 1e6).
+ * On-chain mark source: MarketConfig.hyperp_mark_e6, surfaced by the SDK as
+ * config.authorityPriceE6 (config offset 176), written on-chain by
+ * UpdateHyperpMark and represented in E6 format (i.e. USD * 1e6). The engine
+ * mark field (engine.markPriceE6) was dropped in v12.17 and parses as 0.
  *
  * Off-chain consensus: OracleService.fetchPrice(mint, slabAddress), which
  * returns the DexScreener / Jupiter median as priceE6 (also E6 format).
@@ -32,9 +33,9 @@ import {
 const logger = createLogger("keeper:fraud-detector");
 
 // Price scale used by both on-chain and off-chain price representations.
-// engine.markPriceE6 is in USD * 1e6; OracleService.fetchPrice returns priceE6
-// in the same units. No conversion required — just compare the raw bigint values
-// after converting to Number for the floating-point division.
+// config.authorityPriceE6 (the on-chain HYPERP mark) is in USD * 1e6;
+// OracleService.fetchPrice returns priceE6 in the same units. No conversion
+// required — just compare the raw bigint values after Number() for the division.
 const PRICE_E6_SCALE = 1_000_000;
 
 /**
@@ -125,21 +126,24 @@ export class FraudDetectorService {
     const now = Date.now();
 
     for (const [slabAddress, state] of markets) {
-      // Only HYPERP markets have engine.markPriceE6 set by UpdateHyperpMark.
-      // Non-HYPERP markets use Pyth/Chainlink — no cross-validate needed here.
-      // HYPERP detection: indexFeedId all-zeros AND oracleAuthority all-zeros.
+      // HYPERP detection matches the program's oracle::is_hyperp_mode, which keys
+      // ONLY off index_feed_id == [0;32]. A bootstrapped HYPERP market may carry a
+      // non-zero hyperp_authority, so we must NOT additionally require
+      // oracle_authority == 0 (that silently skipped such markets). Non-HYPERP
+      // markets read an external Pyth/Chainlink feed — nothing to cross-validate.
       const feedBytes = state.market.config.indexFeedId.toBytes();
       const isZeroFeed = feedBytes.every((b: number) => b === 0);
-      const isZeroAuthority = state.market.config.oracleAuthority.toBytes().every((b: number) => b === 0);
-      if (!isZeroFeed || !isZeroAuthority) {
-        // Not a true HYPERP market — no on-chain EMA to compare.
+      if (!isZeroFeed) {
         continue;
       }
 
-      // On-chain mark price: engine.markPriceE6 (E6 units, updated by UpdateHyperpMark).
-      const onChainMarkE6 = state.market.engine.markPriceE6;
+      // On-chain HYPERP mark (E6). v12.17+ dropped the engine mark field
+      // (parseEngine returns 0n), so the live mark is MarketConfig.hyperp_mark_e6,
+      // which the SDK surfaces as config.authorityPriceE6 (config offset 176) and
+      // UpdateHyperpMark writes.
+      const onChainMarkE6 = state.market.config.authorityPriceE6;
       if (onChainMarkE6 === undefined || onChainMarkE6 === 0n) {
-        logger.debug("FraudDetector: on-chain markPriceE6 is zero — skipping market", {
+        logger.debug("FraudDetector: on-chain HYPERP mark is zero — skipping market", {
           slabAddress: slabAddress.slice(0, 8),
         });
         continue;

--- a/tests/services/fraud-detector-mark.poc.test.ts
+++ b/tests/services/fraud-detector-mark.poc.test.ts
@@ -1,0 +1,86 @@
+/**
+ * PoC — proves the fraud-detector pair (MEDIUM): wrong mark field (INS-4) and
+ * over-strict HYPERP detection (INS-5).
+ *
+ * INS-4: the detector reads `engine.markPriceE6`, but on v12.17+ layouts the
+ *   engine mark field was dropped (parseEngine returns 0n). The on-chain HYPERP
+ *   mark lives in MarketConfig; the SDK surfaces it as `config.authorityPriceE6`
+ *   (config offset 176 == program `hyperp_mark_e6`). So the detector skips every
+ *   market (markPriceE6 === 0n) and never compares anything.
+ * INS-5: HYPERP detection requires index_feed_id == 0 AND oracle_authority == 0,
+ *   but the program defines HYPERP purely by index_feed_id == 0 — so a HYPERP
+ *   market with a non-zero hyperp_authority is never checked.
+ *
+ * These tests assert the CORRECT behavior: they FAIL on the unfixed code and PASS
+ * after the fix.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({ sendWarningAlert: vi.fn(() => Promise.resolve()) }));
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  sendWarningAlert: h.sendWarningAlert,
+}));
+
+import { FraudDetectorService } from "../../src/services/fraud-detector.js";
+
+function bytes(zero: boolean, marker = 1): { toBytes: () => Uint8Array } {
+  const a = new Uint8Array(32);
+  if (!zero) a[0] = marker;
+  return { toBytes: () => a };
+}
+
+interface MarketOpts { feedZero: boolean; authZero: boolean; engineMark: bigint; configMark: bigint; }
+function makeState(o: MarketOpts) {
+  return {
+    market: {
+      config: {
+        indexFeedId: bytes(o.feedZero),
+        oracleAuthority: bytes(o.authZero, 9),
+        collateralMint: { toBase58: () => "Mint1111111111111111111111111111111111" },
+        // SDK surfaces program hyperp_mark_e6 (offset 176) as authorityPriceE6.
+        authorityPriceE6: o.configMark,
+      },
+      engine: { markPriceE6: o.engineMark },
+    },
+    mainnetCA: undefined,
+  };
+}
+
+const SLAB = "Slab11111111111111111111111111111111111111";
+
+describe("PoC: fraud detector mark field + HYPERP detection", () => {
+  let oracle: { fetchPrice: ReturnType<typeof vi.fn> };
+  beforeEach(() => {
+    vi.clearAllMocks();
+    oracle = { fetchPrice: vi.fn() };
+  });
+
+  function svcFor(state: ReturnType<typeof makeState>): FraudDetectorService {
+    const markets = new Map<string, any>([[SLAB, state]]);
+    return new FraudDetectorService(oracle as any, () => markets);
+  }
+
+  it("INS-4: uses the on-chain config mark, not engine.markPriceE6 (which is 0n on v12.17+)", async () => {
+    // engine.markPriceE6 == 0n (current layout); the real mark is in config.authorityPriceE6.
+    const svc = svcFor(makeState({ feedZero: true, authZero: true, engineMark: 0n, configMark: 100_000_000n }));
+    oracle.fetchPrice.mockResolvedValue({ priceE6: 50_000_000n }); // 100% divergence vs the config mark
+    await svc._runCheck();
+    expect(h.sendWarningAlert).toHaveBeenCalled(); // FAILS unfixed: reads 0n → skipped
+  });
+
+  it("INS-5: checks a HYPERP market that carries a non-zero oracle authority", async () => {
+    const svc = svcFor(makeState({ feedZero: true, authZero: false, engineMark: 100_000_000n, configMark: 100_000_000n }));
+    oracle.fetchPrice.mockResolvedValue({ priceE6: 50_000_000n });
+    await svc._runCheck();
+    expect(h.sendWarningAlert).toHaveBeenCalled(); // FAILS unfixed: isZeroAuthority false → skipped
+  });
+
+  it("does not alert when the on-chain mark agrees with off-chain consensus", async () => {
+    const svc = svcFor(makeState({ feedZero: true, authZero: true, engineMark: 0n, configMark: 50_000_000n }));
+    oracle.fetchPrice.mockResolvedValue({ priceE6: 50_000_000n }); // 0 divergence
+    await svc._runCheck();
+    expect(h.sendWarningAlert).not.toHaveBeenCalled();
+  });
+});

--- a/tests/services/fraud-detector.test.ts
+++ b/tests/services/fraud-detector.test.ts
@@ -61,10 +61,14 @@ function makeHyperpState(opts: {
         collateralMint: new PublicKey(mint),
         indexFeedId: opts.nonZeroFeed ? NONZERO : ZERO,
         oracleAuthority: opts.nonZeroAuthority ? NONZERO : ZERO,
+        // The on-chain HYPERP mark (program hyperp_mark_e6) is surfaced by the SDK
+        // as config.authorityPriceE6 — this is what the fraud detector reads.
+        authorityPriceE6: opts.markPriceE6 ?? 1_000_000n, // default $1.00 in E6
         dexPool: null,
       } as never,
       engine: {
-        markPriceE6: opts.markPriceE6 ?? 1_000_000n, // default $1.00 in E6
+        // v12.17+ dropped the engine mark field; parseEngine returns 0n.
+        markPriceE6: 0n,
       } as never,
       params: {} as never,
     },
@@ -315,7 +319,9 @@ describe("FraudDetectorService", () => {
 
   // ── non-HYPERP markets are skipped ──────────────────────────────────────
 
-  it("skips non-HYPERP market where oracleAuthority is non-zero", async () => {
+  it("STILL checks a HYPERP market that carries a non-zero oracle authority (program: hyperp iff index_feed_id==0)", async () => {
+    // Post-Phase-G a bootstrapped HYPERP market carries a non-zero hyperp_authority;
+    // it must still be cross-validated, so the detector must NOT skip it.
     const state = makeHyperpState({ nonZeroAuthority: true });
     const markets = new Map([["slab1", state]]);
     const oracle = makeMockOracle({ priceE6: 1_000_000n, source: "dexscreener", timestamp: Date.now() });
@@ -323,8 +329,7 @@ describe("FraudDetectorService", () => {
     const svc = new FraudDetectorService(oracle, () => markets);
     await svc._runCheck();
 
-    expect(oracle.fetchPrice).not.toHaveBeenCalled();
-    expect(mockFraudAlertTotal.inc).not.toHaveBeenCalled();
+    expect(oracle.fetchPrice).toHaveBeenCalled();
   });
 
   it("skips non-HYPERP market where indexFeedId is non-zero", async () => {
@@ -340,7 +345,7 @@ describe("FraudDetectorService", () => {
 
   // ── on-chain mark price is zero: skip market ─────────────────────────────
 
-  it("skips market when engine.markPriceE6 is zero", async () => {
+  it("skips market when the on-chain mark (config.authorityPriceE6) is zero", async () => {
     const state = makeHyperpState({ markPriceE6: 0n });
     const markets = new Map([["slab1", state]]);
     const oracle = makeMockOracle({ priceE6: 1_000_000n, source: "dexscreener", timestamp: Date.now() });


### PR DESCRIPTION
## Summary

Fixes #157. Makes the `FraudDetectorService` actually functional on the current program by reading the real on-chain HYPERP mark and matching the program's HYPERP definition.

## Root cause

1. The detector read `engine.markPriceE6`, but v12.17 dropped that engine field — `parseEngine` returns `0n`, so the `=== 0n` skip fired on every market and nothing was ever compared. The live mark is `MarketConfig.hyperp_mark_e6`, surfaced by the SDK as `config.authorityPriceE6` (config offset 176).
2. HYPERP detection required `index_feed_id == 0` **and** `oracle_authority == 0`, but `oracle::is_hyperp_mode` keys only off `index_feed_id == [0;32]`. A bootstrapped HYPERP market (non-zero `hyperp_authority`) was silently skipped.

## Changes

- **`src/services/fraud-detector.ts`** — read `config.authorityPriceE6` (= `hyperp_mark_e6`) instead of `engine.markPriceE6`; HYPERP detection is now `index_feed_id == [0;32]` only (dropped the `oracle_authority == 0` clause). Comments updated.
- **tests** — new `fraud-detector-mark.poc.test.ts` (fails on the pre-fix code: no alert for a diverging market / a non-zero-authority HYPERP market; passes after). Updated the existing suite's market helper to populate `config.authorityPriceE6`, and flipped the "non-zero authority" case to assert the market is still cross-validated.

## Verification

- `tsc --noEmit`: clean.
- Fraud-detector suites: 29 passed.
- Full keeper test suite: **615 passed**, 0 failed.

## Notes

- The service is observational (no chain side effects), so there is no fund risk — but the price-manipulation early-warning it exists to provide was absent and is now restored. `hyperp_mark_e6` (the pushed DEX mark) is the most direct comparand the SDK exposes; `mark_ewma_e6` (the EMA the engine uses) is not currently surfaced by the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fraud detection mechanism to use the proper on-chain mark price source
  * Simplified market type detection by removing unnecessary validation conditions
  * Improved divergence detection accuracy for fraud alert evaluation

* **Tests**
  * Added comprehensive test suite covering fraud detection scenarios
  * Included validation for previously incorrect detection behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->