### PR TITLE
fix(adl): M3 — wire MonitorService.notifyAdlTx into ADL success path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -224,6 +224,16 @@ crankService.setStalePauseCheck(isMarketStalePaused);
 // 6.2: Wire crank cycle counter into MonitorService so it can track ADL staleness
 crankService.setOnCrankCycle(() => monitorService.notifyCrankCycle());
 
+// M3: wire ADL success notifications into MonitorService. MonitorService
+// already exposes notifyAdlTx() (used by the invariant gauges) but the ADL
+// service never invoked it pre-fix. Without this hook the per-market
+// `cycleCountAtLastAdl` field stays at 0 even when ADL fires, breaking the
+// "ADL stale" invariant downstream (it computes staleness as cycles-since-
+// last-ADL, which would diverge from reality forever).
+if (adlService) {
+  adlService.setOnAdlTx((slabAddress) => monitorService.notifyAdlTx(slabAddress));
+}
+
 // A4: deleted the per-market setInterval loop that used to live here. It was
 // unreachable: crankService.getMarkets() is called at module load time, before
 // discover() has populated the map, so the forEach iterated an empty Map and

--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -297,10 +297,28 @@ export class AdlService {
   // Cache keypair at construction — avoids re-parsing from env on every scanMarket() call
   private readonly _keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
   private _cycleStartedAt = 0;
+  // M3: optional callback fired after each successful ExecuteAdl tx so the
+  // MonitorService can update its invariant gauges (cycleCountAtLastAdl,
+  // adlTxCounts). Mirrors CrankService.setOnCrankCycle's hook pattern.
+  // Until this is wired, MonitorService.notifyAdlTx() — exposed but never
+  // invoked — leaves ADL activity invisible on invariant dashboards.
+  private _onAdlTx?: (slabAddress: string) => void;
 
   /** Inject the crank service's market map so ADL can iterate tracked markets. */
   setMarketSource(fn: () => Map<string, MarketCrankState>): void {
     this._getMarkets = fn;
+  }
+
+  /**
+   * M3: register a callback fired by scanMarket() after each successful
+   * ExecuteAdl tx. Wired from index.ts to MonitorService.notifyAdlTx so
+   * the invariant layer can record ADL activity per market.
+   *
+   * Safe to call multiple times — the most recent callback wins. No-op if
+   * the callback throws (logged at warn).
+   */
+  setOnAdlTx(fn: (slabAddress: string) => void): void {
+    this._onAdlTx = fn;
   }
 
   get isRunning(): boolean {
@@ -511,6 +529,21 @@ export class AdlService {
           pnlPct: (Number(pos.pnlPct) / 1_000_000).toFixed(4) + "%",
           sig,
         });
+
+        // M3: notify the MonitorService (or any other observer) that an
+        // ExecuteAdl tx landed for this market. Pre-fix, this hook was
+        // exposed on MonitorService.notifyAdlTx() but never called — ADL
+        // success was invisible to the invariant layer's per-market gauges.
+        if (this._onAdlTx) {
+          try {
+            this._onAdlTx(slabAddress);
+          } catch (err) {
+            logger.warn("ADL onAdlTx callback threw", {
+              slabAddress,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
 
         sent++;
         // Optimistic: reduce remaining excess by the position's PnL.

--- a/tests/poc/m3.poc.test.ts
+++ b/tests/poc/m3.poc.test.ts
@@ -1,0 +1,105 @@
+/**
+ * M3 PoC — MonitorService.notifyAdlTx() exposed but never invoked by the
+ * ADL success path. Dead wiring in the observability layer.
+ *
+ * THE BUG (pre-fix):
+ *   src/services/monitor.ts:105-110 defines notifyAdlTx(slabAddress) which
+ *   updates _adlTxCounts and the per-market cycleCountAtLastAdl invariant
+ *   gauge. CrankService wires its analogous notifyCrankCycle via
+ *   setOnCrankCycle (index.ts:225). But AdlService has NO equivalent
+ *   notification hook, and adl.ts:508-553 (the success path) only logs
+ *   "ADL tx sent" without invoking the monitor.
+ *
+ *   Consequence: the per-market cycleCountAtLastAdl gauge stays at 0
+ *   forever, even when ADL fires. Downstream "ADL stale" invariants (which
+ *   compute staleness as cycles-since-last-ADL) report perpetual staleness,
+ *   masking real degradation.
+ *
+ * THE FIX (this PR):
+ *   - Add setOnAdlTx(fn) to AdlService (mirrors setOnCrankCycle pattern).
+ *   - Invoke _onAdlTx(slabAddress) in the success path after each
+ *     successful ExecuteAdl tx.
+ *   - Wire from index.ts: adlService.setOnAdlTx(slab =>
+ *     monitorService.notifyAdlTx(slab)).
+ *
+ * This PoC demonstrates the dead-wiring pattern at the observer-shape level.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+// Mini reproduction of the relevant shapes.
+class FakeMonitor {
+  adlTxCounts = new Map<string, number>();
+  notifyAdlTx(slabAddress: string): void {
+    this.adlTxCounts.set(slabAddress, (this.adlTxCounts.get(slabAddress) ?? 0) + 1);
+  }
+}
+
+// OLD pattern: ADL service has no observer hook. The monitor's notifyAdlTx
+// is never called even though ExecuteAdl succeeds.
+async function oldAdlCycle(monitor: FakeMonitor, slabAddress: string): Promise<{ sent: number }> {
+  let sent = 0;
+  // ...build ix, send tx, log "ADL tx sent"...
+  // (NO call to monitor.notifyAdlTx — that's the bug)
+  sent++;
+  return { sent };
+}
+
+// NEW pattern: ADL service exposes setOnAdlTx and invokes it in the success path.
+class NewAdlService {
+  private _onAdlTx?: (slab: string) => void;
+  setOnAdlTx(fn: (slab: string) => void): void { this._onAdlTx = fn; }
+  async cycle(slabAddress: string): Promise<{ sent: number }> {
+    let sent = 0;
+    // ...send tx...
+    if (this._onAdlTx) {
+      try { this._onAdlTx(slabAddress); } catch { /* swallow */ }
+    }
+    sent++;
+    return { sent };
+  }
+}
+
+describe("M3 PoC — wire MonitorService.notifyAdlTx into ADL success path", () => {
+  it("OLD pattern: monitor's notifyAdlTx is NEVER invoked even after a successful ADL tx", async () => {
+    const monitor = new FakeMonitor();
+    const spy = vi.spyOn(monitor, "notifyAdlTx");
+
+    await oldAdlCycle(monitor, "MARKET-A");
+    await oldAdlCycle(monitor, "MARKET-A");
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(monitor.adlTxCounts.get("MARKET-A")).toBeUndefined();
+    // ↑ cycleCountAtLastAdl invariant gauge stays at 0 forever.
+  });
+
+  it("NEW pattern: monitor.notifyAdlTx is invoked exactly once per successful ADL tx", async () => {
+    const monitor = new FakeMonitor();
+    const adl = new NewAdlService();
+    adl.setOnAdlTx((slab) => monitor.notifyAdlTx(slab));
+
+    await adl.cycle("MARKET-A");
+    await adl.cycle("MARKET-A");
+    await adl.cycle("MARKET-B");
+
+    expect(monitor.adlTxCounts.get("MARKET-A")).toBe(2);
+    expect(monitor.adlTxCounts.get("MARKET-B")).toBe(1);
+    // ↑ Per-market gauges update; invariant layer sees ADL activity.
+  });
+
+  it("NEW pattern: observer throwing does not abort the ADL cycle (swallow + continue)", async () => {
+    const adl = new NewAdlService();
+    adl.setOnAdlTx(() => { throw new Error("observer crashed"); });
+
+    // Cycle should still complete cleanly.
+    const result = await adl.cycle("MARKET-A");
+    expect(result.sent).toBe(1);
+  });
+
+  it("NEW pattern: no observer registered → cycle works exactly as before (zero subscribers OK)", async () => {
+    const adl = new NewAdlService();
+    // No setOnAdlTx call — _onAdlTx stays undefined.
+
+    const result = await adl.cycle("MARKET-A");
+    expect(result.sent).toBe(1);
+  });
+});

--- a/tests/services/adl.test.ts
+++ b/tests/services/adl.test.ts
@@ -199,6 +199,59 @@ describe("AdlService", () => {
       expect(shared.sendWithRetryKeeper).toHaveBeenCalledTimes(1);
     });
 
+    // M3: success-path observer is invoked exactly once per successful ADL tx,
+    // with the slab address as the argument. Until this hook was wired, the
+    // MonitorService.notifyAdlTx() method existed but was never called →
+    // per-market `cycleCountAtLastAdl` invariant gauge stayed at 0 forever.
+    it("M3: invokes setOnAdlTx callback with slabAddress after each successful ADL tx", async () => {
+      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+        makeAccounts([
+          { idx: 3, pnl: 600_000n, capital: 1_000_000n, positionSize: 100n },
+        ]) as any
+      );
+
+      const onAdlTx = vi.fn();
+      service.setOnAdlTx(onAdlTx);
+
+      await service.scanMarket(slabAddress, makeMarket() as any);
+
+      expect(onAdlTx).toHaveBeenCalledTimes(1);
+      expect(onAdlTx).toHaveBeenCalledWith(slabAddress);
+    });
+
+    it("M3: does NOT invoke setOnAdlTx callback when the send fails", async () => {
+      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+        makeAccounts([
+          { idx: 3, pnl: 600_000n, capital: 1_000_000n, positionSize: 100n },
+        ]) as any
+      );
+      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValueOnce(new Error("send failed"));
+
+      const onAdlTx = vi.fn();
+      service.setOnAdlTx(onAdlTx);
+
+      await service.scanMarket(slabAddress, makeMarket() as any);
+
+      expect(onAdlTx).not.toHaveBeenCalled();
+    });
+
+    it("M3: callback throwing does NOT abort the ADL cycle (errors swallowed as warn)", async () => {
+      vi.mocked(sdk.parseAllAccounts).mockReturnValue(
+        makeAccounts([
+          { idx: 3, pnl: 600_000n, capital: 1_000_000n, positionSize: 100n },
+          { idx: 5, pnl: 500_000n, capital: 1_000_000n, positionSize: 100n },
+        ]) as any
+      );
+
+      service.setOnAdlTx(() => {
+        throw new Error("observer threw");
+      });
+
+      const result = await service.scanMarket(slabAddress, makeMarket() as any);
+      // Both ADL targets should still get processed despite the callback throwing.
+      expect(result).toBeGreaterThanOrEqual(1);
+    });
+
     it("targets the highest PnL% position first (not highest abs PnL)", async () => {
       vi.mocked(sdk.parseAllAccounts).mockReturnValue(
         makeAccounts([


### PR DESCRIPTION
## Summary

Fixes **M3** from the internal pre-mainnet audit. Wires the dead observability hook between `AdlService` and `MonitorService.notifyAdlTx()`, mirroring the existing `CrankService.setOnCrankCycle` pattern.

## Root cause

`src/services/monitor.ts:105-110` defines:

```ts
/** Called by AdlService after each successful ExecuteAdl tx for a market. */
notifyAdlTx(slabAddress: string): void {
  const prev = this._adlTxCounts.get(slabAddress) ?? 0;
  this._adlTxCounts.set(slabAddress, prev + 1);
  const mState = this._getOrCreatePerMarket(slabAddress);
  mState.cycleCountAtLastAdl = this._totalCrankCycles;
}
```

The docstring says "Called by AdlService after each successful ExecuteAdl tx" — but **no call site exists**. `src/services/adl.ts:508` only logs `"ADL tx sent"` and moves on. Result:

- `cycleCountAtLastAdl` stays at `0` for every market forever, even when ADL fires successfully.
- Downstream "ADL stale" invariants (which compute staleness as cycles-since-last-ADL) report perpetual staleness, **masking real degradation behind constant false-positive noise**.

`CrankService` already follows the right pattern: a `setOnCrankCycle(fn)` hook on the service, wired from `index.ts:225` to `monitorService.notifyCrankCycle()`. This PR brings `AdlService` in line.

## Fix

```ts
// src/services/adl.ts
private _onAdlTx?: (slabAddress: string) => void;

setOnAdlTx(fn: (slabAddress: string) => void): void {
  this._onAdlTx = fn;
}

// inside the ExecuteAdl success path, right after logger.info("ADL tx sent", ...):
if (this._onAdlTx) {
  try {
    this._onAdlTx(slabAddress);
  } catch (err) {
    logger.warn("ADL onAdlTx callback threw", { slabAddress, error: ... });
  }
}
```

```ts
// src/index.ts (right after the crank-cycle wiring):
if (adlService) {
  adlService.setOnAdlTx((slabAddress) => monitorService.notifyAdlTx(slabAddress));
}
```

Defensive: the callback's exceptions are swallowed as warn so one observer's bug can't abort the ADL cycle.

## Files touched

- `src/services/adl.ts` — add `_onAdlTx` field, `setOnAdlTx()` method, invoke callback in success path.
- `src/index.ts` — wire `setOnAdlTx → monitorService.notifyAdlTx` inside the `adlService` null-check.
- `tests/services/adl.test.ts` — 3 new tests.
- `tests/poc/m3.poc.test.ts` — 4 PoC tests demonstrating OLD vs NEW patterns.

## Test plan

- [x] **`M3: invokes setOnAdlTx callback with slabAddress after each successful ADL tx`** — proves the wiring fires.
- [x] **`M3: does NOT invoke setOnAdlTx callback when the send fails`** — callback only fires on the success path.
- [x] **`M3: callback throwing does NOT abort the ADL cycle`** — defensive swallow.
- [x] **PoC**: OLD pattern — monitor's `notifyAdlTx` never invoked even after successful tx.
- [x] **PoC**: NEW pattern — monitor's `notifyAdlTx` invoked exactly once per successful tx.
- [x] **PoC**: NEW pattern — observer throwing does not abort the cycle.
- [x] **PoC**: NEW pattern — no observer registered is a clean no-op.
- [x] adl suite: **20 passed** (was 17 — +3 M3).
- [x] Full vitest suite: **619 passed / 26 skipped** — no regressions.
- [x] `pnpm build` clean.

## Severity

**LOW** — operational observability gap. No security or fund-loss path.

## Related

- **H6/M11** (#139) closed a sibling dead-wiring gap in the same audit cluster (`CL-SHADOW-OBS`).
- Together they leave the observability layer fully wired to its producers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
