### PR TITLE
fix(keeper): per-cycle budget window self-resets so the keeper can't permanently halt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { LeaderLock, makeIdentity } from "./lib/leader.js";
 import { captureAndExit } from "./lib/exit-handlers.js";
 import { StartupTracker } from "./lib/startup-tracker.js";
 import { sharedTxQueue, DRAIN_TIMEOUT_MS } from "./lib/tx-queue.js";
+import { sharedBudget } from "./lib/keeper-send.js";
 import { initSharedShadowHarness, sharedShadowHarness } from "./lib/shadow-harness.js";
 import { sharedDecisionLog } from "./lib/decision-log.js";
 
@@ -428,6 +429,56 @@ res.writeHead(401, secureJsonHeaders);
     return;
   }
 
+  // POST /admin/budget/resume — clear a latched budget circuit-breaker halt
+  // without a full restart. Auth mirrors /register: x-shared-secret header
+  // matching KEEPER_REGISTER_SECRET, constant-time compare, per-IP rate limit.
+  if (req.url === "/admin/budget/resume" && req.method === "POST") {
+    const registerSecret = process.env.KEEPER_REGISTER_SECRET ?? "";
+    if (!registerSecret) {
+      req.resume();
+      res.writeHead(503, secureJsonHeaders);
+      res.end(JSON.stringify({ success: false, message: "Endpoint not configured" }));
+      return;
+    }
+
+    const clientIp = String(req.socket.remoteAddress ?? "unknown");
+    if (isRateLimited(clientIp)) {
+      logger.warn("Budget resume rate limited", { ip: clientIp });
+      req.resume();
+      res.writeHead(429, secureJsonHeaders);
+      res.end(JSON.stringify({ success: false, message: "Too many requests" }));
+      return;
+    }
+
+    const provided = String(req.headers["x-shared-secret"] ?? "");
+    const secretBuf = Buffer.from(registerSecret, "utf8");
+    const providedBuf = Buffer.from(provided, "utf8");
+    const maxLen = Math.max(secretBuf.length, providedBuf.length, 1);
+    const secretPad = Buffer.alloc(maxLen);
+    const providedPad = Buffer.alloc(maxLen);
+    secretBuf.copy(secretPad);
+    providedBuf.copy(providedPad);
+    const lengthMatch = secretBuf.length === providedBuf.length;
+    const contentMatch = timingSafeEqual(secretPad, providedPad);
+    if (!lengthMatch || !contentMatch) {
+      recordAuthFailure(clientIp);
+      req.resume();
+      res.writeHead(401, secureJsonHeaders);
+      res.end(JSON.stringify({ success: false, message: "Unauthorized" }));
+      return;
+    }
+
+    req.resume(); // drain the request body — we don't need it
+    const operator = String(req.headers["x-operator"] ?? `http:${clientIp}`);
+    const wasHalted = sharedBudget.isHalted();
+    const previousHaltKind = sharedBudget.haltKind ?? null;
+    sharedBudget.resume(operator);
+    logger.warn("Budget resume requested via endpoint", { operator, wasHalted, previousHaltKind });
+    res.writeHead(200, secureJsonHeaders);
+    res.end(JSON.stringify({ success: true, wasHalted, previousHaltKind, stats: sharedBudget.getStats() }));
+    return;
+  }
+
   if (req.url === "/health" && req.method === "GET") {
     // A5: hard 503 until start() resolved. Railway otherwise marks the
     // container healthy as soon as healthServer.listen() returns — long
@@ -544,6 +595,20 @@ res.writeHead(401, secureJsonHeaders);
       invariants: monitorService.getStatus(),
       // Task 1.8: Sender land-rate + tip-spend metrics for Phase 1 rollout observability
       senderMetrics: snapshotSenderMetrics(),
+      // Budget circuit-breaker state — surfaced so a latched halt is visible on
+      // dashboards without scraping /metrics. Recover via POST /admin/budget/resume.
+      budget: (() => {
+        const s = sharedBudget.getStats();
+        return {
+          halted: s.halted,
+          haltKind: s.haltKind ?? null,
+          cycleSpend: s.cycleSpend,
+          cycleTxCount: s.cycleTxCount,
+          hourSpend: s.hourSpend,
+          daySpend: s.daySpend,
+          txSuccessRate: s.txSuccessRate,
+        };
+      })(),
     };
     
     const currentRole = leaderLock ? leaderLock.role() : "leader";

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -32,6 +32,15 @@ export interface KeeperBudgetConfig {
   maxSolPerDay: number;
   /** Cap on tx attempts per cycle (default 60). */
   maxTxPerCycle: number;
+  /**
+   * Length of the per-cycle window in ms (default 30_000, matching the default
+   * crank interval). The per-cycle caps (maxSolPerCycle / maxTxPerCycle) are a
+   * burst limiter scoped to this rolling window: the counters reset
+   * automatically once the window elapses, so no external beginCycle() caller
+   * is required. Operators running many markets or a longer crank interval
+   * should size maxTxPerCycle / cycleWindowMs to their peak sends-per-window.
+   */
+  cycleWindowMs: number;
   /** Window length in ms over which success rate is computed (default 60_000). */
   txSuccessRateWindow: number;
   /** Floor for success rate within the window (default 0.70). */
@@ -65,6 +74,9 @@ export interface KeeperBudgetDeps {
   now?: () => number;
   env?: NodeJS.ProcessEnv;
   onHalt?: (kind: HaltKind, reason: string) => void;
+  /** Fired when a latched halt is cleared (resume()). Lets callers reset a
+   *  halted gauge without coupling this class to the metrics layer. */
+  onResume?: () => void;
 }
 
 interface SpendEvent {
@@ -82,6 +94,7 @@ const DEFAULTS: KeeperBudgetConfig = {
   maxSolPerHour: 500_000_000,
   maxSolPerDay: 3_000_000_000,
   maxTxPerCycle: 60,
+  cycleWindowMs: 30_000,
   txSuccessRateWindow: 60_000,
   txSuccessRateThreshold: 0.7,
   txSuccessRateMinSamples: 10,
@@ -95,6 +108,7 @@ const INT_ENV_KEYS: Array<[keyof KeeperBudgetConfig, string]> = [
   ["maxSolPerHour", "KEEPER_MAX_SOL_PER_HOUR"],
   ["maxSolPerDay", "KEEPER_MAX_SOL_PER_DAY"],
   ["maxTxPerCycle", "KEEPER_MAX_TX_PER_CYCLE"],
+  ["cycleWindowMs", "KEEPER_CYCLE_WINDOW_MS"],
   ["txSuccessRateWindow", "KEEPER_TX_SUCCESS_RATE_WINDOW_MS"],
   ["txSuccessRateMinSamples", "KEEPER_TX_SUCCESS_RATE_MIN_SAMPLES"],
 ];
@@ -123,9 +137,14 @@ export class KeeperBudget {
   readonly config: KeeperBudgetConfig;
   private readonly _now: () => number;
   private readonly _onHalt: ((kind: HaltKind, reason: string) => void) | undefined;
+  private readonly _onResume: (() => void) | undefined;
 
   private _cycleSpend = 0;
   private _cycleTxCount = 0;
+  /** Wall-clock anchor for the current per-cycle window. 0 = not yet anchored
+   *  (anchored lazily on first send-path call so the window starts at first
+   *  use, not at construction time). */
+  private _cycleStartMs = 0;
   private readonly _hourEvents: SpendEvent[] = [];
   private _hourSpendSum = 0;
   private readonly _dayEvents: SpendEvent[] = [];
@@ -143,6 +162,7 @@ export class KeeperBudget {
     this.config = { ...DEFAULTS, ...envOverrides, ...config };
     this._now = deps.now ?? (() => Date.now());
     this._onHalt = deps.onHalt;
+    this._onResume = deps.onResume;
   }
 
   /**
@@ -157,6 +177,7 @@ export class KeeperBudget {
     if (this._isHalted) return false;
 
     const nowMs = this._now();
+    this._rollCycleIfElapsed(nowMs);
     this._pruneOld(nowMs);
 
     if (this._cycleSpend + lamports > this.config.maxSolPerCycle) {
@@ -212,6 +233,8 @@ export class KeeperBudget {
   recordTx(lamports: number, txType: string, result: TxResult): void {
     if (lamports < 0 || !Number.isFinite(lamports)) return;
     const nowMs = this._now();
+    // Roll before counting so this tx lands in the current window.
+    this._rollCycleIfElapsed(nowMs);
     this._cycleTxCount++;
 
     if (result !== "drop") {
@@ -241,16 +264,22 @@ export class KeeperBudget {
   }
 
   /**
-   * Reset per-cycle counters at the top of a new cycle. Does NOT clear halt
+   * Manually reset per-cycle counters and re-anchor the per-cycle window.
+   * No longer required for correctness — the per-cycle window now resets
+   * itself on a timer (see _rollCycleIfElapsed) so the caps work without any
+   * caller. Retained for explicit manual cordoning/tests. Does NOT clear halt
    * state — that requires resume().
    */
   beginCycle(): void {
     this._cycleSpend = 0;
     this._cycleTxCount = 0;
+    this._cycleStartMs = this._now();
   }
 
   getStats(): BudgetStats {
-    this._pruneOld(this._now());
+    const nowMs = this._now();
+    this._rollCycleIfElapsed(nowMs);
+    this._pruneOld(nowMs);
     return {
       cycleSpend: this._cycleSpend,
       hourSpend: this._hourSpendSum,
@@ -292,6 +321,13 @@ export class KeeperBudget {
     this._isHalted = false;
     this._haltKind = undefined;
     this._haltReason = undefined;
+    try {
+      this._onResume?.();
+    } catch (err) {
+      logger.warn("onResume hook threw — ignoring", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**
@@ -317,6 +353,36 @@ export class KeeperBudget {
       logger.warn("onHalt hook threw — ignoring", {
         error: err instanceof Error ? err.message : String(err),
       });
+    }
+  }
+
+  /**
+   * Reset the per-cycle counters when the cycle window has elapsed. This is the
+   * reset that beginCycle() was supposed to provide but that no production
+   * caller ever invoked, which made the per-cycle caps accumulate over the whole
+   * process lifetime and permanently self-halt the keeper.
+   *
+   * Time-driven on purpose: the budget is a single shared singleton hit by the
+   * crank, liquidation, and ADL services on independent timers. If each service
+   * reset the counters at the top of its own loop they would stomp one another
+   * (multi-owner race). Anchoring the reset to wall-clock time means no service
+   * owns it — any send-path call crossing the window boundary rolls it
+   * identically, race-free under Node's single-threaded event loop.
+   *
+   * It deliberately does NOT clear a latched halt: a breach within a single
+   * window is a genuine burst anomaly that must stay halted until an operator
+   * resume()s (see resume() / the /admin/budget/resume endpoint). Only the
+   * lifetime-accumulation that caused the self-halt is removed.
+   */
+  private _rollCycleIfElapsed(nowMs: number): void {
+    if (this._cycleStartMs === 0) {
+      this._cycleStartMs = nowMs;
+      return;
+    }
+    if (nowMs - this._cycleStartMs >= this.config.cycleWindowMs) {
+      this._cycleSpend = 0;
+      this._cycleTxCount = 0;
+      this._cycleStartMs = nowMs;
     }
   }
 

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
 import type { Connection, TransactionInstruction, Keypair } from "@solana/web3.js";
-import { sendWithRetryKeeper, createLogger } from "@percolatorct/shared";
+import { sendWithRetryKeeper, createLogger, sendCriticalAlert } from "@percolatorct/shared";
 import type { KeeperSendOptions } from "@percolatorct/shared";
 import { KeeperBudget } from "./budget.js";
+import { budgetHalted } from "./metrics.js";
 import type { TxType, TxResult } from "./budget.js";
 import { HeliusPriorityFeeEstimator } from "./priority-fee.js";
 import type { PriorityFeeEstimator, PriorityFeeTier } from "./priority-fee.js";
@@ -50,7 +51,39 @@ function getCuEstimator(): CuEstimator {
   return _cuEstimator;
 }
 
-export const sharedBudget = new KeeperBudget();
+/**
+ * Process-wide budget circuit breaker. Wired with observability so a halt is
+ * never silent: onHalt sets the keeper_budget_halted gauge and pages on-call;
+ * onResume clears the gauge. Recovery from a latched halt is via the
+ * authenticated POST /admin/budget/resume endpoint (see index.ts).
+ */
+export const sharedBudget = new KeeperBudget(
+  {},
+  {
+    onHalt: (kind, reason) => {
+      budgetHalted.set(1);
+      logger.error("KeeperBudget circuit-breaker halted — refusing all sends until resume", {
+        kind,
+        reason,
+      });
+      // Page on-call. The budget wraps this hook in try/catch, so an alerting
+      // failure can never break the send path. Promise.resolve guards against
+      // a non-thenable return.
+      Promise.resolve(
+        sendCriticalAlert("Keeper budget circuit-breaker tripped — sends halted", [
+          { name: "Kind", value: kind, inline: true },
+          { name: "Reason", value: reason.slice(0, 200), inline: false },
+          {
+            name: "Recovery",
+            value: "Investigate the cause, then POST /admin/budget/resume (x-shared-secret).",
+            inline: false,
+          },
+        ]),
+      ).catch(() => {});
+    },
+    onResume: () => budgetHalted.set(0),
+  },
+);
 
 function isMainnetSender(): boolean {
   return (

--- a/tests/lib/budget-cycle-reset.test.ts
+++ b/tests/lib/budget-cycle-reset.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression test for the CRITICAL budget self-halt.
+ *
+ * KeeperBudget caps maxTxPerCycle (default 60) and maxSolPerCycle (default
+ * 0.05 SOL) per cycle. Those counters used to be reset only by beginCycle(),
+ * which had NO production caller — so recordTx() accumulated them for the whole
+ * process lifetime and canSpend() permanently latched a halt after ~60
+ * cumulative sends, after which keeperSend() returned null for EVERY send
+ * (cranks, liquidations, HYPERP marks, ADL), silently and unrecoverably.
+ *
+ * The fix makes the per-cycle window reset itself on a timer (cycleWindowMs),
+ * so no caller is required. These tests drive the REAL keeperSend + KeeperBudget
+ * with an injected clock and assert:
+ *   1. under sustained, realistically-spaced load the keeper never self-halts;
+ *   2. a genuine within-window burst still trips the cap (the brake survives)
+ *      and is recoverable via resume().
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  sendWithRetryKeeper: vi.fn(async () => "mock-signature"),
+  sendCriticalAlert: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("../../src/lib/priority-fee.js", () => {
+  class HeliusPriorityFeeEstimator { estimate = vi.fn(async () => 1_000); }
+  return { HeliusPriorityFeeEstimator };
+});
+vi.mock("../../src/lib/cu-estimator.js", () => {
+  class CuEstimator { estimate = vi.fn(async () => 200_000); }
+  return { CuEstimator };
+});
+
+import { keeperSend } from "../../src/lib/keeper-send.js";
+import { KeeperBudget } from "../../src/lib/budget.js";
+import { Keypair, TransactionInstruction, PublicKey } from "@solana/web3.js";
+
+function makeClock(start = 1_700_000_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; } };
+}
+function ix(): TransactionInstruction {
+  return new TransactionInstruction({ programId: PublicKey.default, keys: [], data: Buffer.from([]) });
+}
+function conn() {
+  return { simulateTransaction: vi.fn(async () => ({ value: { unitsConsumed: 200_000, err: null, logs: [] } })) } as any;
+}
+
+describe("KeeperBudget cycle-reset regression (drives the real keeperSend)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NETWORK = "devnet";
+    process.env.USE_HELIUS_SENDER = "false";
+    delete process.env.DRY_RUN;
+  });
+
+  it("FIXED: sustained multi-window load never self-halts (no beginCycle() caller)", async () => {
+    // Default caps (maxTxPerCycle = 60, cycleWindowMs = 30s). Drive 50 cycles
+    // of 30 sends each = 1_500 sends — 25x the old 60-send fuse — advancing the
+    // clock one window between cycles, exactly how production spacing looks.
+    const clock = makeClock();
+    const budget = new KeeperBudget({}, { now: clock.now });
+    const kp = Keypair.generate();
+    const c = conn();
+    let refused = 0;
+    for (let cycle = 0; cycle < 50; cycle++) {
+      for (let i = 0; i < 30; i++) {
+        if ((await keeperSend(c, [ix()], [kp], "crank", budget)) === null) refused++;
+      }
+      clock.advance(30_000); // next cycle window
+    }
+    expect(budget.isHalted()).toBe(false);
+    expect(refused).toBe(0);
+  });
+
+  it("a genuine burst beyond the per-cycle cap within one window still halts, and resume() recovers", async () => {
+    // No clock advance → all sends fall in one window. The 61st trips the cap.
+    const clock = makeClock();
+    const budget = new KeeperBudget({}, { now: clock.now });
+    const kp = Keypair.generate();
+    const c = conn();
+    let refused = 0;
+    for (let i = 0; i < 80; i++) {
+      if ((await keeperSend(c, [ix()], [kp], "crank", budget)) === null) refused++;
+    }
+    expect(budget.isHalted()).toBe(true);
+    expect(budget.getStats().haltKind).toBe("cycle-tx-count-cap");
+    expect(refused).toBeGreaterThan(0);
+
+    // Recoverable without a restart: resume + a fresh window lets sends through.
+    budget.resume("test-operator");
+    clock.advance(30_000);
+    expect(await keeperSend(c, [ix()], [kp], "crank", budget)).not.toBeNull();
+    expect(budget.isHalted()).toBe(false);
+  });
+});

--- a/tests/lib/budget.test.ts
+++ b/tests/lib/budget.test.ts
@@ -32,6 +32,7 @@ describe("KeeperBudget — defaults", () => {
     expect(stats.config.maxSolPerHour).toBe(500_000_000);
     expect(stats.config.maxSolPerDay).toBe(3_000_000_000);
     expect(stats.config.maxTxPerCycle).toBe(60);
+    expect(stats.config.cycleWindowMs).toBe(30_000);
     expect(stats.config.txSuccessRateThreshold).toBe(0.7);
     expect(stats.halted).toBe(false);
   });
@@ -161,6 +162,93 @@ describe("KeeperBudget — cycle tx count cap", () => {
     }
     expect(b.canSpend(1, "crank")).toBe(false);
     expect(b.haltKind).toBe("cycle-tx-count-cap");
+  });
+});
+
+describe("KeeperBudget — per-cycle window auto-reset", () => {
+  // Regression for the CRITICAL self-halt: the per-cycle counters used to be
+  // reset only by beginCycle(), which had no production caller, so they
+  // accumulated for the whole process lifetime and permanently latched a halt.
+  // They now reset on a time window with no caller required.
+
+  it("resets cycle spend + tx count once the window elapses, without beginCycle()", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000 }, { now: clock.now });
+    // Spend 802 of the 1_000 cycle cap across 2 txs — no manual reset.
+    b.recordTx(800, "crank", "success");
+    b.recordTx(2, "crank", "success");
+    expect(b.getStats().cycleSpend).toBe(802);
+    expect(b.getStats().cycleTxCount).toBe(2);
+    // Pre-roll, another 500 would breach (802 + 500 > 1_000).
+    clock.advance(30_000); // window elapses
+    expect(b.canSpend(500, "crank")).toBe(true); // window rolled → counters cleared
+    b.recordTx(500, "crank", "success");
+    const s = b.getStats();
+    expect(s.cycleSpend).toBe(500); // reset to 0, then this tx
+    expect(s.cycleTxCount).toBe(1);
+    expect(b.isHalted()).toBe(false);
+  });
+
+  it("does not reset until the full window has elapsed", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000 }, { now: clock.now });
+    b.recordTx(900, "crank", "success");
+    clock.advance(29_999); // just under the window
+    expect(b.getStats().cycleSpend).toBe(900); // not yet rolled
+    clock.advance(1); // now exactly at the boundary
+    expect(b.getStats().cycleSpend).toBe(0); // rolled
+  });
+
+  it("a genuine within-window burst still trips the cap and latches (brake intact)", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000 }, { now: clock.now });
+    for (let i = 0; i < 5; i++) b.recordTx(1, "crank", "success"); // maxTxPerCycle = 5
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.haltKind).toBe("cycle-tx-count-cap");
+  });
+
+  it("window roll does NOT clear a latched halt — resume() is still required", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000 }, { now: clock.now });
+    for (let i = 0; i < 5; i++) b.recordTx(1, "crank", "success");
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(true);
+    clock.advance(120_000); // several windows elapse
+    expect(b.isHalted()).toBe(true); // a real breach stays halted until a human resumes
+    expect(b.canSpend(1, "crank")).toBe(false);
+    b.resume("op");
+    expect(b.canSpend(1, "crank")).toBe(true);
+  });
+});
+
+describe("KeeperBudget — onResume hook", () => {
+  it("fires when a halt is cleared and lets callers reset a halted gauge", () => {
+    const clock = makeClock();
+    const onResume = vi.fn();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, onResume });
+    b.haltManually("cordon");
+    expect(b.isHalted()).toBe(true);
+    b.resume("op");
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when resume() is a no-op on a non-halted budget", () => {
+    const clock = makeClock();
+    const onResume = vi.fn();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, onResume });
+    b.resume("op");
+    expect(onResume).not.toHaveBeenCalled();
+  });
+
+  it("onResume errors are caught and do not break resume()", () => {
+    const clock = makeClock();
+    const onResume = vi.fn(() => {
+      throw new Error("metric backend down");
+    });
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, onResume });
+    b.haltManually("cordon");
+    expect(() => b.resume("op")).not.toThrow();
+    expect(b.isHalted()).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

`KeeperBudget` is the single circuit breaker every keeper send flows through (crank, liquidation, HYPERP mark, ADL — all via `keeperSend` → `budget.canSpend()`/`budget.recordTx()`). Its per-cycle caps `maxTxPerCycle` (default 60) and `maxSolPerCycle` (default 0.05 SOL) were reset only by `beginCycle()`, and `beginCycle()` had **no production caller**. The per-cycle counters therefore accumulated over the whole process lifetime, so the budget permanently latched a halt after ~60 cumulative sends (or 0.05 SOL of cumulative spend), after which `keeperSend()` returned `null` for **every** send. On a normal deployment this trips within minutes of boot and never recovers — funding cranks stop, undercollateralized accounts are never liquidated, HYPERP marks stop refreshing — while `/health` keeps reporting healthy.

It was also silent and unrecoverable in-process: the shared budget was constructed with no `onHalt`, the `keeper_budget_halted` gauge was never set, and there was no `resume()` path other than a full restart (which reset the counters and repeated the cycle).

## Root cause

- `recordTx()` increments `_cycleTxCount` unconditionally on every send and adds to `_cycleSpend`; the only reset was `beginCycle()`.
- A repo-wide search shows `beginCycle()` was referenced only at its definition and in tests — the crank/liquidation/ADL loops never called it.
- `sharedBudget = new KeeperBudget()` was built with no `onHalt`; `budgetHalted` was never `.set()`; `resume()` had no caller/endpoint.

## Fix

Make the per-cycle window **reset itself on a wall-clock timer** (`cycleWindowMs`, default `30_000` = the default crank interval) inside `KeeperBudget`, rather than relying on an external `beginCycle()` caller.

This is time-driven on purpose. The budget is a single shared singleton hit by three services on independent timers (crank, liquidation, ADL). If each service called `beginCycle()` at the top of its own loop they would stomp one another's counters (a multi-owner race), and the per-cycle cap would stop meaning anything. Anchoring the reset to wall-clock time means **no service owns it** — any send-path call crossing the window boundary rolls it identically, race-free under Node's single-threaded event loop, exactly like the existing rolling hour/day windows.

Key property: the roll **does not clear a latched halt**. Under normal load the counters reset every window well before any cap is hit, so the keeper no longer self-halts. A cap breach can now only happen on a genuine burst within a single window — which is precisely when latching-until-resume is the correct, safe behaviour. The rolling hour/day caps and the success-rate guard are untouched and remain the long-horizon protections; the day cap stays manual-resume-only.

Observability + recovery (so a genuine halt is never silent again):
- the shared budget's `onHalt` now sets `keeper_budget_halted` and fires a critical alert; a new `onResume` hook clears the gauge;
- a new authenticated `POST /admin/budget/resume` endpoint clears a halt without a restart (same shared-secret + constant-time compare + per-IP rate limit as `/register`);
- budget state is surfaced in the `/health` payload.

Operators running many markets or a longer crank interval can size `KEEPER_MAX_TX_PER_CYCLE` / `KEEPER_CYCLE_WINDOW_MS` to their peak sends-per-window.

## Tests

- `tests/lib/budget.test.ts` — new unit tests: the per-cycle window resets when it elapses (no `beginCycle()`), does not reset before the boundary, a genuine within-window burst still trips the cap, the roll does **not** clear a latched halt, and the `onResume` hook fires/clears correctly.
- `tests/lib/budget-cycle-reset.test.ts` — end-to-end regression driving the **real** `keeperSend` + `KeeperBudget` with an injected clock across 50 realistically-spaced cycles (1,500 sends, 25× the old 60-send fuse): asserts the keeper never self-halts, and that a genuine within-window burst still halts and is recoverable via `resume()`.

Full suite: 697 passing, 25 skipped; `tsc --noEmit` clean. All existing budget invariants (including the property test "once halted, stays halted until resume()") remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin endpoint to manually resume halted budget.
  * Health endpoint now includes budget metrics (spend, transaction counts, success rates).
  * Budget cycles now auto-reset on a rolling window instead of requiring manual intervention.

* **Bug Fixes**
  * Prevents budget caps from accumulating across the process lifetime.

* **Tests**
  * Added test coverage for auto-cycling and halt/resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->