### PR TITLE
fix(oracle): stale-pause guard uses the real freshness clock so the keeper keeps cranking

### DIFF
--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -54,7 +54,6 @@ interface JupiterResponse {
 
 export class OracleService {
   private priceHistory = new Map<string, PriceEntry[]>();
-  private lastPushTime = new Map<string, number>();
   private _nonAuthorityLogged = new Set<string>();
   private readonly rateLimitMs = parseInt(process.env.ORACLE_RATE_LIMIT_MS ?? "5000", 10);
   private readonly maxHistory = 100;
@@ -70,13 +69,20 @@ export class OracleService {
     { consecutive: number; alertSent: boolean }
   >();
   private static readonly SINGLE_SOURCE_ALERT_THRESHOLD = 10;
-  // M-4: Track when an external source (DexScreener or Jupiter) last returned a
-  // valid price for each slab. Used to cap the on-chain fallback duration so that
-  // a prolonged external outage causes the oracle to go stale rather than cycling
-  // the same on-chain price forever.
+  // Track when an external source (DexScreener or Jupiter) last returned a valid
+  // price for each slab. This is the single freshness signal read by
+  // getStaleMarkets(): a prolonged external outage (only cached/on-chain fallback
+  // prices, which never advance this clock) causes the market to age into
+  // staleness rather than cranking on a frozen price forever.
   private lastExternalPriceMs = new Map<string, number>();
 
-  constructor() {
+  /** Injectable clock — defaults to Date.now() in production; overridden in
+   *  tests so price freshness / staleness is deterministic without faking the
+   *  global Date around the async fetch path. */
+  private readonly now: () => number;
+
+  constructor(opts?: { now?: () => number }) {
+    this.now = opts?.now ?? (() => Date.now());
     // M5: DexScreener and Jupiter REST APIs return prices with NO publisher
     // signature and NO slot field. Cross-source validation (10% deviation) +
     // min-liquidity filter ($1000) + historical deviation cap (30%) mitigate
@@ -346,10 +352,10 @@ export class OracleService {
       if (history && history.length > 0) {
         const last = history[history.length - 1];
         // Reject stale cached prices (>60s) to prevent bad liquidations
-        if (Date.now() - last.timestamp > CACHED_PRICE_MAX_AGE_MS) {
+        if (this.now() - last.timestamp > CACHED_PRICE_MAX_AGE_MS) {
           logger.warn("Cached price is stale", {
             mint,
-            ageSeconds: Math.round((Date.now() - last.timestamp) / 1000),
+            ageSeconds: Math.round((this.now() - last.timestamp) / 1000),
             maxAgeSeconds: CACHED_PRICE_MAX_AGE_MS / 1000
           });
           return null;
@@ -382,11 +388,12 @@ export class OracleService {
       }
     }
 
-    const entry: PriceEntry = { priceE6, source, timestamp: Date.now() };
+    const entry: PriceEntry = { priceE6, source, timestamp: this.now() };
     this.recordPrice(slabAddress, entry);
     oraclePushCountTotal.inc({ mint, source });
-    // M-4: Record that an external source produced a valid price. This resets the
-    // fallback clock so the on-chain fallback cap counts from the last real fetch.
+    // Single freshness signal for getStaleMarkets(): record that an external
+    // source produced a valid price now. Cached/fallback returns above bail out
+    // before this line, so they never refresh the staleness clock.
     this.lastExternalPriceMs.set(slabAddress, entry.timestamp);
     return entry;
   }
@@ -413,7 +420,12 @@ export class OracleService {
           oldestKey = key;
         }
       }
-      if (oldestKey) this.priceHistory.delete(oldestKey);
+      if (oldestKey) {
+        this.priceHistory.delete(oldestKey);
+        // Keep lastExternalPriceMs lifetime identical to priceHistory so the
+        // freshness map can't leak entries for markets we no longer track.
+        this.lastExternalPriceMs.delete(oldestKey);
+      }
     }
   }
 
@@ -430,27 +442,21 @@ export class OracleService {
   }
 
   /**
-   * Returns slab addresses where the last successful price push
-   * was more than `thresholdMs` ago (or never pushed).
+   * Returns slab addresses whose last successful EXTERNAL price fetch was more
+   * than `thresholdMs` ago (or which have never had one). Freshness is sourced
+   * exclusively from lastExternalPriceMs, set in fetchPrice() on — and only on —
+   * a successful external fetch, so a market surviving on a cached/on-chain
+   * fallback price never advances the clock and correctly ages into staleness.
+   * This is the single source of truth; there is no separate push-time to drift.
    * Only considers markets that have at least one price history entry.
    */
-  /**
-   * Record a successful price push for a market. Called by CrankService when
-   * a price push is bundled into a crank transaction (bypassing pushPrice()).
-   * Without this, getStaleMarkets() would flag bundled-push markets as stale
-   * because lastPushTime is never updated.
-   */
-  recordPushTime(slabAddress: string): void {
-    this.lastPushTime.set(slabAddress, Date.now());
-  }
-
   getStaleMarkets(thresholdMs: number): string[] {
-    const now = Date.now();
+    const now = this.now();
     const stale: string[] = [];
     for (const [slabAddress] of this.priceHistory) {
-      const lastPush = this.lastPushTime.get(slabAddress) ?? 0;
-      const stalenessMs = lastPush === 0 ? Infinity : now - lastPush;
-      if (lastPush === 0 || stalenessMs > thresholdMs) {
+      const lastFresh = this.lastExternalPriceMs.get(slabAddress) ?? 0;
+      const stalenessMs = lastFresh === 0 ? Infinity : now - lastFresh;
+      if (stalenessMs > thresholdMs) {
         stale.push(slabAddress);
       }
       if (isFinite(stalenessMs)) {

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -639,52 +639,6 @@ describe('CrankService', () => {
       expect(state.successCount).toBe(1);
     });
 
-    it.skip('should call recordPushTime after successful bundled price push', async () => {
-      const slabAddress = 'MarketPushTime111111111111111111111111';
-      const KEEPER_KEY = '11111111111111111111111111111111';
-      const KEEPER_AUTH = 'KeeperAuth11111111111111111111111111111';
-
-      vi.mocked(shared.loadKeypair).mockReturnValue({
-        publicKey: {
-          toBase58: () => KEEPER_AUTH,
-          equals: (other: any) => other?.toBase58?.() === KEEPER_AUTH,
-        },
-        secretKey: new Uint8Array(64),
-      } as any);
-
-      const localCrank = new CrankService(mockOracleService);
-
-      const mockMarket = {
-        slabAddress: { toBase58: () => slabAddress },
-        programId: { toBase58: () => KEEPER_KEY },
-        config: {
-          collateralMint: { toBase58: () => 'MintPush1111111111111111111111111111111' },
-          oracleAuthority: {
-            toBase58: () => KEEPER_AUTH,
-            equals: (other: any) => other?.toBase58?.() === KEEPER_AUTH,
-          },
-          indexFeedId: { toBytes: () => new Uint8Array(32) },
-          authorityPriceE6: BigInt(1_000_000),
-        },
-        params: { maintenanceMarginBps: 500n },
-        header: { admin: { toBase58: () => 'AdminPush111111111111111111111111111111' } },
-      };
-
-      vi.mocked(core.discoverMarkets).mockResolvedValue([mockMarket] as any);
-      await localCrank.discover();
-
-      mockOracleService.fetchPrice = vi.fn().mockResolvedValue({ priceE6: BigInt(50_000_000), source: 'dexscreener', timestamp: Date.now() });
-      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'sig-push-time', estimatedCost: 5000 } as any);
-
-      try {
-        const result = await localCrank.crankMarket(slabAddress);
-        expect(result).toBe(true);
-        expect(mockOracleService.recordPushTime).toHaveBeenCalledWith(slabAddress);
-      } finally {
-        localCrank.stop();
-      }
-    });
-
     // Post-Phase-G: the "foreign oracle" skip (admin-push oracle requiring the keeper
     // to be the oracle authority) was removed. A market with a non-zero oracle authority
     // and index_feed_id == 0 is a normal HYPERP market and must be cranked, not skipped.

--- a/tests/services/oracle-stale.test.ts
+++ b/tests/services/oracle-stale.test.ts
@@ -38,95 +38,99 @@ vi.mock('@percolatorct/shared', () => ({
     if (err instanceof Error) return err.message;
     return String(err);
   }),
+  sendWarningAlert: vi.fn(() => Promise.resolve()),
 }));
 
 import { OracleService } from '../../src/services/oracle.js';
 
+/**
+ * Staleness is now measured from the last successful EXTERNAL price fetch
+ * (lastExternalPriceMs), set by fetchPrice(). These tests use an injected clock
+ * so "becomes stale after N minutes" is deterministic, and assert the corrected
+ * behavior: a freshly-fetched market is NOT stale; a market with no fresh fetch
+ * for longer than the threshold IS stale.
+ */
 describe('OracleService.getStaleMarkets', () => {
+  let clock: number;
   let oracle: OracleService;
 
+  // URL-based fetch mock: both sources return $1.00 for any mint. Routing on the
+  // URL (rather than a mockResolvedValueOnce queue) keeps the mock robust against
+  // the module-level DexScreener cache, which can serve a repeated mint without a
+  // fetch call and would otherwise desync an ordered once-queue.
   beforeEach(() => {
     vi.clearAllMocks();
-    oracle = new OracleService();
+    clock = 1_700_000_000_000;
+    oracle = new OracleService({ now: () => clock });
+    vi.mocked(fetch).mockImplementation(async (input: any) => {
+      const url = String(input);
+      if (url.includes('dexscreener')) {
+        return { ok: true, json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }] }) } as any;
+      }
+      const mint = decodeURIComponent(url.split('ids=')[1] ?? '');
+      return { ok: true, json: async () => ({ data: { [mint]: { price: '1.00' } } }) } as any;
+    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
+  /** Seed a fresh, cross-validated external price for `slab` via fetchPrice. */
+  async function seedFreshPrice(mint: string, slab: string) {
+    await oracle.fetchPrice(mint, slab);
+  }
+
   it('should return empty array when no markets are tracked', () => {
-    const stale = oracle.getStaleMarkets(5 * 60 * 1000);
-    expect(stale).toEqual([]);
+    expect(oracle.getStaleMarkets(5 * 60 * 1000)).toEqual([]);
   });
 
-  it('should return markets that have price history but no push', async () => {
-    // Seed price history via fetchPrice (no pushPrice call → lastPushTime stays 0)
-    vi.mocked(fetch)
-      .mockResolvedValueOnce({
-        ok: true, json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }] }),
-      } as any)
-      .mockResolvedValueOnce({
-        ok: true, json: async () => ({ data: { MINT_A: { price: '1.00' } } }),
-      } as any);
-
-    await oracle.fetchPrice('MINT_A', 'SLAB_A');
-
-    const stale = oracle.getStaleMarkets(5 * 60 * 1000);
-    expect(stale).toContain('SLAB_A');
+  it('does NOT flag a market whose price was just fetched', async () => {
+    await seedFreshPrice('MINT_A', 'SLAB_A');
+    expect(oracle.getStaleMarkets(10 * 60 * 1000)).not.toContain('SLAB_A');
+    expect(oracle.getStaleMarkets(5 * 60 * 1000)).not.toContain('SLAB_A');
   });
 
-  // "should not return markets with recent push" test removed — pushPrice
-  // was deleted in Phase G. The getStaleMarkets logic now depends on
-  // recordPushTime calls from external oracle sources instead.
-
-  it('should distinguish between 5min alert and 10min pause thresholds', async () => {
-    // We'll test the logic by checking that the same market appears
-    // at a short threshold but not at a long one
-
-    // Seed market with price history but no push
-    vi.mocked(fetch)
-      .mockResolvedValueOnce({
-        ok: true, json: async () => ({ pairs: [{ priceUsd: '2.00', liquidity: { usd: 100000 } }] }),
-      } as any)
-      .mockResolvedValueOnce({
-        ok: true, json: async () => ({ data: { MINT_C: { price: '2.00' } } }),
-      } as any);
-
-    await oracle.fetchPrice('MINT_C', 'SLAB_C');
-
-    // With threshold=0, everything with no push is stale
-    const staleAt0 = oracle.getStaleMarkets(0);
-    expect(staleAt0).toContain('SLAB_C');
-
-    // With a very large threshold (1 hour), a never-pushed market is still stale
-    // because lastPushTime=0 means now - 0 > threshold for any threshold
-    const staleAtHour = oracle.getStaleMarkets(60 * 60 * 1000);
-    expect(staleAtHour).toContain('SLAB_C');
+  it('flags a market once its last fresh fetch is older than the threshold', async () => {
+    await seedFreshPrice('MINT_A', 'SLAB_A'); // fresh at t0
+    clock += 11 * 60 * 1000; // 11 minutes later
+    expect(oracle.getStaleMarkets(10 * 60 * 1000)).toContain('SLAB_A');
   });
 
-  it('should return multiple stale markets', async () => {
-    // Seed two markets
-    vi.mocked(fetch)
-      .mockResolvedValueOnce({
-        ok: true, json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }] }),
-      } as any)
-      .mockResolvedValueOnce({
-        ok: true, json: async () => ({ data: { MINT_X: { price: '1.00' } } }),
-      } as any);
-    await oracle.fetchPrice('MINT_X', 'SLAB_X');
+  it('distinguishes the 5-min alert threshold from the 10-min pause threshold', async () => {
+    await seedFreshPrice('MINT_C', 'SLAB_C'); // fresh at t0
+    clock += 6 * 60 * 1000; // 6 minutes later
 
-    vi.mocked(fetch)
-      .mockResolvedValueOnce({
-        ok: true, json: async () => ({ pairs: [{ priceUsd: '3.00', liquidity: { usd: 50000 } }] }),
-      } as any)
-      .mockResolvedValueOnce({
-        ok: true, json: async () => ({ data: { MINT_Y: { price: '3.00' } } }),
-      } as any);
-    await oracle.fetchPrice('MINT_Y', 'SLAB_Y');
+    // Older than the 5-min alert threshold...
+    expect(oracle.getStaleMarkets(5 * 60 * 1000)).toContain('SLAB_C');
+    // ...but younger than the 10-min pause threshold.
+    expect(oracle.getStaleMarkets(10 * 60 * 1000)).not.toContain('SLAB_C');
+  });
 
-    const stale = oracle.getStaleMarkets(5 * 60 * 1000);
-    expect(stale).toContain('SLAB_X');
-    expect(stale).toContain('SLAB_Y');
-    expect(stale.length).toBe(2);
+  it('recovers a market on a fresh fetch (unpause path)', async () => {
+    await seedFreshPrice('MINT_E', 'SLAB_E');
+    clock += 11 * 60 * 1000;
+    expect(oracle.getStaleMarkets(10 * 60 * 1000)).toContain('SLAB_E'); // stale
+
+    await seedFreshPrice('MINT_E', 'SLAB_E'); // fresh again at the advanced clock
+    expect(oracle.getStaleMarkets(10 * 60 * 1000)).not.toContain('SLAB_E'); // recovered
+  });
+
+  it('reports multiple stale markets and only the stale ones', async () => {
+    await seedFreshPrice('MINT_X', 'SLAB_X');
+    await seedFreshPrice('MINT_Y', 'SLAB_Y');
+    clock += 11 * 60 * 1000; // both stale now
+
+    const allStale = oracle.getStaleMarkets(10 * 60 * 1000);
+    expect(allStale).toContain('SLAB_X');
+    expect(allStale).toContain('SLAB_Y');
+    expect(allStale.length).toBe(2);
+
+    // Refresh only X — Y stays stale.
+    await seedFreshPrice('MINT_X', 'SLAB_X');
+    const stillStale = oracle.getStaleMarkets(10 * 60 * 1000);
+    expect(stillStale).not.toContain('SLAB_X');
+    expect(stillStale).toContain('SLAB_Y');
+    expect(stillStale.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

`getStaleMarkets()` reported **every market that has ever had a price fetched** as stale, because it measured staleness from `lastPushTime` — a map that no production code ever writes. This feeds the stale-pause guard, so a few minutes after boot the crank paused every market and never unpaused it: funding cranks stop, undercollateralized accounts stop being evaluated, and HYPERP marks stop refreshing. `/health` keeps reporting healthy because it ages off `lastCrankTime` rather than detecting the pause.

## Root cause

1. `fetchPrice()` records a fresh price into `priceHistory` via `recordPrice()` and updates `lastExternalPriceMs` (`src/services/oracle.ts`), but never updates `lastPushTime`.
2. `lastPushTime` is written **only** by `recordPushTime()`, which has **no production caller** — a repo-wide search finds only its definition and test mocks.
3. `getStaleMarkets()` treats `lastPushTime.get(slab) ?? 0 === 0` as `Infinity` staleness, so every market in `priceHistory` is returned as stale for any threshold.
4. `index.ts` runs `getStaleMarkets(STALE_PAUSE_THRESHOLD_MS)` every 60s after a 5-minute startup grace and can only unpause a market that is *absent* from the result set — which never happens, because every market is always present.
5. `crankService.setStalePauseCheck(isMarketStalePaused)` makes the crank skip every paused market (`skippedStalePaused`).

The freshness signal the guard should use already exists: `lastExternalPriceMs` is updated on every successful external fetch — but it was read nowhere, while `getStaleMarkets()` read the never-written `lastPushTime`.

## Fix

- Point `getStaleMarkets()` at `lastExternalPriceMs`. A market that can only serve a cached/on-chain fallback price never advances that clock (the cached early-return bails out before the write), so it correctly ages into staleness **by construction** — no special case.
- Delete the dead `lastPushTime` field and `recordPushTime()` method so the staleness clock cannot drift out of the fetch path again (this is what caused the bug).
- Delete `lastExternalPriceMs` entries on `priceHistory` eviction so the freshness map shares `priceHistory`'s lifetime.
- The `keeper_oracle_staleness_seconds` gauge now reports real staleness (it was previously guarded by `isFinite`, which was never true).
- Add an injectable clock seam to `OracleService` (`constructor(opts?: { now })`, defaulting to `Date.now`) so staleness is deterministically testable. The single production construction site needs no change.

No changes to `index.ts` or `crank.ts` — they were already correct given a correct `getStaleMarkets`.

## Tests

`tests/services/oracle-stale.test.ts` previously **encoded the bug as expected** (asserting a market fetched moments earlier is "stale", with a comment that "a never-pushed market is still stale … for any threshold"). It is rewritten to assert the corrected behavior using the injected clock:
- a freshly-fetched market is **not** stale (at the 5- and 10-min thresholds);
- a market with no fresh fetch is **stale** once past the threshold;
- the 5-min alert vs 10-min pause thresholds are distinguished;
- a market **recovers** only on a fresh fetch (not by the passage of time);
- multiple markets report independently.

Also removed a skipped `crank.test.ts` test that asserted the deleted `recordPushTime` contract.

Full suite: 690 passing, 24 skipped; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)