### PR TITLE
fix(boot): refuse mainnet boot when the RPC fallback is unset or points at devnet

### DIFF
--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -35,6 +35,42 @@ function rejectLocalRpcUrl(varName: string, raw: string | undefined): void {
   }
 }
 
+// A8: classify an RPC host as devnet/testnet. Anchored on dot-delimited
+// hostname labels, never a raw substring, so a legit mainnet host that merely
+// contains the text "devnet" (e.g. "my-devnet-migration.example.com", label
+// "my-devnet-migration") or "mainnet-beta" is never a false positive. Catches
+// every real form: api.devnet.solana.com, devnet.helius-rpc.com,
+// api.testnet.solana.com, testnet.helius-rpc.com.
+function isDevnetOrTestnetHost(hostname: string): boolean {
+  const labels = hostname.toLowerCase().split(".");
+  return labels.includes("devnet") || labels.includes("testnet");
+}
+
+// A8: When NETWORK=mainnet, refuse any RPC URL whose host is a known
+// devnet/testnet cluster. Complements rejectLocalRpcUrl (localhost/port-8899);
+// this catches public devnet hosts that the local-host guard lets through —
+// most importantly api.devnet.solana.com, which @percolatorct/shared substitutes
+// for an unset FALLBACK_RPC_URL. The keeper runs ALL market discovery and
+// liquidation retry on the fallback connection, so a devnet host there means it
+// discovers zero mainnet markets and cranks nothing.
+function rejectDevnetTestnetRpcUrl(varName: string, raw: string | undefined): void {
+  if (!raw) return; // presence is enforced separately for FALLBACK_RPC_URL
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    // Malformed URLs are reported by rejectLocalRpcUrl (which runs first).
+    return;
+  }
+  if (isDevnetOrTestnetHost(parsed.hostname)) {
+    throw new Error(
+      `${varName} points at devnet/testnet host '${parsed.hostname}' but NETWORK=mainnet — ` +
+        `refusing to boot. A mainnet keeper must use a mainnet RPC endpoint. ` +
+        `(@percolatorct/shared defaults an unset FALLBACK_RPC_URL to api.devnet.solana.com.)`,
+    );
+  }
+}
+
 export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): void {
   // M1: validate CRANK_KEYPAIR parseability at boot. Without this, a malformed
   // keypair (truncated JSON, wrong base58) survives boot and only crashes in
@@ -145,5 +181,26 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
     // (not SOLANA_RPC_URL). Without this guard a RPC_URL=http://localhost
     // on mainnet would be accepted while the other vars are caught.
     rejectLocalRpcUrl("RPC_URL", env.RPC_URL?.trim());
+
+    // A8: reject devnet/testnet hosts on every connection a mainnet keeper opens
+    // (discovery + liquidation retry run on the fallback connection).
+    rejectDevnetTestnetRpcUrl("SOLANA_RPC_URL", env.SOLANA_RPC_URL?.trim());
+    rejectDevnetTestnetRpcUrl("SOLANA_RPC_WS_URL", env.SOLANA_RPC_WS_URL?.trim());
+    rejectDevnetTestnetRpcUrl("FALLBACK_RPC_URL", env.FALLBACK_RPC_URL?.trim());
+    rejectDevnetTestnetRpcUrl("RPC_URL", env.RPC_URL?.trim());
+
+    // A8: FALLBACK_RPC_URL has no safe default on mainnet — when unset,
+    // @percolatorct/shared substitutes https://api.devnet.solana.com (with no
+    // network condition), and the keeper runs all market discovery + liquidation
+    // retry on that devnet connection. Require it to be set explicitly. (Checked
+    // last so an offending localhost/devnet value still gets its specific error.)
+    if (!env.FALLBACK_RPC_URL?.trim()) {
+      throw new Error(
+        "FALLBACK_RPC_URL must be set to a mainnet RPC endpoint when NETWORK=mainnet. " +
+          "It is unset, and @percolatorct/shared silently defaults it to " +
+          "api.devnet.solana.com — which would run all market discovery and " +
+          "liquidation retry on devnet, discovering zero mainnet markets.",
+      );
+    }
   }
 }

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -321,4 +321,103 @@ describe("validateKeeperEnvGuards", () => {
     } as NodeJS.ProcessEnv;
     expect(() => validateKeeperEnvGuards(env)).not.toThrow();
   });
+
+  // A8: mainnet must not silently fall back to devnet RPC. @percolatorct/shared
+  // defaults an unset FALLBACK_RPC_URL to api.devnet.solana.com, and the keeper
+  // runs all market discovery + liquidation retry on the fallback connection.
+  describe("A8: mainnet devnet/testnet RPC guard", () => {
+    const MAINNET = "https://mainnet.helius-rpc.com/?api-key=test";
+
+    it("throws when FALLBACK_RPC_URL is unset on mainnet", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: MAINNET,
+        RPC_URL: MAINNET,
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /FALLBACK_RPC_URL must be set to a mainnet RPC endpoint/,
+      );
+    });
+
+    it("throws when FALLBACK_RPC_URL is whitespace-only on mainnet", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: MAINNET,
+        RPC_URL: MAINNET,
+        FALLBACK_RPC_URL: "   ",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /FALLBACK_RPC_URL must be set to a mainnet RPC endpoint/,
+      );
+    });
+
+    it.each([
+      ["FALLBACK_RPC_URL", "https://api.devnet.solana.com"],
+      ["FALLBACK_RPC_URL", "https://devnet.helius-rpc.com/?api-key=test"],
+      ["FALLBACK_RPC_URL", "https://api.testnet.solana.com"],
+      ["SOLANA_RPC_URL", "https://api.devnet.solana.com"],
+      ["RPC_URL", "https://api.testnet.solana.com"],
+    ])("rejects %s pointing at a devnet/testnet host on mainnet", (varName, url) => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: MAINNET,
+        RPC_URL: MAINNET,
+        FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
+        [varName]: url,
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        new RegExp(`${varName} points at devnet/testnet host`),
+      );
+    });
+
+    it("accepts a complete mainnet env with an explicit mainnet FALLBACK_RPC_URL", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: MAINNET,
+        SOLANA_RPC_WS_URL: "wss://mainnet.helius-rpc.com/?api-key=test",
+        FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
+        RPC_URL: MAINNET,
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
+
+    // Label-anchored, not substring: a mainnet host that merely contains the
+    // text "devnet" inside a label is NOT a false positive.
+    it("does not reject a mainnet host containing 'devnet' as a substring", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: "https://my-devnet-migration.example.com",
+        RPC_URL: "https://my-devnet-migration.example.com",
+        FALLBACK_RPC_URL: "https://my-devnet-migration.example.com",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
+
+    // The guard is independent of ALLOW_INSECURE_RPC (which only gates http/https).
+    it("rejects a devnet fallback on mainnet even when ALLOW_INSECURE_RPC=true", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: MAINNET,
+        RPC_URL: MAINNET,
+        FALLBACK_RPC_URL: "https://api.devnet.solana.com",
+        ALLOW_INSECURE_RPC: "true",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /FALLBACK_RPC_URL points at devnet\/testnet host/,
+      );
+    });
+
+    it("does NOT require FALLBACK_RPC_URL off mainnet (devnet/unset)", () => {
+      expect(() => validateKeeperEnvGuards({ NETWORK: "devnet" } as NodeJS.ProcessEnv)).not.toThrow();
+      expect(() => validateKeeperEnvGuards({} as NodeJS.ProcessEnv)).not.toThrow();
+    });
+
+    it("allows a devnet FALLBACK_RPC_URL when NETWORK=devnet", () => {
+      const env = {
+        NETWORK: "devnet",
+        FALLBACK_RPC_URL: "https://api.devnet.solana.com",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

On mainnet, an unset `FALLBACK_RPC_URL` silently resolves to **devnet**, and the keeper runs all market discovery on the fallback connection — so a mainnet keeper discovers no markets and cranks/liquidates nothing, while `/health` reports healthy. The trigger is a missing env var, not an exotic misconfiguration.

## Root cause

- `@percolatorct/shared` config defaults the fallback RPC with no network condition: `fallbackRpcUrl: env.FALLBACK_RPC_URL ?? "https://api.devnet.solana.com"`. When `FALLBACK_RPC_URL` is unset, `getFallbackConnection()` returns a devnet connection for the whole process, even when `NETWORK=mainnet`.
- Market discovery runs **exclusively** on the fallback connection — both the `getProgramAccounts` discovery loop and the `MARKETS_FILTER` batch path in `src/services/crank.ts` — and liquidation retries use it too (`src/services/liquidation.ts`).
- `validateKeeperEnvGuards` (`src/env-guards.ts`) on mainnet rejects localhost / port-8899 RPC URLs, but that helper (1) returns early when the var is unset, and (2) only rejects local hosts. An unset var is never examined, and a public devnet host like `api.devnet.solana.com` passes.

The shared package lives in `node_modules` and cannot be patched, so the fix is a boot-time guard in the keeper.

## Fix

Extend `validateKeeperEnvGuards` so that when `NETWORK=mainnet`:
- **`FALLBACK_RPC_URL` must be set and non-empty** (otherwise it silently defaults to devnet);
- the RPC URL vars (`SOLANA_RPC_URL`, `SOLANA_RPC_WS_URL`, `FALLBACK_RPC_URL`, `RPC_URL`) are **rejected if their host is a known devnet/testnet cluster**.

Devnet/testnet detection is anchored on dot-delimited hostname **labels** (a host is flagged iff a whole label equals `devnet` or `testnet`), never a raw substring — so a legit mainnet host that merely contains the text "devnet" (e.g. `my-devnet-migration.example.com`) or `mainnet-beta` is never a false positive. It catches every real form: `api.devnet.solana.com`, `devnet.helius-rpc.com`, `api.testnet.solana.com`, `testnet.helius-rpc.com`.

Notes:
- The presence check runs **last** in the mainnet block, so an offending localhost/devnet value still surfaces its specific existing error.
- Both guards are mainnet-gated and **not** bypassable by `ALLOW_INSECURE_RPC` (which only governs http/https), matching the existing localhost-guard behavior.
- The presence requirement is scoped to `FALLBACK_RPC_URL` only — the primary `RPC_URL` is already required on mainnet by the shared network validation; the devnet-host rejection applies to all four vars as defense-in-depth.
- Off mainnet, behavior is unchanged — devnet defaults remain fine for local dev.

## Tests

Adds an `A8` block to `tests/env-guards.test.ts` covering: unset/whitespace `FALLBACK_RPC_URL` on mainnet → throws; devnet/testnet hosts across each RPC var → throws; label-anchored false-positive safety (a `devnet` substring inside a label is accepted); `ALLOW_INSECURE_RPC` does not bypass the guard; and devnet defaults remain accepted off mainnet. All existing guard tests are unchanged and stay green (the presence-last ordering preserves their specific error messages).

Full suite: 700 passing, 25 skipped; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Mainnet configurations now require an explicitly set fallback RPC URL
  * RPC endpoints pointing to devnet or testnet hosts are rejected when NETWORK=mainnet
  * Configuration validation prevents unintended network mismatches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->