### PR TITLE
fix(keeper): exclude landed-but-reverted txs from the success-rate breaker

### DIFF
--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -21,7 +21,7 @@ import { createLogger } from "@percolatorct/shared";
 const logger = createLogger("keeper:budget");
 
 export type TxType = "crank" | "liquidation" | "oracle" | "adl";
-export type TxResult = "success" | "fail" | "drop";
+export type TxResult = "success" | "fail" | "reverted" | "drop";
 
 export interface KeeperBudgetConfig {
   /** Per cycle cap in lamports (default 50_000_000 = 0.05 SOL). */
@@ -204,8 +204,16 @@ export class KeeperBudget {
    * Record a settled tx. Called regardless of halt state — accounts for
    * in-flight txs that settle after the budget has already tripped.
    *
-   * - 'success' / 'fail': lamports are added to spend trackers (fees pay on
-   *   failed txs that landed in a block).
+   * - 'success' / 'fail' / 'reverted': lamports are added to spend trackers
+   *   (fees are paid on any tx that landed in a block).
+   * - Only 'success' and 'fail' feed the tx-success-rate window. 'reverted'
+   *   means the tx LANDED on-chain and the program returned an error — the
+   *   send path demonstrably works, so a revert is NOT an "are we landing?"
+   *   failure and must not move that breaker. Otherwise a single
+   *   persistently-reverting market, or an attacker who front-runs liquidations
+   *   to make them revert, would drive the global rate down and halt every
+   *   market (cross-market DoS). A reverting market is instead contained by the
+   *   per-market consecutiveFailures skip in crank.ts.
    * - 'drop': lamports are NOT added (we never reached the chain). Still
    *   counts toward cycleTxCount as an attempt.
    */
@@ -220,10 +228,14 @@ export class KeeperBudget {
       this._hourSpendSum += lamports;
       this._dayEvents.push({ ts: nowMs, lamports });
       this._daySpendSum += lamports;
-      const success = result === "success";
-      this._txWindow.push({ ts: nowMs, success });
-      if (success) this._txWindowSuccesses++;
-      else this._txWindowFailures++;
+      // Only landing outcomes feed the success-rate guard. A revert landed, so
+      // it is excluded from the window entirely (neither success nor failure).
+      if (result === "success" || result === "fail") {
+        const success = result === "success";
+        this._txWindow.push({ ts: nowMs, success });
+        if (success) this._txWindowSuccesses++;
+        else this._txWindowFailures++;
+      }
     }
 
     this._pruneOld(nowMs);

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -98,6 +98,28 @@ export interface KeeperSendResult {
 }
 
 /**
+ * Classify a send failure for budget accounting.
+ *
+ * `pollSignatureStatus` (in @percolatorct/shared) is the only source that throws
+ * AFTER the tx confirmed on-chain: on `status.err` it throws
+ * `Transaction failed: <err json>`. So that prefix is a reliable "the tx LANDED
+ * and the program reverted" marker. Every other keeper-path throw — confirmation
+ * timeout ("... not confirmed after ...ms"), broadcast rejection, RPC/429,
+ * blockhash, signing, oversize — means the tx did NOT land.
+ *
+ * A landed-but-reverted tx proves the send path works, so it is recorded as
+ * "reverted" (counts as spend + attempt, but excluded from the success-rate
+ * breaker — see KeeperBudget.recordTx). This stops an attacker who dodges
+ * liquidations, or one reverting market, from halting the whole keeper. Anything
+ * we cannot positively identify as a revert defaults to "fail" — the safe
+ * direction, since it keeps feeding the systemic "are we landing?" guard.
+ */
+export function classifySendError(err: unknown): TxResult {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.startsWith("Transaction failed:") ? "reverted" : "fail";
+}
+
+/**
  * Send a keeper transaction with budget gate, priority-fee estimation, and CU simulation.
  *
  * Returns null if the budget is exhausted (budget.canSpend returned false) — caller
@@ -191,7 +213,10 @@ export async function keeperSend(
     result = "success";
     return { signature, estimatedCost, simulatedCu };
   } catch (err) {
-    result = "fail";
+    // A landed-but-reverted tx ("Transaction failed: ...") is recorded as
+    // "reverted" so it doesn't poison the success-rate breaker; genuine
+    // never-landed failures stay "fail". The error is rethrown unchanged.
+    result = classifySendError(err);
     throw err;
   } finally {
     budget.recordTx(estimatedCost, txType, result);

--- a/tests/lib/budget-success-rate-isolation.test.ts
+++ b/tests/lib/budget-success-rate-isolation.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression test for the success-rate cross-market DoS.
+ *
+ * KeeperBudget's tx-success-rate breaker halts ALL sends when the landed-tx
+ * success rate over a rolling window drops below the threshold. The window used
+ * to count an on-chain REVERT (a tx that landed in a block and the program
+ * rejected) as a "fail" — so an attacker who front-runs liquidations to make
+ * them revert, or one persistently-reverting market, could drive the GLOBAL
+ * rate down and halt cranks/marks/liquidations on every market.
+ *
+ * The fix: keeperSend classifies a landed-but-reverted tx as "reverted"
+ * (counts as spend + attempt, but excluded from the success-rate window), while
+ * genuine never-landed failures stay "fail" and still feed the breaker.
+ *
+ * These tests drive the REAL keeperSend + KeeperBudget. The first asserts that
+ * localized reverts no longer halt healthy unrelated sends (fails on old main,
+ * passes after the fix); the second asserts a genuine "nothing lands" outage
+ * still halts (the breaker is not gutted).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({ send: vi.fn(async () => "mock-signature") }));
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  sendWithRetryKeeper: h.send,
+}));
+vi.mock("../../src/lib/priority-fee.js", () => {
+  class HeliusPriorityFeeEstimator { estimate = vi.fn(async () => 1_000); }
+  return { HeliusPriorityFeeEstimator };
+});
+vi.mock("../../src/lib/cu-estimator.js", () => {
+  class CuEstimator { estimate = vi.fn(async () => 200_000); }
+  return { CuEstimator };
+});
+
+import { keeperSend } from "../../src/lib/keeper-send.js";
+import { KeeperBudget } from "../../src/lib/budget.js";
+import { Keypair, TransactionInstruction, PublicKey } from "@solana/web3.js";
+import type { TxType } from "../../src/lib/budget.js";
+
+function ix(): TransactionInstruction {
+  return new TransactionInstruction({ programId: PublicKey.default, keys: [], data: Buffer.from([]) });
+}
+function conn() {
+  return { simulateTransaction: vi.fn(async () => ({ value: { unitsConsumed: 200_000, err: null, logs: [] } })) } as any;
+}
+
+describe("success-rate breaker: reverts excluded, systemic failures still halt", () => {
+  let budget: KeeperBudget;
+  const c = conn();
+  const kp = Keypair.generate();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NETWORK = "devnet";
+    process.env.USE_HELIUS_SENDER = "false";
+    delete process.env.DRY_RUN;
+    h.send.mockResolvedValue("mock-signature");
+    budget = new KeeperBudget(); // defaults: threshold 0.70, minSamples 10, window 60s
+  });
+
+  async function attempt(txType: TxType): Promise<"ok" | "refused" | "failed"> {
+    try {
+      const r = await keeperSend(c, [ix()], [kp], txType, budget);
+      return r === null ? "refused" : "ok";
+    } catch {
+      return "failed";
+    }
+  }
+
+  it("FIXED: liquidation reverts do NOT halt healthy cranks (cross-market DoS closed)", async () => {
+    // 12 healthy cranks land — well past minSamples, rate 1.0.
+    for (let i = 0; i < 12; i++) expect(await attempt("crank")).toBe("ok");
+
+    // Attacker dodges liquidations → each keeper liquidation LANDS and REVERTS.
+    // pollSignatureStatus throws "Transaction failed: ..." → classified "reverted".
+    h.send.mockRejectedValue(new Error('Transaction failed: {"InstructionError":[0,{"Custom":1}]}'));
+    for (let i = 0; i < 15; i++) expect(await attempt("liquidation")).toBe("failed");
+
+    // The keeper is NOT halted, and a healthy crank still goes through — reverts
+    // never entered the success-rate window.
+    h.send.mockResolvedValue("mock-signature");
+    expect(budget.isHalted()).toBe(false);
+    expect(await attempt("crank")).toBe("ok");
+    expect(budget.getStats().haltKind).toBeUndefined();
+    // Window saw only the (successful) cranks — no failures recorded from reverts.
+    expect(budget.getStats().txSuccessRate).toBe(1);
+  });
+
+  it("reverts still count as spend and attempts (they paid fees)", async () => {
+    const before = budget.getStats();
+    h.send.mockRejectedValue(new Error('Transaction failed: {"InstructionError":[0,{"Custom":1}]}'));
+    await attempt("liquidation");
+    const after = budget.getStats();
+    expect(after.cycleTxCount).toBe(before.cycleTxCount + 1);
+    expect(after.cycleSpend).toBeGreaterThan(before.cycleSpend);
+  });
+
+  it("SYSTEMIC: genuine never-landed failures still halt the keeper (breaker intact)", async () => {
+    for (let i = 0; i < 5; i++) expect(await attempt("crank")).toBe("ok");
+    // Confirmation timeout — the tx never landed. Not a revert → stays "fail".
+    h.send.mockRejectedValue(new Error("Transaction 5xZ not confirmed after 60000ms"));
+    for (let i = 0; i < 10; i++) await attempt("liquidation");
+
+    expect(budget.isHalted()).toBe(true);
+    expect(budget.getStats().haltKind).toBe("tx-success-rate");
+    // Latched: a healthy crank is still refused until manual resume.
+    h.send.mockResolvedValue("mock-signature");
+    expect(await attempt("crank")).toBe("refused");
+  });
+
+  it("SYSTEMIC: RPC/send errors (never landed) also still halt", async () => {
+    for (let i = 0; i < 5; i++) expect(await attempt("crank")).toBe("ok");
+    h.send.mockRejectedValue(new Error("failed to send transaction: 429 Too Many Requests"));
+    for (let i = 0; i < 10; i++) await attempt("crank");
+    expect(budget.isHalted()).toBe(true);
+    expect(budget.getStats().haltKind).toBe("tx-success-rate");
+  });
+});

--- a/tests/lib/budget.property.test.ts
+++ b/tests/lib/budget.property.test.ts
@@ -12,7 +12,7 @@ const PROPERTY_CONFIG = {
   txSuccessRateMinSamples: 4,
 } as const;
 
-const txResultArb: fc.Arbitrary<TxResult> = fc.constantFrom("success", "fail", "drop");
+const txResultArb: fc.Arbitrary<TxResult> = fc.constantFrom("success", "fail", "reverted", "drop");
 const lamportsArb = fc.integer({ min: 1, max: 100_000 });
 const advanceArb = fc.integer({ min: 0, max: 5_000 });
 

--- a/tests/lib/budget.test.ts
+++ b/tests/lib/budget.test.ts
@@ -232,6 +232,29 @@ describe("KeeperBudget — drop result accounting", () => {
   });
 });
 
+describe("KeeperBudget — reverted result accounting", () => {
+  it("counts toward tx count + spend but NOT the success-rate window", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    b.recordTx(300, "liquidation", "reverted");
+    const s = b.getStats();
+    expect(s.cycleSpend).toBe(300); // fees were paid — the tx landed
+    expect(s.cycleTxCount).toBe(1);
+    expect(s.hourSpend).toBe(300);
+    expect(s.daySpend).toBe(300);
+    expect(s.txWindowSize).toBe(0); // excluded from the breaker
+  });
+
+  it("a flood of reverts never trips the tx-success-rate breaker", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget({ ...TIGHT_CONFIG, maxTxPerCycle: 999, maxSolPerCycle: 1e12, maxSolPerHour: 1e12, maxSolPerDay: 1e12 }, { now: clock.now });
+    for (let i = 0; i < 50; i++) b.recordTx(1, "liquidation", "reverted");
+    expect(b.canSpend(1, "crank")).toBe(true);
+    expect(b.isHalted()).toBe(false);
+    expect(b.getStats().txSuccessRate).toBeNull(); // no success/fail samples at all
+  });
+});
+
 describe("KeeperBudget — resume() semantics", () => {
   it("resume clears halt state and lets canSpend return true again", () => {
     const clock = makeClock();

--- a/tests/lib/keeper-send.test.ts
+++ b/tests/lib/keeper-send.test.ts
@@ -25,7 +25,7 @@ vi.mock("../../src/lib/cu-estimator.js", () => {
 });
 
 import * as shared from "@percolatorct/shared";
-import { keeperSend } from "../../src/lib/keeper-send.js";
+import { keeperSend, classifySendError } from "../../src/lib/keeper-send.js";
 import { KeeperBudget } from "../../src/lib/budget.js";
 import { Keypair, TransactionInstruction, PublicKey } from "@solana/web3.js";
 
@@ -103,6 +103,37 @@ describe("keeperSend", () => {
     expect(stats.cycleTxCount).toBe(1);
     // failed txs still consume lamports (fees paid on-chain if landed)
     expect(stats.cycleSpend).toBeGreaterThan(0);
+  });
+
+  describe("classifySendError", () => {
+    it("classifies a landed-but-reverted tx as 'reverted'", () => {
+      expect(classifySendError(new Error('Transaction failed: {"InstructionError":[0,{"Custom":1}]}'))).toBe("reverted");
+    });
+
+    it("classifies a confirmation timeout as 'fail' (never landed)", () => {
+      expect(classifySendError(new Error("Transaction 5xZ not confirmed after 60000ms"))).toBe("fail");
+    });
+
+    it("classifies an RPC/send error as 'fail'", () => {
+      expect(classifySendError(new Error("failed to send transaction: 429 Too Many Requests"))).toBe("fail");
+      expect(classifySendError("some non-error value")).toBe("fail");
+    });
+  });
+
+  it("records a reverted tx (excluded from success-rate window) when the send reverts on-chain", async () => {
+    vi.mocked(shared.sendWithRetryKeeper).mockRejectedValueOnce(
+      new Error('Transaction failed: {"InstructionError":[0,{"Custom":1}]}'),
+    );
+
+    await expect(
+      keeperSend(connection, [makeDummyIx()], [keypair], "liquidation", budget),
+    ).rejects.toThrow("Transaction failed:");
+
+    const stats = budget.getStats();
+    // Counts as an attempt + spend, but is NOT a success-rate sample.
+    expect(stats.cycleTxCount).toBe(1);
+    expect(stats.cycleSpend).toBeGreaterThan(0);
+    expect(stats.txWindowSize).toBe(0);
   });
 
   it("passes maxRetries to sendWithRetryKeeper", async () => {


### PR DESCRIPTION
## Summary

The `tx-success-rate` circuit breaker halts **all** keeper sends when the landed-tx success rate over a rolling window drops below the threshold (default 0.70). The window is **global** and an on-chain **revert** was counted as a "fail" — so a transaction that *landed and reverted* (proof the send path works) was treated as a landing failure. A position owner who front-runs the keeper's liquidations to make them revert (top up margin / self-close), or a single persistently-reverting market, could drive the global rate below the threshold and halt cranks, marks, liquidations, and ADL across **every** market, latched until manual resume — a cross-market denial-of-service.

## Root cause

- `keeperSend` records `"fail"` whenever `sendWithRetryKeeper` throws (`src/lib/keeper-send.ts`).
- `sendWithRetryKeeper` → `pollSignatureStatus` throws `Transaction failed: <err>` when a **confirmed** tx carries `status.err` (`@percolatorct/shared` `utils/solana.js`). A landed-but-reverted tx therefore surfaces as a "fail".
- `KeeperBudget`'s success-rate window (`src/lib/budget.ts`) aggregates `success`/`fail` across all markets and tx types and halts (latched) when the rate falls below the threshold.

The breaker's stated purpose is to catch "we're sending but nothing lands". A landed-but-reverted tx is the opposite of that signal.

## Fix

Classify the failure at the source. `keeperSend` now records a landed-but-reverted tx (error message starting with `Transaction failed:`) as a new `"reverted"` result, which counts as **spend + attempt** (fees were paid, it landed) but is **excluded from the success-rate window**. Genuine never-landed failures — confirmation timeouts (`not confirmed after`), RPC/broadcast errors, blockhash/signing failures — stay `"fail"` and still feed the breaker, so a real "nothing lands" outage still halts the keeper exactly as before. Anything not positively identified as a revert defaults to `"fail"` (the safe direction — an unrecognized error keeps tripping the systemic guard).

This closes the attacker's lever **without** per-market/per-type scoping changes: the only remaining breaker inputs (`never-landed` / `send-error`) are properties of the keeper's shared RPC/send path, which an on-chain counterparty cannot manufacture for a single market. A reverting market remains contained by the existing per-market `consecutiveFailures` skip in `crank.ts`. (Per-market success-rate scoping is a reasonable follow-up hardening, not required to close this issue.)

## Tests

- Rewrites the PoC into a regression test: localized liquidation reverts no longer halt healthy unrelated cranks, and the keeper is not halted.
- Systemic-outage tests: confirmation timeouts and RPC/429 errors (never landed) still drive the rate down, halt, and latch.
- `classifySendError` unit tests pinning the three thrown shapes (`Transaction failed:` → reverted; `not confirmed after` → fail; RPC error → fail).
- Budget-level accounting tests: a `reverted` result counts toward spend + tx-count but not the success-rate window; a flood of reverts never trips the breaker.
- Extends the property-test result arbitrary with `"reverted"` — the latch invariants ("once halted, stays halted until resume()") and the cycle-spend invariant hold unchanged.

Full suite: 698 passing, 25 skipped; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)