### PR TITLE
fix(liquidation): add a minimum-notional floor so the keeper skips dust

### DIFF
--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -26,6 +26,13 @@ export const solSpentLamportsTotal = new Counter({
   registers: [registry],
 });
 
+export const liquidationSkippedDustTotal = new Counter({
+  name: "keeper_liquidation_skipped_dust_total",
+  help: "Liquidation candidates skipped for being below the min-notional floor, partitioned by stage (scan|presubmit)",
+  labelNames: ["stage"] as const,
+  registers: [registry],
+});
+
 export const jitoBundleFailCountTotal = new Counter({
   name: "keeper_jito_bundle_fail_count_total",
   help: "Total number of Jito bundle submission failures",

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -24,6 +24,7 @@ import {
   solSpentLamportsTotal,
   cycleDurationSeconds,
   txLandTimeSeconds,
+  liquidationSkippedDustTotal,
 } from "../lib/metrics.js";
 import type { AccountLoader } from "../lib/account-loader.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
@@ -87,6 +88,47 @@ async function fetchSlabWithRetry(
 // BL2: Extract magic numbers to named constants
 const PRICE_E6_DIVISOR = 1_000_000n; // Price precision divisor (6 decimals)
 const BPS_MULTIPLIER = 10_000n; // Basis points multiplier (100% = 10000 bps)
+
+// Minimum position notional below which the keeper will NOT liquidate.
+//
+// `notional = abs(positionSize) * priceE6 / PRICE_E6_DIVISOR`. Because POS_SCALE
+// is a fixed 1e6 (program spec) and priceE6 is a USD price scaled by 1e6, the
+// resulting notional is denominated in a fixed 6-decimal USD quote unit
+// (1_000_000n == $1) for EVERY market — it does not depend on the collateral
+// mint's token decimals (SOL/BTC/ETH collateral all reduce to the same USD
+// quote). So a single USD-denominated floor is correct across all markets.
+//
+// Why a floor: the keeper liquidates as a permissionless cranker and earns NO
+// liquidation fee (the on-chain penalty goes to the protocol, not the keeper),
+// so every liquidation is a pure cost — a crank+LiquidateAtOracle tx that on
+// mainnet pays a Jito tip (default 200_000 lamports) plus fees. Without a floor,
+// the keeper spends real SOL liquidating dust worth less than the fee, and —
+// since the program allows dust deposits — an attacker can spam tiny
+// undercollateralized positions across many owner accounts (bypassing
+// MAX_LIQ_PER_OWNER_PER_CYCLE) to drain the wallet up to the budget caps.
+//
+// Default $1 (1_000_000n): ~10-20x the per-liquidation fee, well below any
+// economically meaningful position. Tunable via KEEPER_MIN_LIQ_NOTIONAL (raw
+// 6-decimal-USD units); set to 0 to disable.
+const DEFAULT_MIN_LIQ_NOTIONAL = 1_000_000n; // $1 in 6-decimal USD units
+
+/** Parse KEEPER_MIN_LIQ_NOTIONAL (a non-negative integer, raw 6-dec USD units).
+ *  Falls back to the default on missing/invalid input. Exported for testing. */
+export function parseMinLiqNotional(raw: string | undefined): bigint {
+  if (raw === undefined || raw.trim() === "") return DEFAULT_MIN_LIQ_NOTIONAL;
+  try {
+    const n = BigInt(raw.trim());
+    return n >= 0n ? n : DEFAULT_MIN_LIQ_NOTIONAL;
+  } catch {
+    logger.warn("Invalid KEEPER_MIN_LIQ_NOTIONAL — using default", {
+      raw,
+      default: DEFAULT_MIN_LIQ_NOTIONAL.toString(),
+    });
+    return DEFAULT_MIN_LIQ_NOTIONAL;
+  }
+}
+
+const MIN_LIQUIDATION_NOTIONAL: bigint = parseMinLiqNotional(process.env.KEEPER_MIN_LIQ_NOTIONAL);
 
 /**
  * A.13: pure helper for margin-ratio-in-bps. scanMarket() and liquidate()
@@ -309,6 +351,20 @@ export class LiquidationService {
           const notional = absBI(account.positionSize) * price / PRICE_E6_DIVISOR;
           if (notional === 0n) continue;
 
+          // Min-notional floor: skip sub-floor dust — the keeper earns no
+          // liquidation fee, so liquidating value below the tx fee is a pure
+          // loss and an attacker-spammable drain. (notional is 6-decimal USD.)
+          if (notional < MIN_LIQUIDATION_NOTIONAL) {
+            liquidationSkippedDustTotal.inc({ stage: "scan" });
+            logger.debug("Skipping dust-notional candidate (below min-notional floor)", {
+              slabAddress,
+              accountIdx: i,
+              notional: notional.toString(),
+              floor: MIN_LIQUIDATION_NOTIONAL.toString(),
+            });
+            continue;
+          }
+
           // v12.17: entryPrice is always 0n (removed from on-chain struct).
           // Use account.pnl directly — it is always populated and accurate.
           const markPnl = account.pnl;
@@ -453,6 +509,22 @@ export class LiquidationService {
         }
 
         const notional = absBI(freshAccount.positionSize) * freshPrice / PRICE_E6_DIVISOR;
+
+        // Min-notional floor (mirrors scanMarket): a position can shrink below
+        // the floor between scan and submit (partial fill, owner partial-close,
+        // price move), and the event-driven path reaches liquidate() without
+        // scanAndLiquidateAll. Re-check before paying a fee on dust.
+        if (notional < MIN_LIQUIDATION_NOTIONAL) {
+          liquidationSkippedDustTotal.inc({ stage: "presubmit" });
+          logger.warn("Pre-submit: notional below min-notional floor, aborting", {
+            accountIndex: accountIdx,
+            slabAddress: slabAddress.toBase58(),
+            notional: notional.toString(),
+            floor: MIN_LIQUIDATION_NOTIONAL.toString(),
+          });
+          return null;
+        }
+
         // A.13: shared helper. equity<=0n returns 0n, which is < any
         // positive maintenanceMarginBps and so correctly proceeds with
         // liquidation; the previous `if (equity > 0n)` wrapper just

--- a/tests/services/liquidation-min-notional.test.ts
+++ b/tests/services/liquidation-min-notional.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Regression test for the liquidation min-notional floor.
+ *
+ * The keeper liquidates as a permissionless cranker and earns no liquidation fee
+ * (the on-chain penalty goes to the protocol), so every liquidation is a pure
+ * cost — a crank+LiquidateAtOracle tx paying a Jito tip (default 200_000
+ * lamports) + fees. Previously scanMarket()/liquidate() had no minimum-notional
+ * floor, so the keeper would liquidate dust at a loss and an attacker could spam
+ * tiny undercollateralized positions across many owners to drain the wallet.
+ *
+ * notional = abs(positionSize) * priceE6 / 1e6 is denominated in a fixed
+ * 6-decimal USD quote unit (1_000_000n == $1) for every market — POS_SCALE and
+ * the price scale are fixed, so collateral-mint decimals don't enter it. A
+ * single USD-denominated floor (default $1) is therefore correct across all
+ * markets and is applied in both scanMarket and the pre-submit re-check.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@solana/web3.js", async () => {
+  const actual = await vi.importActual("@solana/web3.js");
+  return {
+    ...actual,
+    SYSVAR_CLOCK_PUBKEY: { toBase58: () => "SysvarC1ock11111111111111111111111111111111", equals: () => false },
+  };
+});
+
+vi.mock("@percolatorct/sdk", () => ({
+  fetchSlab: vi.fn(),
+  parseConfig: vi.fn(),
+  parseEngine: vi.fn(),
+  parseParams: vi.fn(),
+  parseAccount: vi.fn(),
+  parseUsedIndices: vi.fn(),
+  detectLayout: vi.fn(),
+  buildAccountMetas: vi.fn(() => []),
+  buildIx: vi.fn(() => ({})),
+  encodeLiquidateAtOracle: vi.fn(() => Buffer.from([1])),
+  encodeKeeperCrank: vi.fn(() => Buffer.from([2])),
+  encodePushOraclePrice: vi.fn(() => Buffer.from([3])),
+  derivePythPushOraclePDA: vi.fn(() => [{ toBase58: () => "Oracle11111111111111111111111111111111" }, 0]),
+  ACCOUNTS_LIQUIDATE_AT_ORACLE: {},
+  ACCOUNTS_KEEPER_CRANK: {},
+  ACCOUNTS_PUSH_ORACLE_PRICE: {},
+}));
+
+vi.mock("@percolatorct/shared", () => ({
+  config: { crankKeypair: "mock-keypair-path" },
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  sendWarningAlert: vi.fn(),
+  getConnection: vi.fn(() => ({})),
+  loadKeypair: vi.fn(() => ({ publicKey: { toBase58: () => "11111111111111111111111111111111", equals: () => false }, secretKey: new Uint8Array(64) })),
+  sendWithRetry: vi.fn(),
+  sendWithRetryKeeper: vi.fn(),
+  pollSignatureStatus: vi.fn(),
+  getRecentPriorityFees: vi.fn(async () => ({ priorityFeeMicroLamports: 5000, computeUnitLimit: 200000 })),
+  checkTransactionSize: vi.fn(),
+  eventBus: { publish: vi.fn() },
+  acquireToken: vi.fn(async () => {}),
+  getFallbackConnection: vi.fn(() => ({})),
+  backoffMs: vi.fn(() => 100),
+  getErrorMessage: vi.fn((err: unknown) => (err instanceof Error ? err.message : String(err))),
+}));
+
+vi.mock("../../src/lib/keeper-send.js", async () => {
+  const { KeeperBudget } = await vi.importActual<typeof import("../../src/lib/budget.js")>("../../src/lib/budget.js");
+  return { keeperSend: vi.fn(async () => ({ signature: "sig", estimatedCost: 5000 })), sharedBudget: new KeeperBudget() };
+});
+
+import { LiquidationService, parseMinLiqNotional } from "../../src/services/liquidation.js";
+import * as core from "@percolatorct/sdk";
+import * as keeperSendModule from "../../src/lib/keeper-send.js";
+
+function zeroKey() {
+  return { toBase58: () => "11111111111111111111111111111111", toBytes: () => new Uint8Array(32), equals: () => false };
+}
+
+// Price $1 (1e6). At $1, notional (6-decimal USD units) == positionSize.
+const mkAccount = (over: Record<string, unknown>) => ({
+  kind: 0,
+  owner: { toBase58: () => "Owner11111111111111111111111111111111111" },
+  positionSize: 0n,
+  capital: 0n,
+  pnl: 0n,
+  ...over,
+});
+const DUST = mkAccount({ positionSize: 10_000n, capital: 0n });        // notional $0.01, underwater
+const MATERIAL = mkAccount({ positionSize: 10_000_000_000n, capital: 100_000_000n }); // $10,000, ~1% margin
+
+function market() {
+  return {
+    slabAddress: { toBase58: () => "Market111111111111111111111111111111111" },
+    programId: { toBase58: () => "Program11111111111111111111111111111111" },
+    config: { indexFeedId: { toBytes: () => new Uint8Array(32) } },
+  } as any;
+}
+
+describe("liquidation min-notional floor", () => {
+  let svc: LiquidationService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svc = new LiquidationService({ fetchPrice: vi.fn() } as any, 15000);
+    vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+    vi.mocked(core.parseEngine).mockReturnValue({ totalOpenInterest: 100_000_000n } as any);
+    vi.mocked(core.parseParams).mockReturnValue({ maintenanceMarginBps: 500n } as any); // 5%
+    vi.mocked(core.parseConfig).mockReturnValue({
+      oracleAuthority: zeroKey(),
+      indexFeedId: zeroKey(), // Hyperp mode
+      authorityPriceE6: 1_000_000n,
+      lastEffectivePriceE6: 1_000_000n,
+      authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
+    } as any);
+    vi.mocked(core.detectLayout).mockReturnValue({ accountsOffset: 0 } as any);
+  });
+
+  afterEach(() => svc.stop());
+
+  describe("parseMinLiqNotional", () => {
+    it("defaults to $1 (1_000_000n) on missing/empty input", () => {
+      expect(parseMinLiqNotional(undefined)).toBe(1_000_000n);
+      expect(parseMinLiqNotional("")).toBe(1_000_000n);
+      expect(parseMinLiqNotional("   ")).toBe(1_000_000n);
+    });
+    it("parses a valid non-negative integer", () => {
+      expect(parseMinLiqNotional("5000000")).toBe(5_000_000n);
+      expect(parseMinLiqNotional("0")).toBe(0n); // explicit disable
+    });
+    it("falls back to default on invalid / negative input", () => {
+      expect(parseMinLiqNotional("abc")).toBe(1_000_000n);
+      expect(parseMinLiqNotional("1.5")).toBe(1_000_000n);
+      expect(parseMinLiqNotional("-100")).toBe(1_000_000n);
+    });
+  });
+
+  describe("scanMarket", () => {
+    it("skips a dust-notional position and keeps a material one", async () => {
+      vi.mocked(core.parseUsedIndices).mockReturnValue([0, 1]);
+      vi.mocked(core.parseAccount).mockImplementation((_d: any, i: number) => (i === 0 ? { ...DUST } : { ...MATERIAL }) as any);
+
+      const candidates = await svc.scanMarket(market());
+
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]!.accountIdx).toBe(1); // material kept, dust (idx 0) skipped
+    });
+
+    it("keeps a position exactly at the floor, skips one just below", async () => {
+      // notional == positionSize at $1. Floor is $1 == 1_000_000n. Both underwater.
+      vi.mocked(core.parseUsedIndices).mockReturnValue([0, 1]);
+      vi.mocked(core.parseAccount).mockImplementation((_d: any, i: number) =>
+        (i === 0 ? mkAccount({ positionSize: 999_999n }) : mkAccount({ positionSize: 1_000_000n })) as any);
+
+      const candidates = await svc.scanMarket(market());
+
+      expect(candidates.map((c) => c.accountIdx)).toEqual([1]); // exactly-at-floor kept; below skipped
+    });
+  });
+
+  describe("liquidate pre-submit floor", () => {
+    it("aborts (returns null, no send) when the fresh notional is below the floor", async () => {
+      // The pre-submit re-check re-parses fresh state; make it dust.
+      vi.mocked(core.parseUsedIndices).mockReturnValue([0]);
+      vi.mocked(core.parseAccount).mockReturnValue({ ...DUST } as any);
+
+      const result = await svc.liquidate(market(), 0);
+
+      expect(result).toBeNull();
+      expect(keeperSendModule.keeperSend).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The liquidation scanner has no minimum-notional floor: `scanMarket()` flags **any** account with `marginRatioBps < maintenanceMarginBps` and `notional > 0n` as a candidate, and the pre-submit re-check applies the same test. The keeper liquidates as a permissionless cranker and earns **no** liquidation fee (the on-chain penalty is charged to the liquidated trader and goes to the protocol, not the keeper), so every liquidation is a pure cost — a crank+`LiquidateAtOracle` tx paying a Jito tip (default 200,000 lamports) plus fees. So the keeper spends real SOL liquidating dust worth less than the fee, and — because the program allows dust deposits (no per-deposit minimum) — an attacker can open many tiny undercollateralized positions across many owner accounts (bypassing the per-owner cap) to drain the wallet up to the budget caps, at which point the budget breaker halts the keeper entirely.

## Fix

Add a configurable minimum-notional floor (`KEEPER_MIN_LIQ_NOTIONAL`, default **$1**) and skip candidates below it in **both** `scanMarket()` and the pre-submit re-check in `liquidate()` — so a position that slips through the scan, or the event-driven path that calls `liquidate()` directly, is still floored before paying a fee.

### Why a single flat floor is decimal-correct

`notional = abs(positionSize) * priceE6 / 1e6`. `POS_SCALE` is a fixed `1_000_000` (program spec) and `priceE6` is a USD price scaled by `1e6`, so `notional` is denominated in a **fixed 6-decimal USD quote unit** (`1_000_000n == $1`) for every market — the collateral mint's token decimals (SOL 9, wBTC 8, …) do **not** enter it. So one USD-denominated floor is correct across all markets; no per-mint configuration is needed.

The default ($1) is ~10–20× the per-liquidation fee yet far below any economically meaningful position. The dangerous failure mode for a floor is "too high → skip a real liquidation", so the default is deliberately conservative; operators tune via `KEEPER_MIN_LIQ_NOTIONAL` (raw 6-decimal-USD units) and can set it to `0` to disable.

### Residual exposure

Sub-floor positions are left unliquidated, but the residual bad debt per position is immaterial (< the floor) and is backstopped by the insurance fund / ADL. Parking aggregate exposure under the floor is uneconomic for an attacker (each dust position costs on-chain rent + fees + forfeited collateral to open, while the keeper pays nothing to skip). A new metric, `keeper_liquidation_skipped_dust_total` (labelled by stage `scan`|`presubmit`), surfaces dust-spam activity so operators can watch aggregate skipped exposure rather than relying on an automated cap (which an attacker could weaponize into a halt).

## Tests

Adds a regression test: a dust ($0.01) position is skipped while a material ($10,000) one is kept; a position exactly at the floor is kept and one just below is skipped; the pre-submit path aborts (returns `null`, no send) on a sub-floor fresh notional. Plus parser unit tests for `KEEPER_MIN_LIQ_NOTIONAL` (default / valid / invalid / negative / explicit-zero). Existing `scanMarket`/`liquidate` tests use $10,000 positions and are unaffected.

Full suite: 694 passing, 25 skipped; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Liquidations below a configurable minimum notional threshold (default $1 USD) are now automatically filtered out during market scanning and pre-submit validation stages.

* **Chores**
  * Added monitoring metrics to track skipped liquidations due to notional floor enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->