### PR TITLE
fix(oracle): resolve Chainlink oracle accounts by owner instead of always deriving a Pyth PDA

### DIFF
--- a/src/lib/oracle-account.ts
+++ b/src/lib/oracle-account.ts
@@ -1,0 +1,94 @@
+import { PublicKey } from "@solana/web3.js";
+import type { Connection } from "@solana/web3.js";
+import { derivePythPushOraclePDA } from "@percolatorct/sdk";
+import { createLogger } from "@percolatorct/shared";
+
+const logger = createLogger("keeper:oracle-account");
+
+/**
+ * Chainlink OCR2 Store program id.
+ *
+ * The on-chain program (percolator-prog `read_engine_price_e6`) detects the
+ * oracle type by the supplied oracle account's OWNER — PYTH_RECEIVER → Pyth,
+ * CHAINLINK_OCR2 → Chainlink — and for a Chainlink market `index_feed_id` IS the
+ * aggregator account pubkey (the program checks `price_ai.key == index_feed_id`).
+ * The SDK does not export this constant, so it is pinned here against the
+ * program's `CHAINLINK_OCR2_PROGRAM_ID` (percolator.rs). A unit test asserts the
+ * literal so a drift is caught loudly.
+ */
+export const CHAINLINK_OCR2_PROGRAM_ID = new PublicKey(
+  "HEvSKofvBgfaexv23kMabbYqxasxU3mQ4ibBMEmJWHny",
+);
+
+/** Minimal feed shape — compatible with a real PublicKey and parsed-config mocks. */
+interface FeedLike {
+  toBytes(): Uint8Array;
+  toBase58(): string;
+}
+
+type OracleKind = "chainlink" | "pyth";
+
+/** feed pubkey (base58) → resolved oracle kind. The owner of a feed account is
+ *  fixed at InitMarket, so this is cached for the process lifetime; only
+ *  positively-resolved verdicts are cached (a failed lookup is retried). */
+const ownerCache = new Map<string, OracleKind>();
+
+/** Test hook: drop cached verdicts so the next resolve re-fetches. */
+export function _resetOracleAccountCache(): void {
+  ownerCache.clear();
+}
+
+function pythPushPda(feedBytes: Uint8Array): PublicKey {
+  const feedHex = Array.from(feedBytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return derivePythPushOraclePDA(feedHex)[0];
+}
+
+/**
+ * Resolve the oracle account to pass on-chain for a market that uses an EXTERNAL
+ * pinned feed (i.e. non-HYPERP, non-admin: `index_feed_id != 0`). Callers must
+ * have already handled HYPERP / admin-oracle (both → slab); this only
+ * distinguishes Pyth from Chainlink, which is indistinguishable from config
+ * alone and so requires the on-chain account owner:
+ *
+ *   - owner == CHAINLINK_OCR2  → the oracle account IS `index_feed_id` (the aggregator)
+ *   - otherwise / null / error → derive the Pyth Push PDA (pre-fix behavior)
+ *
+ * The Pyth-derive default makes this a strict correctness superset of the old
+ * code: a Pyth market is byte-for-byte unchanged, a flaky lookup never makes a
+ * working market worse, and a confirmed Chainlink owner routes correctly. A
+ * confirmed verdict is cached; an inconclusive/errored lookup is NOT cached, so
+ * a Chainlink market self-heals on the next send once the lookup succeeds.
+ */
+export async function resolveExternalOracleAccount(
+  indexFeedId: FeedLike,
+  connection: Connection,
+): Promise<PublicKey> {
+  const feedBytes = indexFeedId.toBytes();
+  const feedKey = indexFeedId.toBase58();
+
+  const cached = ownerCache.get(feedKey);
+  if (cached === "chainlink") return new PublicKey(feedBytes);
+  if (cached === "pyth") return pythPushPda(feedBytes);
+
+  try {
+    const info = await connection.getAccountInfo(new PublicKey(feedBytes));
+    const kind: OracleKind =
+      info && info.owner.equals(CHAINLINK_OCR2_PROGRAM_ID) ? "chainlink" : "pyth";
+    ownerCache.set(feedKey, kind);
+    if (kind === "chainlink") {
+      logger.info("Resolved Chainlink oracle for feed", { feed: feedKey });
+      return new PublicKey(feedBytes);
+    }
+    return pythPushPda(feedBytes);
+  } catch (err) {
+    // Inconclusive: fall back to Pyth for this send (== pre-fix behavior) but do
+    // NOT cache, so a real Chainlink market retries once the lookup recovers.
+    logger.warn("Oracle owner lookup failed — defaulting to Pyth PDA (uncached)", {
+      feed: feedKey,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return pythPushPda(feedBytes);
+  }
+}

--- a/src/services/adl.ts
+++ b/src/services/adl.ts
@@ -41,7 +41,6 @@ import {
   ACCOUNTS_EXECUTE_ADL,
   buildAccountMetas,
   buildIx,
-  derivePythPushOraclePDA,
   type DiscoveredMarket,
 } from "@percolatorct/sdk";
 import {
@@ -55,6 +54,7 @@ import type { MarketCrankState } from "./crank-types.js";
 import { recordAttempt, recordLanded, recordFailed } from "../lib/sender-metrics.js";
 import { txSentTotal, solSpentLamportsTotal, txLandTimeSeconds } from "../lib/metrics.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
+import { resolveExternalOracleAccount } from "../lib/oracle-account.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
 
 const logger = createLogger("keeper:adl");
@@ -439,10 +439,9 @@ export class AdlService {
       // Admin-oracle or HYPERP mode: oracle account is the slab itself
       oracleKey = market.slabAddress;
     } else {
-      const feedHex = Array.from(feedBytes)
-        .map((b: number) => b.toString(16).padStart(2, "0"))
-        .join("");
-      oracleKey = derivePythPushOraclePDA(feedHex)[0];
+      // External feed → resolve Pyth vs Chainlink by account owner (Chainlink
+      // markets need index_feed_id, not a derived Pyth PDA).
+      oracleKey = await resolveExternalOracleAccount(pConfig.indexFeedId, connection);
     }
 
     let sent = 0;

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -6,7 +6,6 @@ import {
   encodeUpdateHyperpMark,
   buildAccountMetas,
   buildIx,
-  derivePythPushOraclePDA,
   ACCOUNTS_KEEPER_CRANK,
   fetchSlab,
   parseHeader,
@@ -31,6 +30,7 @@ import {
 } from "../lib/metrics.js";
 import type { AccountLoader } from "../lib/account-loader.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
+import { resolveExternalOracleAccount } from "../lib/oracle-account.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
 
 const logger = createLogger("keeper:crank");
@@ -855,9 +855,10 @@ export class CrankService {
       if (this.isAdminOracle(market)) {
         oracleKey = market.slabAddress;
       } else {
-        const feedHex = Array.from(market.config.indexFeedId.toBytes())
-          .map(b => b.toString(16).padStart(2, "0")).join("");
-        oracleKey = derivePythPushOraclePDA(feedHex)[0];
+        // Pyth vs Chainlink is indistinguishable from config; resolve by the
+        // on-chain account owner so Chainlink markets get index_feed_id (the
+        // aggregator) instead of a wrong derived Pyth PDA.
+        oracleKey = await resolveExternalOracleAccount(market.config.indexFeedId, connection);
       }
 
       const crankKeys = buildAccountMetas(ACCOUNTS_KEEPER_CRANK, [

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -13,7 +13,6 @@ import {
   encodeKeeperCrank,
   ACCOUNTS_LIQUIDATE_AT_ORACLE,
   ACCOUNTS_KEEPER_CRANK,
-  derivePythPushOraclePDA,
   type DiscoveredMarket,
 } from "@percolatorct/sdk";
 import { config, getConnection, loadKeypair, sendWithRetry, pollSignatureStatus, getRecentPriorityFees, checkTransactionSize, eventBus, createLogger, sendWarningAlert, acquireToken, getFallbackConnection, backoffMs, getErrorMessage } from "@percolatorct/shared";
@@ -27,6 +26,7 @@ import {
 } from "../lib/metrics.js";
 import type { AccountLoader } from "../lib/account-loader.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
+import { resolveExternalOracleAccount } from "../lib/oracle-account.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
 import { AlertAggregator } from "../lib/alert-aggregator.js";
 
@@ -389,9 +389,12 @@ export class LiquidationService {
 
       // Determine oracle account for crank/liquidate
       const feedIdBytes = market.config.indexFeedId.toBytes();
-      const feedHex = Array.from(feedIdBytes).map(b => b.toString(16).padStart(2, "0")).join("");
-      const isAllZeros = feedHex === "0".repeat(64);
-      const oracleAccount = isAllZeros ? slabAddress : derivePythPushOraclePDA(feedHex)[0];
+      const isAllZeros = feedIdBytes.every((b) => b === 0);
+      // HYPERP → slab; external feed → resolve Pyth vs Chainlink by account owner
+      // (Chainlink markets need index_feed_id, not a derived Pyth PDA).
+      const oracleAccount = isAllZeros
+        ? slabAddress
+        : await resolveExternalOracleAccount(market.config.indexFeedId, connection);
 
       // 1. Crank (make sure engine state is fresh)
       const crankData = encodeKeeperCrank({ callerIdx: 65535 });

--- a/tests/lib/oracle-account.test.ts
+++ b/tests/lib/oracle-account.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+
+const PYTH_PDA = PublicKey.unique();
+
+vi.mock("@percolatorct/sdk", () => ({
+  derivePythPushOraclePDA: vi.fn(() => [PYTH_PDA, 0]),
+}));
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+}));
+
+import {
+  resolveExternalOracleAccount,
+  CHAINLINK_OCR2_PROGRAM_ID,
+  _resetOracleAccountCache,
+} from "../../src/lib/oracle-account.js";
+
+const FEED = new PublicKey("Cv4T27XbjVoKUYwP72NQQanvZeA7W4YF9L4EnYT9kx5o"); // Chainlink aggregator / Pyth feed id
+const OTHER_OWNER = PublicKey.unique();
+
+/** Build a fake Connection whose getAccountInfo is a spy with the given behavior. */
+function fakeConn(getAccountInfo: any) {
+  return { getAccountInfo } as any;
+}
+
+describe("resolveExternalOracleAccount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetOracleAccountCache();
+  });
+
+  it("pins to the program's CHAINLINK_OCR2 program id", () => {
+    expect(CHAINLINK_OCR2_PROGRAM_ID.toBase58()).toBe("HEvSKofvBgfaexv23kMabbYqxasxU3mQ4ibBMEmJWHny");
+  });
+
+  it("Chainlink owner → returns index_feed_id (the aggregator account)", async () => {
+    const conn = fakeConn(vi.fn(async () => ({ owner: CHAINLINK_OCR2_PROGRAM_ID, data: new Uint8Array(0) })));
+    const acct = await resolveExternalOracleAccount(FEED, conn);
+    expect(acct.toBase58()).toBe(FEED.toBase58());
+  });
+
+  it("null account (a Pyth feed id is not an account) → derives the Pyth Push PDA", async () => {
+    const conn = fakeConn(vi.fn(async () => null));
+    const acct = await resolveExternalOracleAccount(FEED, conn);
+    expect(acct.toBase58()).toBe(PYTH_PDA.toBase58());
+  });
+
+  it("some unrelated owner → derives the Pyth Push PDA (safe default)", async () => {
+    const conn = fakeConn(vi.fn(async () => ({ owner: OTHER_OWNER, data: new Uint8Array(0) })));
+    const acct = await resolveExternalOracleAccount(FEED, conn);
+    expect(acct.toBase58()).toBe(PYTH_PDA.toBase58());
+  });
+
+  it("caches a positive verdict — getAccountInfo is called once across repeated resolves", async () => {
+    const spy = vi.fn(async () => ({ owner: CHAINLINK_OCR2_PROGRAM_ID, data: new Uint8Array(0) }));
+    const conn = fakeConn(spy);
+    await resolveExternalOracleAccount(FEED, conn);
+    await resolveExternalOracleAccount(FEED, conn);
+    await resolveExternalOracleAccount(FEED, conn);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("RPC error → falls back to Pyth PDA and does NOT cache (self-heals on retry)", async () => {
+    let call = 0;
+    const conn = fakeConn(vi.fn(async () => {
+      call++;
+      if (call === 1) throw new Error("RPC down");
+      return { owner: CHAINLINK_OCR2_PROGRAM_ID, data: new Uint8Array(0) };
+    }));
+
+    const first = await resolveExternalOracleAccount(FEED, conn);
+    expect(first.toBase58()).toBe(PYTH_PDA.toBase58()); // fallback
+
+    // The failure was not cached: the next resolve re-fetches and now sees Chainlink.
+    const second = await resolveExternalOracleAccount(FEED, conn);
+    expect(second.toBase58()).toBe(FEED.toBase58());
+  });
+});

--- a/tests/services/adl.test.ts
+++ b/tests/services/adl.test.ts
@@ -32,7 +32,7 @@ vi.mock("@percolatorct/sdk", () => ({
 }));
 
 vi.mock("@percolatorct/shared", () => ({
-  getConnection: vi.fn(() => ({})),
+  getConnection: vi.fn(() => ({ getAccountInfo: vi.fn(async () => null) })),
   loadKeypair: vi.fn(() => ({
     publicKey: {
       toBase58: () => "keeperPubkey1111111111111111111111111111111",
@@ -262,12 +262,13 @@ describe("AdlService", () => {
       expect(callArgs[1][3]).toBe(slabKey);
     });
 
-    it("derives Pyth oracle PDA for non-zero indexFeedId", async () => {
+    it("derives Pyth oracle PDA for a non-zero indexFeedId whose feed account is not Chainlink-owned", async () => {
+      // getAccountInfo returns null (a Pyth feed id is not an account) → Pyth PDA.
       const nonZeroFeed = new Uint8Array(32);
       nonZeroFeed[0] = 0xab;
       vi.mocked(sdk.parseConfig).mockReturnValue(makeConfig({
         maxPnlCap: 500_000n,
-        indexFeedId: { toBytes: () => nonZeroFeed },
+        indexFeedId: { toBytes: () => nonZeroFeed, toBase58: () => "FeedNonZeroPyth111111111111111111111111111" },
       }) as any);
 
       await service.scanMarket(slabAddress, makeMarket() as any);

--- a/tests/services/chainlink-oracle-account.test.ts
+++ b/tests/services/chainlink-oracle-account.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression test for the Chainlink oracle-account bug (end-to-end through liquidate()).
+ *
+ * The program dispatches read_engine_price_e6 on the oracle account's OWNER. For
+ * a Chainlink market, config.index_feed_id IS the aggregator account pubkey; for
+ * a Pyth market, index_feed_id is a feed id and the oracle account is the derived
+ * Pyth Push PDA. The keeper previously derived a Pyth PDA for ALL non-HYPERP
+ * markets, so Chainlink markets got the wrong account and reverted permanently.
+ *
+ * The fix resolves the oracle account by inspecting the owner of the account at
+ * index_feed_id. These tests drive the real liquidate() and capture the oracle
+ * account passed into the LiquidateAtOracle instruction:
+ *   - Chainlink-owned feed account  -> oracle account == index_feed_id (aggregator)
+ *   - feed id is not an account (null) -> oracle account == derived Pyth Push PDA
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+
+const CHAINLINK_OCR2 = new PublicKey("HEvSKofvBgfaexv23kMabbYqxasxU3mQ4ibBMEmJWHny");
+const AGGREGATOR = new PublicKey("Cv4T27XbjVoKUYwP72NQQanvZeA7W4YF9L4EnYT9kx5o");
+const PYTH_PDA = PublicKey.unique();
+
+const captured: PublicKey[] = [];
+// Controllable owner-lookup result for the account at index_feed_id.
+const h = vi.hoisted(() => ({ getAccountInfo: vi.fn() }));
+
+vi.mock("@solana/web3.js", async () => {
+  const actual = await vi.importActual("@solana/web3.js");
+  return {
+    ...actual,
+    SYSVAR_CLOCK_PUBKEY: { toBase58: () => "SysvarC1ock11111111111111111111111111111111", equals: () => false },
+  };
+});
+
+vi.mock("@percolatorct/sdk", () => ({
+  fetchSlab: vi.fn(async () => new Uint8Array(1024)),
+  parseConfig: vi.fn(),
+  parseEngine: vi.fn(),
+  parseParams: vi.fn(),
+  parseAccount: vi.fn(),
+  parseUsedIndices: vi.fn(),
+  detectLayout: vi.fn(),
+  buildAccountMetas: vi.fn((_accounts: unknown, keys: PublicKey[]) => {
+    captured.push(keys[3]!); // [signer, slab, clock, ORACLE]
+    return [];
+  }),
+  buildIx: vi.fn(() => ({})),
+  encodeLiquidateAtOracle: vi.fn(() => Buffer.from([1])),
+  encodeKeeperCrank: vi.fn(() => Buffer.from([2])),
+  derivePythPushOraclePDA: vi.fn(() => [PYTH_PDA, 0]),
+  ACCOUNTS_LIQUIDATE_AT_ORACLE: {},
+  ACCOUNTS_KEEPER_CRANK: {},
+}));
+
+vi.mock("@percolatorct/shared", () => ({
+  config: { crankKeypair: "mock-keypair-path" },
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  sendWarningAlert: vi.fn(),
+  getConnection: vi.fn(() => ({ getAccountInfo: h.getAccountInfo })),
+  loadKeypair: vi.fn(() => ({ publicKey: { toBase58: () => "11111111111111111111111111111111", equals: () => false }, secretKey: new Uint8Array(64) })),
+  sendWithRetry: vi.fn(),
+  sendWithRetryKeeper: vi.fn(),
+  pollSignatureStatus: vi.fn(),
+  getRecentPriorityFees: vi.fn(async () => ({ priorityFeeMicroLamports: 5000, computeUnitLimit: 200000 })),
+  checkTransactionSize: vi.fn(),
+  eventBus: { publish: vi.fn() },
+  acquireToken: vi.fn(async () => {}),
+  getFallbackConnection: vi.fn(() => ({ getAccountInfo: h.getAccountInfo })),
+  backoffMs: vi.fn(() => 100),
+  getErrorMessage: vi.fn((err: unknown) => (err instanceof Error ? err.message : String(err))),
+}));
+
+vi.mock("../../src/lib/keeper-send.js", async () => {
+  const { KeeperBudget } = await vi.importActual<typeof import("../../src/lib/budget.js")>("../../src/lib/budget.js");
+  return { keeperSend: vi.fn(async () => ({ signature: "sig", estimatedCost: 5000 })), sharedBudget: new KeeperBudget() };
+});
+
+import { LiquidationService } from "../../src/services/liquidation.js";
+import { _resetOracleAccountCache } from "../../src/lib/oracle-account.js";
+import * as core from "@percolatorct/sdk";
+
+/** A non-HYPERP market: index_feed_id != 0 (== the aggregator), oracle_authority == 0. */
+function externalFeedMarket() {
+  return {
+    slabAddress: { toBase58: () => "Market111111111111111111111111111111111", toBytes: () => new Uint8Array(32) },
+    programId: { toBase58: () => "Program11111111111111111111111111111111" },
+    config: {
+      indexFeedId: { toBytes: () => AGGREGATOR.toBytes(), toBase58: () => AGGREGATOR.toBase58(), equals: () => false },
+      oracleAuthority: { toBase58: () => "11111111111111111111111111111111", toBytes: () => new Uint8Array(32), equals: () => true },
+    },
+  } as any;
+}
+
+describe("Chainlink oracle-account resolution (liquidate)", () => {
+  let svc: LiquidationService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captured.length = 0;
+    _resetOracleAccountCache();
+    svc = new LiquidationService({ fetchPrice: vi.fn() } as any, 15000);
+    vi.mocked(core.parseEngine).mockReturnValue({ totalOpenInterest: 0n } as any);
+    vi.mocked(core.parseParams).mockReturnValue({ maintenanceMarginBps: 500n } as any);
+    vi.mocked(core.parseConfig).mockReturnValue({
+      oracleAuthority: { equals: () => true, toBytes: () => new Uint8Array(32) },
+      indexFeedId: { equals: () => false, toBytes: () => AGGREGATOR.toBytes() },
+      authorityPriceE6: 0n, lastEffectivePriceE6: 1_000_000n, authorityTimestamp: 0n,
+    } as any);
+    vi.mocked(core.parseUsedIndices).mockReturnValue([0]);
+    vi.mocked(core.parseAccount).mockReturnValue({ kind: 0, owner: { toBase58: () => "U" }, positionSize: 1n, capital: 0n, pnl: 0n } as any);
+    vi.mocked(core.detectLayout).mockReturnValue({ accountsOffset: 0 } as any);
+  });
+
+  afterEach(() => svc.stop());
+
+  it("Chainlink market → passes index_feed_id (the aggregator) as the oracle account", async () => {
+    h.getAccountInfo.mockResolvedValue({ owner: CHAINLINK_OCR2, data: new Uint8Array(0) });
+
+    await svc.liquidate(externalFeedMarket(), 0).catch(() => null);
+
+    expect(captured.length).toBeGreaterThan(0);
+    for (const acct of captured) {
+      expect(acct.toBase58()).toBe(AGGREGATOR.toBase58());
+    }
+  });
+
+  it("Pyth market (feed id is not an account) → derives the Pyth Push PDA", async () => {
+    h.getAccountInfo.mockResolvedValue(null);
+
+    await svc.liquidate(externalFeedMarket(), 0).catch(() => null);
+
+    expect(captured.length).toBeGreaterThan(0);
+    for (const acct of captured) {
+      expect(acct.toBase58()).toBe(PYTH_PDA.toBase58());
+    }
+  });
+});

--- a/tests/services/crank-error-code.poc.test.ts
+++ b/tests/services/crank-error-code.poc.test.ts
@@ -31,8 +31,8 @@ vi.mock("@percolatorct/sdk", () => ({
 vi.mock("@percolatorct/shared", () => ({
   config: { crankIntervalMs: 30000, crankInactiveIntervalMs: 120000, discoveryIntervalMs: 300000, allProgramIds: ["11111111111111111111111111111111"], crankKeypair: "mock" },
   createLogger: () => h.logger, // singleton so we can assert on the module logger
-  getConnection: () => ({}),
-  getFallbackConnection: () => ({}),
+  getConnection: () => ({ getAccountInfo: vi.fn(async () => null) }),
+  getFallbackConnection: () => ({ getAccountInfo: vi.fn(async () => null) }),
   loadKeypair: () => ({ publicKey: { toBase58: () => "11111111111111111111111111111111", equals: () => false } }),
   sendWithRetryKeeper: vi.fn(),
   eventBus: { publish: vi.fn() },
@@ -56,7 +56,7 @@ function nonHyperpMarket(slab: string) {
     programId: { toBase58: () => "11111111111111111111111111111111" },
     config: {
       collateralMint: { toBase58: () => "Mint1111111111111111111111111111111111" },
-      indexFeedId: { toBytes: () => feed, equals: () => false },
+      indexFeedId: { toBytes: () => feed, toBase58: () => "FeedNonZero11111111111111111111111111111111", equals: () => false },
       oracleAuthority: { toBase58: () => "11111111111111111111111111111111", equals: () => true },
     },
     params: { maintenanceMarginBps: 500n },


### PR DESCRIPTION
## Summary

The keeper had no oracle-type discriminator for non-HYPERP markets: crank, liquidation, and ADL all derived a Pyth Push PDA for the oracle account. For a **Chainlink**-oracle market this is the wrong account, so every crank, liquidation, and ADL on that market reverts on-chain and the market is never serviced — it stales, accrues consecutive failures, and is eventually paused/evicted.

## Root cause

The program (`percolator.rs` `read_engine_price_e6`) detects the oracle type by the supplied oracle account's **owner** — `PYTH_RECEIVER_PROGRAM_ID` → Pyth, `CHAINLINK_OCR2_PROGRAM_ID` → Chainlink, else `IllegalOwner`. For Chainlink, `config.index_feed_id` **is** the aggregator account pubkey (the program checks `price_ai.key == index_feed_id`); for Pyth, `index_feed_id` is the feed id and the oracle account is the derived Pyth Push PDA. The two are indistinguishable from config alone (both `index_feed_id != 0`, post-Phase-G `oracle_authority == 0`).

The keeper derived a Pyth PDA for every non-HYPERP market (`crank.ts`, `liquidation.ts`, `adl.ts`), so a Chainlink market got an account owned by neither program with key ≠ `index_feed_id` → `IllegalOwner`/`InvalidOracleKey` → permanent revert. Chainlink is a supported, deployable oracle (`CHAINLINK_OCR2_PROGRAM_ID` is a real mainnet program; `InitMarket` reads through the same dispatch).

## Fix

Add a shared resolver, `src/lib/oracle-account.ts`, that distinguishes Pyth from Chainlink by the **on-chain owner** of the account at `index_feed_id`, cached per feed (the owner is fixed at `InitMarket`):

- owner == `CHAINLINK_OCR2` → oracle account = `index_feed_id` (the aggregator)
- otherwise / null / RPC error → derive the Pyth Push PDA (pre-fix behavior)

This is a **strict correctness superset** of the old code: a Pyth market is byte-for-byte unchanged; a flaky owner lookup never makes a working market worse; a confirmed Chainlink owner routes correctly. A confirmed verdict is cached (no per-send RPC); an inconclusive/errored lookup is **not** cached, so a Chainlink market self-heals on the next send once the lookup succeeds.

The three services keep their existing **HYPERP / admin pre-checks (→ slab) unchanged** and call the resolver only in the external-feed branch — so HYPERP and Pyth behavior is provably unchanged and the Pyth-vs-Chainlink logic lives in exactly one place (eliminating the three-way drift that caused the bug). `CHAINLINK_OCR2_PROGRAM_ID` is pinned locally (the SDK does not export it) with a unit test asserting the literal.

## Tests

- `tests/lib/oracle-account.test.ts` — resolver unit tests: Chainlink owner → `index_feed_id`; null/unrelated owner → Pyth PDA; positive verdict cached (one `getAccountInfo` across repeated resolves); RPC error → Pyth fallback **not** cached (self-heals on retry); the pinned program-id literal.
- `tests/services/chainlink-oracle-account.test.ts` — end-to-end through `liquidate()`: a Chainlink market passes `index_feed_id` (the aggregator) into the `LiquidateAtOracle` instruction; a Pyth market (feed id is not an account) derives the Pyth Push PDA.
- Updated two existing test mocks (`adl`, `crank-error-code`) to provide the feed's `toBase58` + a `getAccountInfo` the resolver now consults.

Full suite: 696 passing, 25 skipped; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic oracle provider detection for market operations, enabling seamless handling across different oracle types
* **Tests**
  * Introduced comprehensive test coverage for oracle account resolution and market compatibility scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->