### PR TITLE
fix(liquidation): make the scan overlap guard single-flight (watchdog no longer spawns concurrent scans)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -182,9 +182,16 @@ export class LiquidationService {
   private liquidationCount = 0;
   private scanCount = 0;
   private lastScanTime = 0;
-  // Overlap guard: prevent concurrent scan cycles from interleaving
-  private _scanning = false;
-  private _scanStartedAt = 0;
+  // Overlap guard: the in-flight scan promise (null ⇒ no scan running). A new
+  // cycle starts only when this is null — i.e. the previous scan has SETTLED.
+  // We never force-clear it: a JS promise can't be cancelled, so clearing the
+  // guard while a scan is still awaiting its RPCs would only start a second
+  // scan concurrently (duplicate liquidations against the same accounts). A
+  // genuinely hung cycle therefore stops new scans; lastScanTime stops
+  // advancing, which the index.ts stall alert (3min) and /health "down" (5min →
+  // supervisor restart) already act on.
+  private _inFlight: Promise<void> | null = null;
+  private _scanStartedAt = 0; // start of the in-flight scan — for the watchdog WARN log only
   // BC1: Signature replay protection
   private recentSignatures = new Map<string, number>(); // signature -> timestamp
   private readonly signatureTTLMs = 60_000; // 60 seconds
@@ -665,49 +672,65 @@ export class LiquidationService {
 
     const MAX_SCAN_MS = this.intervalMs * 5;
 
-    const runCycle = async () => {
-      if (this._scanning) {
+    const runCycle = (): void => {
+      // Single-flight: never start a second scan while one is in flight. The
+      // watchdog only WARNs on an over-long cycle — it must NOT force-reset the
+      // guard, because clearing it cannot cancel the in-flight RPCs and would
+      // only spawn a concurrent scan. A hung cycle stops new scans; recovery is
+      // driven by the existing stall alert / health-down → restart path.
+      if (this._inFlight) {
         const elapsed = Date.now() - this._scanStartedAt;
         if (elapsed > MAX_SCAN_MS) {
-          logger.error("Liquidation scan watchdog: cycle exceeded max duration, force-resetting", {
+          logger.warn("Liquidation scan still in flight past max duration — not starting a concurrent scan", {
             elapsedMs: elapsed,
             maxScanMs: MAX_SCAN_MS,
           });
-          this._scanning = false;
         }
         return;
       }
-      this._scanning = true;
+
       this._scanStartedAt = Date.now();
-      try {
-        const marketsSnapshot = new Map(getMarkets());
-        const result = await this.scanAndLiquidateAll(marketsSnapshot);
-        this.consecutiveFailures = 0; // Reset on success
-        if (result.candidates > 0) {
-          logger.info("Liquidation scan complete", {
-            scanned: result.scanned,
-            candidates: result.candidates,
-            liquidated: result.liquidated
+      const scan = (async () => {
+        try {
+          const marketsSnapshot = new Map(getMarkets());
+          const result = await this.scanAndLiquidateAll(marketsSnapshot);
+          this.consecutiveFailures = 0; // Reset on success
+          if (result.candidates > 0) {
+            logger.info("Liquidation scan complete", {
+              scanned: result.scanned,
+              candidates: result.candidates,
+              liquidated: result.liquidated,
+            });
+          }
+        } catch (err) {
+          this.consecutiveFailures++;
+          const backoff = Math.min(
+            this.intervalMs * Math.pow(2, this.consecutiveFailures - 1),
+            this.maxBackoffMs,
+          );
+          logger.error("Liquidation cycle failed", {
+            error: err instanceof Error ? err.message : String(err),
+            consecutiveFailures: this.consecutiveFailures,
+            nextRetryMs: Math.round(backoff),
           });
+          // Schedule a delayed retry instead of waiting for the next fixed
+          // interval. Guard on this.timer so a queued retry can't start a scan
+          // after stop(); the single-flight check above prevents overlap if the
+          // regular interval tick also fires.
+          if (backoff > this.intervalMs && this.timer !== null) {
+            setTimeout(() => {
+              if (this.timer !== null) runCycle();
+            }, backoff - this.intervalMs);
+          }
         }
-      } catch (err) {
-        this.consecutiveFailures++;
-        const backoff = Math.min(
-          this.intervalMs * Math.pow(2, this.consecutiveFailures - 1),
-          this.maxBackoffMs,
-        );
-        logger.error("Liquidation cycle failed", {
-          error: err instanceof Error ? err.message : String(err),
-          consecutiveFailures: this.consecutiveFailures,
-          nextRetryMs: Math.round(backoff),
-        });
-        // Schedule delayed retry instead of waiting for next fixed interval
-        if (backoff > this.intervalMs) {
-          setTimeout(runCycle, backoff - this.intervalMs);
-        }
-      } finally {
-        this._scanning = false;
-      }
+      })();
+
+      this._inFlight = scan;
+      // Clear the guard only when THIS scan settles. The identity check makes a
+      // slow cycle unable to clobber a newer cycle's guard.
+      void scan.finally(() => {
+        if (this._inFlight === scan) this._inFlight = null;
+      });
     };
     this.timer = setInterval(runCycle, this.intervalMs);
 

--- a/tests/services/liquidation-watchdog-race.test.ts
+++ b/tests/services/liquidation-watchdog-race.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression test for the liquidation watchdog overlap race.
+ *
+ * runCycle() previously used a boolean `_scanning` guard with a watchdog that
+ * force-cleared it after MAX_SCAN_MS. Since a JS promise can't be cancelled,
+ * clearing the flag while a scan was still awaiting its RPCs let the next tick
+ * start a SECOND concurrent scanAndLiquidateAll — concurrent scans have their
+ * own per-cycle dedup, so the same account got duplicate liquidation txs.
+ *
+ * The fix tracks the in-flight scan as a Promise (`_inFlight`): a new cycle
+ * starts only when the previous scan has SETTLED, and the watchdog only WARNs
+ * (never force-clears). A genuinely hung cycle therefore stops new scans and
+ * lastScanTime stalls, which the index.ts stall alert / health-down path acts on.
+ *
+ * These tests drive the real start()/runCycle with fake timers.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@solana/web3.js", async () => ({ ...(await vi.importActual("@solana/web3.js")) }));
+vi.mock("@percolatorct/sdk", () => ({
+  fetchSlab: vi.fn(), parseConfig: vi.fn(), parseEngine: vi.fn(), parseParams: vi.fn(),
+  parseAccount: vi.fn(), parseUsedIndices: vi.fn(), detectLayout: vi.fn(),
+  buildAccountMetas: vi.fn(() => []), buildIx: vi.fn(() => ({})),
+  encodeLiquidateAtOracle: vi.fn(() => Buffer.from([1])), encodeKeeperCrank: vi.fn(() => Buffer.from([2])),
+  derivePythPushOraclePDA: vi.fn(() => [{ toBase58: () => "Oracle1" }, 0]),
+  ACCOUNTS_LIQUIDATE_AT_ORACLE: {}, ACCOUNTS_KEEPER_CRANK: {},
+}));
+vi.mock("@percolatorct/shared", () => ({
+  config: { crankKeypair: "mock" },
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  sendWarningAlert: vi.fn(), getConnection: vi.fn(() => ({})), getFallbackConnection: vi.fn(() => ({})),
+  loadKeypair: vi.fn(() => ({ publicKey: { toBase58: () => "11111111111111111111111111111111", equals: () => false }, secretKey: new Uint8Array(64) })),
+  sendWithRetry: vi.fn(), sendWithRetryKeeper: vi.fn(), pollSignatureStatus: vi.fn(),
+  getRecentPriorityFees: vi.fn(async () => ({ priorityFeeMicroLamports: 5000, computeUnitLimit: 200000 })),
+  checkTransactionSize: vi.fn(), eventBus: { publish: vi.fn() }, acquireToken: vi.fn(async () => {}),
+  backoffMs: vi.fn(() => 100), getErrorMessage: vi.fn((e: unknown) => (e instanceof Error ? e.message : String(e))),
+}));
+vi.mock("../../src/lib/keeper-send.js", async () => {
+  const { KeeperBudget } = await vi.importActual<typeof import("../../src/lib/budget.js")>("../../src/lib/budget.js");
+  return { keeperSend: vi.fn(), sharedBudget: new KeeperBudget() };
+});
+
+import { LiquidationService } from "../../src/services/liquidation.js";
+
+describe("liquidation watchdog single-flight guard", () => {
+  let svc: LiquidationService;
+  let release: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    svc = new LiquidationService({ fetchPrice: vi.fn() } as any, 1000); // intervalMs=1000 → MAX_SCAN_MS=5000
+  });
+
+  afterEach(() => {
+    if (release) release();
+    svc.stop();
+    vi.useRealTimers();
+  });
+
+  it("never runs two scans concurrently, even past the watchdog window", async () => {
+    let inFlight = 0;
+    let maxConcurrent = 0;
+    const blocker = new Promise<void>((r) => { release = r; });
+    const spy = vi.spyOn(svc, "scanAndLiquidateAll").mockImplementation(async () => {
+      inFlight++; maxConcurrent = Math.max(maxConcurrent, inFlight);
+      await blocker; inFlight--;
+      return { scanned: 0, candidates: 0, liquidated: 0 };
+    });
+
+    svc.start(() => new Map());
+    await vi.advanceTimersByTimeAsync(8000); // many ticks, well past MAX_SCAN_MS=5000
+
+    expect(maxConcurrent).toBe(1);
+    expect(spy).toHaveBeenCalledTimes(1); // the stuck scan blocks all later ticks
+  });
+
+  it("a hung cycle stalls lastScanTime (so the stall alert / health-down fires) instead of overlapping", async () => {
+    const blocker = new Promise<void>((r) => { release = r; });
+    vi.spyOn(svc, "scanAndLiquidateAll").mockImplementation(async () => {
+      await blocker;
+      return { scanned: 0, candidates: 0, liquidated: 0 };
+    });
+
+    svc.start(() => new Map());
+    await vi.advanceTimersByTimeAsync(8000);
+
+    // lastScanTime is only set when a scan COMPLETES; a hung scan never advances
+    // it, so index.ts (timeSinceLastScanMs) detects the stall and restarts.
+    expect(svc.getStatus().lastScanTime).toBe(0);
+  });
+
+  it("releases the guard between completed cycles (one scan per interval tick)", async () => {
+    const spy = vi.spyOn(svc, "scanAndLiquidateAll").mockResolvedValue({ scanned: 0, candidates: 0, liquidated: 0 });
+
+    svc.start(() => new Map());
+    await vi.advanceTimersByTimeAsync(3000); // 3 ticks; each scan completes immediately
+
+    expect(spy).toHaveBeenCalledTimes(3); // guard released after each settle → next tick runs
+  });
+});


### PR DESCRIPTION
## Summary

The liquidation scan's overlap guard could be defeated, letting two (or more) `scanAndLiquidateAll()` cycles run concurrently. Because each cycle resets its own per-cycle dedup state (`_cycleSeenPositions`, `_cycleOwnerCounts`), concurrent cycles independently target the same undercollateralized account and submit **duplicate liquidation transactions** — wasted priority fees / Jito tips, and on-chain reverts.

## Root cause

`runCycle()` guarded overlap with a boolean `_scanning` plus a watchdog that force-cleared it after `MAX_SCAN_MS` (= 5 × `intervalMs`):

```ts
if (this._scanning) {
  if (elapsed > MAX_SCAN_MS) { this._scanning = false; }  // (A)
  return;
}
this._scanning = true;
try { await this.scanAndLiquidateAll(...); }              // (B) still running after (A)
finally { this._scanning = false; }                       // (C)
```

A JS promise can't be cancelled, so when the watchdog cleared the flag at (A) the slow scan at (B) was **still in flight** — the next interval tick saw `_scanning === false` and started a second concurrent scan; the original cycle's `finally` at (C) then cleared the flag again, enabling a third. The watchdog, meant to recover a hung cycle, instead amplified the problem (clearing a flag doesn't stop the in-flight RPCs).

## Fix

Replace the boolean + force-reset with a single in-flight **Promise handle** (`_inFlight`):

- A new cycle starts only when `_inFlight === null` — i.e. the previous scan has **settled** — regardless of elapsed time.
- The scan clears the handle in its **own** `.finally`, identity-checked (`if (this._inFlight === scan)`), so a slow cycle can never clobber a newer one's guard.
- The check-and-set is synchronous (no `await` between them), so two timer callbacks can't both pass the guard. **Overlap is now structurally impossible.**
- The watchdog no longer force-clears anything — it only WARNs that a cycle is running long.
- The backoff retry is guarded on `this.timer !== null` so a queued retry can't start a scan after `stop()`.

### Hung-cycle recovery

A genuinely hung cycle stops new scans and `lastScanTime` stops advancing — which the **existing** infrastructure already handles: the index.ts stall alert fires at >3 min (`sendCriticalAlert`), and `/health` returns `down` (503) at >5 min, triggering a supervisor restart. So recovery is automatic, without the data race. Force-clearing the guard (or a `Promise.race` timeout that abandons the await) was rejected because neither stops the in-flight work — both just re-introduce the concurrency.

## Tests

Adds a regression test (`tests/services/liquidation-watchdog-race.test.ts`): no two scans run concurrently past the watchdog window; a hung cycle leaves `lastScanTime` unadvanced (stall stays detectable) instead of overlapping; and the guard releases between completed cycles (one scan per interval tick).

Full suite: 691 passing, 25 skipped; `tsc --noEmit` clean.

Note: the event-driven (LaserStream) liquidation path and the polling path can still overlap on the same slab — a separate, lower-severity concern (each path is guarded by signature-replay protection + on-chain rejection) that I've scoped out of this PR to keep it surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)