### PR TITLE
fix(security): enforce the program-id allow-list end-to-end (boot + MARKETS_FILTER)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { FraudDetectorService } from "./services/fraud-detector.js";
 import { validateKeeperEnvGuards } from "./env-guards.js";
 import { isMainnet } from "./config/network.js";
 import { CURRENT_NETWORK } from "./network.js";
-import { assertMainnetProgramId } from "./lib/boot-assertions.js";
+import { assertMainnetProgramId, assertProgramIdAllowList } from "./lib/boot-assertions.js";
 import { snapshotMetrics as snapshotSenderMetrics } from "./lib/sender-metrics.js";
 import { walletBalanceSol, activeMarketsCount, registerDefaultMetrics } from "./lib/metrics.js";
 import * as metricsServer from "./lib/metrics-server.js";
@@ -77,6 +77,9 @@ const keeperKeypair = loadKeypair(process.env.CRANK_KEYPAIR!);
 // On mainnet, HYPERP markets (SOL-PERP, BTC-PERP, ETH-PERP) use the keeper as oracle authority
 // and price lookups use mainnet mints directly (no mainnetCA override needed).
 assertMainnetProgramId({ isMainnet: isMainnet(), programId: config.programId });
+// Validate the full discovery/signing program set (config.allProgramIds), not
+// just the single config.programId — discovery scans and signs against every entry.
+assertProgramIdAllowList({ isMainnet: isMainnet(), allProgramIds: config.allProgramIds });
 if (isMainnet()) {
   logger.info("Running in MAINNET mode", { programId: config.programId });
 }

--- a/src/lib/boot-assertions.ts
+++ b/src/lib/boot-assertions.ts
@@ -35,3 +35,53 @@ export function assertMainnetProgramId(opts: {
       `transactions against an unintended program.`,
   );
 }
+
+/**
+ * Validate config.allProgramIds — the program set the keeper actually DISCOVERS
+ * and SIGNS against. assertMainnetProgramId() above guards only config.programId
+ * (the single id used for tx construction), but discovery scans EVERY entry of
+ * config.allProgramIds (crank.ts) and stamps each market with the scanned id,
+ * which the keeper then signs KeeperCrank/LiquidateAtOracle/UpdateHyperpMark
+ * against. allProgramIds is sourced independently from ALL_PROGRAM_IDS env, so
+ * it must be validated separately.
+ *
+ * Two failure modes, two checks:
+ *   1. Empty set — ANY network. `ALL_PROGRAM_IDS=""` (or `","`) survives the
+ *      `?? PROGRAM_ID` fallback (empty string is not nullish) and `.filter(Boolean)`
+ *      yields []. The keeper would boot "healthy" yet scan zero programs and
+ *      silently crank/liquidate nothing — a misconfig on devnet too, so we catch
+ *      it everywhere (before it can ride a release to mainnet).
+ *   2. Non-canonical entry — MAINNET only. A foreign id injected via
+ *      ALL_PROGRAM_IDS would make discovery scan, and the keeper sign against, an
+ *      unintended program with the live keeper key.
+ *
+ * Ordering matters: the non-empty check MUST come first. `[].every(...)` is
+ * vacuously true, so an empty array would otherwise pass a per-entry check and
+ * re-open failure mode 1.
+ */
+export function assertProgramIdAllowList(opts: {
+  isMainnet: boolean;
+  allProgramIds: readonly string[];
+}): void {
+  // (1) Non-empty — all networks. Checked first to avoid the .every()/.filter()
+  //     vacuous-truth trap on an empty array.
+  if (opts.allProgramIds.length === 0) {
+    throw new Error(
+      "SECURITY: ALL_PROGRAM_IDS resolved to an empty program set — the keeper " +
+        "would scan zero programs and silently crank/liquidate nothing. Refusing " +
+        "to boot. Set ALL_PROGRAM_IDS (or PROGRAM_ID) to at least one program id.",
+    );
+  }
+
+  // (2) Per-entry canonical equality — mainnet only (devnet uses its own ids).
+  if (!opts.isMainnet) return;
+  const offending = opts.allProgramIds.filter((id) => id !== MAINNET_PROGRAM_ID);
+  if (offending.length > 0) {
+    throw new Error(
+      `SECURITY: NETWORK=mainnet but ALL_PROGRAM_IDS contains non-canonical ` +
+        `program id(s) [${offending.join(", ")}] — expected every entry to be ` +
+        `${MAINNET_PROGRAM_ID}. Refusing to boot to prevent scanning/signing ` +
+        `against an unintended program.`,
+    );
+  }
+}

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -313,6 +313,10 @@ export class CrankService {
       // top of this file — drop the redundant dynamic import that used to run on every call.
       // B15: batch via getMultipleAccountsInfo with a per-call timeout on the fallback RPC.
       const conn = getFallbackConnection();
+      // Mirror registerMarket()'s owner allow-list (crank.ts: knownIds check):
+      // only track slabs owned by an allow-listed Percolator program, so the
+      // keeper never signs txs against an account owned by an arbitrary program.
+      const knownIds = new Set(config.allProgramIds);
       const pubkeys: Array<PublicKey | null> = slabAddresses.map((addr) => {
         try {
           return new PublicKey(addr);
@@ -344,6 +348,16 @@ export class CrankService {
           const info = infos[j];
           if (!info?.data) {
             logger.warn("MARKETS_FILTER: slab not found on-chain", { slab: pubkey.toBase58().slice(0, 8) });
+            continue;
+          }
+          // Reject slabs owned by a non-allow-listed program before parsing or
+          // tracking them — mirrors registerMarket. Prevents the keeper from
+          // signing crank/liquidate txs against an arbitrary (hostile) program.
+          if (!knownIds.has(info.owner.toBase58())) {
+            logger.warn("MARKETS_FILTER: slab owned by non-allow-listed program — skipping", {
+              slab: pubkey.toBase58().slice(0, 8),
+              owner: info.owner.toBase58(),
+            });
             continue;
           }
           try {

--- a/tests/lib/boot-assertions.test.ts
+++ b/tests/lib/boot-assertions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   assertMainnetProgramId,
+  assertProgramIdAllowList,
   MAINNET_PROGRAM_ID,
 } from "../../src/lib/boot-assertions.js";
 
@@ -59,5 +60,31 @@ describe("assertMainnetProgramId", () => {
       "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv",
     );
     expect(MAINNET_PROGRAM_ID).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
+  });
+});
+
+describe("assertProgramIdAllowList", () => {
+  const WRONG = "GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24";
+
+  it("throws on an empty list on ANY network (silent zero-program scan)", () => {
+    expect(() => assertProgramIdAllowList({ isMainnet: false, allProgramIds: [] })).toThrow(/empty program set/);
+    // Mainnet-empty too — the length check must precede the per-entry check so
+    // [] does NOT pass the vacuously-true .every/.filter (regression guard).
+    expect(() => assertProgramIdAllowList({ isMainnet: true, allProgramIds: [] })).toThrow(/empty program set/);
+  });
+
+  it("allows a non-canonical id off mainnet (devnet uses its own program)", () => {
+    expect(() => assertProgramIdAllowList({ isMainnet: false, allProgramIds: [WRONG] })).not.toThrow();
+    expect(() => assertProgramIdAllowList({ isMainnet: false, allProgramIds: [WRONG, "AnotherDevProg1111111111111111111111111111"] })).not.toThrow();
+  });
+
+  it("allows a mainnet list that is exactly the canonical id (incl. dupes)", () => {
+    expect(() => assertProgramIdAllowList({ isMainnet: true, allProgramIds: [MAINNET_PROGRAM_ID] })).not.toThrow();
+    expect(() => assertProgramIdAllowList({ isMainnet: true, allProgramIds: [MAINNET_PROGRAM_ID, MAINNET_PROGRAM_ID] })).not.toThrow();
+  });
+
+  it("throws on mainnet when any entry is non-canonical, naming the offender", () => {
+    expect(() => assertProgramIdAllowList({ isMainnet: true, allProgramIds: [WRONG] })).toThrow(/non-canonical/);
+    expect(() => assertProgramIdAllowList({ isMainnet: true, allProgramIds: [MAINNET_PROGRAM_ID, WRONG] })).toThrow(new RegExp(WRONG));
   });
 });

--- a/tests/services/program-id-allowlist.test.ts
+++ b/tests/services/program-id-allowlist.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression test for the MARKETS_FILTER program-id allow-list.
+ *
+ * The MARKETS_FILTER discovery path builds a market from `programId: info.owner`
+ * straight from the account owner. It must reject slabs owned by a program not
+ * in config.allProgramIds (mirroring registerMarket), so the keeper never signs
+ * crank/liquidate txs against an arbitrary program. (The boot guard
+ * assertProgramIdAllowList — tested in tests/lib/boot-assertions.test.ts — pins
+ * config.allProgramIds itself.)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const C = vi.hoisted(() => ({
+  KNOWN_PROGRAM: "11111111111111111111111111111111",
+  FOREIGN_PROGRAM: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", // not in allProgramIds
+  SLAB: "So11111111111111111111111111111111111111112",
+  ownerToReturn: "" as string, // set per test
+}));
+
+vi.mock("@percolatorct/sdk", () => ({
+  discoverMarkets: vi.fn(async () => []),
+  encodeKeeperCrank: vi.fn(() => Buffer.from([1])),
+  encodeUpdateHyperpMark: vi.fn(() => Buffer.from([7])),
+  buildAccountMetas: vi.fn(() => []),
+  buildIx: vi.fn(() => ({})),
+  derivePythPushOraclePDA: vi.fn(() => [{ toBase58: () => C.KNOWN_PROGRAM }, 0]),
+  parseHeader: vi.fn(() => ({ admin: { toBase58: () => "Admin1" } })),
+  parseConfig: vi.fn(() => ({
+    collateralMint: { toBase58: () => "Mint1111111111111111111111111111111111" },
+    indexFeedId: { toBytes: () => new Uint8Array(32), toBase58: () => C.KNOWN_PROGRAM, equals: () => true },
+    oracleAuthority: { toBase58: () => C.KNOWN_PROGRAM, equals: () => true },
+  })),
+  parseEngine: vi.fn(() => ({ totalOpenInterest: 0n })),
+  parseParams: vi.fn(() => ({ maintenanceMarginBps: 500n })),
+  detectDexType: vi.fn(() => "raydium-clmm"),
+  parseDexPool: vi.fn(),
+  ACCOUNTS_KEEPER_CRANK: {},
+}));
+vi.mock("@percolatorct/shared", () => ({
+  config: {
+    crankIntervalMs: 30000, crankInactiveIntervalMs: 120000, discoveryIntervalMs: 300000,
+    allProgramIds: [C.KNOWN_PROGRAM], crankKeypair: "mock",
+  },
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  getConnection: vi.fn(() => ({ getAccountInfo: vi.fn() })),
+  getFallbackConnection: vi.fn(() => ({
+    getMultipleAccountsInfo: vi.fn(async () => [
+      { owner: { toBase58: () => C.ownerToReturn, equals: () => false }, data: new Uint8Array(1024) },
+    ]),
+  })),
+  loadKeypair: vi.fn(() => ({ publicKey: { toBase58: () => C.KNOWN_PROGRAM, equals: () => false }, secretKey: new Uint8Array(64) })),
+  sendWithRetryKeeper: vi.fn(), eventBus: { publish: vi.fn() },
+  getSupabase: vi.fn(() => ({
+    from: vi.fn(() => ({ select: vi.fn(() => ({ in: vi.fn(async () => ({ data: [], error: null })) })) })),
+  })),
+}));
+vi.mock("../../src/lib/keeper-send.js", async () => {
+  const { KeeperBudget } = await vi.importActual<typeof import("../../src/lib/budget.js")>("../../src/lib/budget.js");
+  return { keeperSend: vi.fn(), sharedBudget: new KeeperBudget() };
+});
+
+import { CrankService } from "../../src/services/crank.js";
+
+describe("MARKETS_FILTER program-id allow-list", () => {
+  let crank: CrankService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.MARKETS_FILTER = C.SLAB;
+    crank = new CrankService({ pushPrice: vi.fn(), recordPushTime: vi.fn() } as any);
+  });
+
+  afterEach(() => {
+    delete process.env.MARKETS_FILTER;
+    crank.stop();
+  });
+
+  it("does NOT track a slab owned by a non-allow-listed program", async () => {
+    C.ownerToReturn = C.FOREIGN_PROGRAM;
+    await crank.discover();
+    expect(crank.getMarkets().has(C.SLAB)).toBe(false);
+  });
+
+  it("DOES track a slab owned by an allow-listed program (no over-skip)", async () => {
+    C.ownerToReturn = C.KNOWN_PROGRAM;
+    await crank.discover();
+    expect(crank.getMarkets().has(C.SLAB)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The keeper signs `KeeperCrank` / `LiquidateAtOracle` / `UpdateHyperpMark` — with its key as a writable signer + fee payer — against `market.programId`. The invariant that keeps this safe ("only sign against an allow-listed Percolator program") was enforced inconsistently, leaving three gaps that let an operator/env misconfiguration redirect the keeper to sign against an unintended (potentially hostile) program:

1. **Boot ignored `allProgramIds`.** `assertMainnetProgramId` validated only `config.programId` against the hardcoded `MAINNET_PROGRAM_ID`. But discovery scans **every** entry of `config.allProgramIds` (sourced independently from `ALL_PROGRAM_IDS` env) and stamps each market with it. So `ALL_PROGRAM_IDS="<correct>,<foreign>"` made the keeper crank/liquidate against `<foreign>` while the existing guard reported clean.
2. **`MARKETS_FILTER` skipped the owner check.** That path built a market with `programId: info.owner` straight from the account owner, with no allow-list check — unlike `registerMarket`, which rejects unknown owners (`crank.ts:1191-1196`). The two paths disagreed on the same trust boundary.
3. **No non-empty assertion.** `ALL_PROGRAM_IDS=""` resolves to `[]` (the `?? PROGRAM_ID` fallback only fires on nullish, not empty string), so the keeper scanned zero programs and silently did nothing.

These are not remotely exploitable on their own — each needs operator/env misconfiguration — but together they defeat a marquee mainnet safety invariant the codebase otherwise upholds.

## Fix (end-to-end)

- **Boot:** new `assertProgramIdAllowList()` — on **any** network, refuse to boot if `config.allProgramIds` is empty; on **mainnet**, also refuse if any entry isn't the canonical `MAINNET_PROGRAM_ID`. The non-empty check is ordered **first** so an empty array can't slip through the per-entry check by `[].every()`/`filter` vacuous truth. Added as a **new** function (so `assertMainnetProgramId` and its tests are untouched), called right after it at boot. The error names the offending id(s).
- **`MARKETS_FILTER`:** hoist `new Set(config.allProgramIds)` and skip+warn any slab whose `info.owner` isn't allow-listed, before parsing/tracking it — mirroring `registerMarket`.

The `getProgramAccounts` discovery path is already scoped to `config.allProgramIds`, and `registerMarket` is already guarded; both are left untouched. Once the boot guard pins `allProgramIds` to the canonical id, the `MARKETS_FILTER` check is a defense-in-depth layer over on-chain reality (a lying/compromised RPC still can't get the keeper to sign against a foreign-owned slab).

### Non-empty on all networks (not mainnet-only)

An empty scan set is a misconfiguration on *every* network (boots "healthy", does nothing). Catching it in devnet/staging is exactly where you want to — before it ships to mainnet. It can't break local dev: with `ALL_PROGRAM_IDS` unset, `allProgramIds` defaults to `[PROGRAM_ID]` (non-empty); it only throws on an explicit `ALL_PROGRAM_IDS=""`/`","`, which is a real misconfig.

## Tests

- Boot unit tests: empty-on-any-network throws; the mainnet-empty **vacuous-truth regression**; non-canonical entry throws and names the offender; off-mainnet allows devnet ids; canonical (incl. dupes) passes.
- MARKETS_FILTER regression: a foreign-owned slab is skipped; an allow-listed owner is still tracked (no over-skip).

Full suite: 694 passing, 25 skipped; `tsc --noEmit` clean.

> Note: if a second mainnet program is ever legitimately deployed (e.g. a migration window), the boot guard's `=== MAINNET_PROGRAM_ID` would need widening to a small hardcoded allow-list — intentionally a reviewed code change, not an env edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added program ID validation during startup and slab discovery to ensure only authorized programs are processed, strengthening system security and integrity.

* **Tests**
  * Expanded test coverage for program ID validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->