### PR TITLE
Demoted leader rejoins the election instead of parking in standby forever

### DIFF
--- a/src/lib/leader.ts
+++ b/src/lib/leader.ts
@@ -31,6 +31,15 @@ export class LeaderLock {
   private _renewFailures = 0;
   private _lockKey = "";
   private _onDemote: ((reason: string) => void) | null = null;
+  // Captured at start() so _demote() can re-enter the standby poll loop — it is
+  // the one transition that needs StartOptions but isn't handed them.
+  private _opts: StartOptions | null = null;
+  // Terminal kill-switch. Set true at the top of stop() BEFORE any await so an
+  // already-queued _poll/_renew callback (a timer that fired into the event
+  // loop microseconds before _clearTimers ran) cannot re-arm a timer or promote
+  // a node the operator has shut down. Role alone can't express this: stop()
+  // leaves the role as "standby", indistinguishable from a live standby.
+  private _stopped = false;
 
   constructor(redis: RedisLike, identity: string, opts: LeaderLockOptions = {}) {
     this.redis = redis;
@@ -47,6 +56,8 @@ export class LeaderLock {
   start(opts: StartOptions): void {
     this._lockKey = `keeper:leader:${opts.network}`;
     this._onDemote = opts.onDemote;
+    this._opts = opts;
+    this._stopped = false;
 
     logger.info("LeaderLock starting", {
       identity: this.identity,
@@ -60,6 +71,9 @@ export class LeaderLock {
   }
 
   async stop(): Promise<void> {
+    // Latch BEFORE _clearTimers() and before any await: a poll/renew callback
+    // already past clearTimeout's reach will observe this and abort.
+    this._stopped = true;
     this._clearTimers();
 
     if (this._role === "leader") {
@@ -98,6 +112,7 @@ export class LeaderLock {
   }
 
   private _promote(opts: StartOptions): void {
+    if (this._stopped) return;
     this._role = "leader";
     this._renewFailures = 0;
     logger.info("LeaderLock promoted to leader", { identity: this.identity });
@@ -113,7 +128,7 @@ export class LeaderLock {
   }
 
   private async _renew(opts: StartOptions): Promise<void> {
-    if (this._role !== "leader") return;
+    if (this._stopped || this._role !== "leader") return;
 
     const ttlSec = Math.ceil(this.ttlMs / 1000);
 
@@ -149,6 +164,7 @@ export class LeaderLock {
   }
 
   private _enterStandby(opts: StartOptions): void {
+    if (this._stopped) return;
     this._role = "standby";
     logger.info("LeaderLock entering standby", { identity: this.identity });
     this._schedulePoll(opts);
@@ -162,14 +178,18 @@ export class LeaderLock {
   }
 
   private async _poll(opts: StartOptions): Promise<void> {
-    if (this._role !== "standby") return;
+    if (this._stopped || this._role !== "standby") return;
 
     try {
       const current = await this.redis.get(this._lockKey);
+      // stop() may have run while we were awaiting Redis — never promote or
+      // re-arm a timer on a stopped node.
+      if (this._stopped || this._role !== "standby") return;
 
       if (current === null) {
         const ttlSec = Math.ceil(this.ttlMs / 1000);
         const result = await this.redis.set(this._lockKey, this.identity, { ex: ttlSec, nx: true } as { ex: number; nx: true });
+        if (this._stopped || this._role !== "standby") return;
         if (result === "OK") {
           this._promote(opts);
           return;
@@ -182,6 +202,7 @@ export class LeaderLock {
         identity: this.identity,
         error: err instanceof Error ? err.message : String(err),
       });
+      if (this._stopped) return;
       this._schedulePoll(opts);
     }
   }
@@ -191,6 +212,14 @@ export class LeaderLock {
     this._role = "standby";
     this._clearTimers();
     logger.warn("LeaderLock demoted", { identity: this.identity, reason });
+    // Re-arm the standby poll so the node rejoins the election and re-acquires
+    // once Redis recovers and the lock frees — without this, a transient blip
+    // parks the node forever (services stopped via onDemote, never restarted).
+    // Scheduled BEFORE firing onDemote so recovery is armed even if the handler
+    // throws; _clearTimers() above guarantees no timer is live (no double-arm),
+    // and stop() (incl. one invoked from onDemote) latches _stopped and clears
+    // this poll. Mirrors _enterStandby()'s initial-standby behavior.
+    if (this._opts) this._schedulePoll(this._opts);
     this._onDemote?.(reason);
   }
 

--- a/tests/lib/leader-demote-recovery.poc.test.ts
+++ b/tests/lib/leader-demote-recovery.poc.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { LeaderLock } from "../../src/lib/leader.js";
+import type { RedisLike } from "../../src/lib/redis-client.js";
+
+/**
+ * PoC: a leader that is demoted (transient Redis renew failure) must resume
+ * polling so it can re-acquire leadership once Redis recovers and the lock is
+ * free again.
+ *
+ * On current `main` `_demote()` clears both timers and enters "standby" WITHOUT
+ * scheduling a standby poll (unlike `_enterStandby()`), so the node is parked
+ * forever: services are stopped via onDemote and nothing ever re-acquires.
+ * For a single-replica HA deployment that is a permanent, silent total outage
+ * after one Redis blip; for a multi-replica cluster every node retires the
+ * first time it is demoted until the whole cluster is dark.
+ *
+ * Both assertions below FAIL on current main and pass after the fix.
+ */
+
+const KEY = "keeper:leader:devnet";
+type SetOpts = { ex: number; nx?: true } | { ex: number; xx?: true };
+
+describe("LeaderLock demote recovery (PoC)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("re-acquires leadership after a transient renew failure once Redis recovers", async () => {
+    const store = new Map<string, string>();
+    // Toggled true while we want the periodic RENEW (xx) to fail, simulating a
+    // transient Redis outage that costs the leader its lock.
+    let renewShouldFail = true;
+
+    const redis: RedisLike = {
+      async set(key: string, value: string, opts: SetOpts): Promise<"OK" | null> {
+        const hasNx = "nx" in opts && opts.nx === true;
+        const hasXx = "xx" in opts && (opts as { xx?: true }).xx === true;
+        if (hasXx) {
+          if (renewShouldFail) throw new Error("Redis connection refused");
+          if (!store.has(key)) return null;
+          store.set(key, value);
+          return "OK";
+        }
+        // nx acquire
+        if (hasNx && store.has(key)) return null;
+        store.set(key, value);
+        return "OK";
+      },
+      async get(key: string): Promise<string | null> {
+        return store.get(key) ?? null;
+      },
+      async del(...keys: string[]): Promise<number> {
+        let n = 0;
+        for (const k of keys) if (store.delete(k)) n++;
+        return n;
+      },
+    };
+
+    const lock = new LeaderLock(redis, "node-a", {
+      ttlMs: 30_000,
+      renewMs: 10_000,
+      pollMs: 5_000,
+    });
+    const onPromote = vi.fn();
+    const onDemote = vi.fn();
+
+    lock.start({ network: "devnet", onPromote, onDemote });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(lock.role()).toBe("leader");
+    expect(onPromote).toHaveBeenCalledTimes(1);
+    expect(store.has(KEY)).toBe(true);
+
+    // Two consecutive renew failures → demote("redis-renew-failed").
+    await vi.advanceTimersByTimeAsync(10_100); // 1st failure → retry scheduled
+    expect(lock.role()).toBe("leader");
+    await vi.advanceTimersByTimeAsync(10_100); // 2nd failure → demote
+    expect(lock.role()).toBe("standby");
+    expect(onDemote).toHaveBeenCalledWith("redis-renew-failed");
+
+    // Redis recovers and the stale lock expires server-side (TTL) so it is free.
+    renewShouldFail = false;
+    store.delete(KEY);
+
+    // A healthy node MUST poll and re-acquire within pollMs. On current main no
+    // poll was ever scheduled after demotion, so it stays standby forever.
+    await vi.advanceTimersByTimeAsync(5_100);
+
+    expect(lock.role()).toBe("leader"); // FAILS on main: stuck in "standby"
+    expect(onPromote).toHaveBeenCalledTimes(2); // recovery promote never fires on main
+
+    await lock.stop();
+  });
+
+  it("re-acquires after a stolen-lock demotion (renew returns null) once the lock frees", async () => {
+    const store = new Map<string, string>();
+    store.set(KEY, "node-a"); // we hold it after acquire (set below)
+    store.delete(KEY);
+    // renew (xx) returns null while the lock is considered lost; flip to allow
+    // a fresh nx acquire on recovery.
+    let lockLost = false;
+
+    const redis: RedisLike = {
+      async set(key: string, value: string, opts: SetOpts): Promise<"OK" | null> {
+        const hasNx = "nx" in opts && opts.nx === true;
+        const hasXx = "xx" in opts && (opts as { xx?: true }).xx === true;
+        if (hasXx) {
+          if (lockLost) return null; // renew finds the key gone → lock-lost demote
+          if (!store.has(key)) return null;
+          store.set(key, value);
+          return "OK";
+        }
+        if (hasNx && store.has(key)) return null;
+        store.set(key, value);
+        return "OK";
+      },
+      async get(key: string): Promise<string | null> {
+        return store.get(key) ?? null;
+      },
+      async del(...keys: string[]): Promise<number> {
+        let n = 0;
+        for (const k of keys) if (store.delete(k)) n++;
+        return n;
+      },
+    };
+
+    const lock = new LeaderLock(redis, "node-a", { ttlMs: 30_000, renewMs: 10_000, pollMs: 5_000 });
+    const onPromote = vi.fn();
+    const onDemote = vi.fn();
+    lock.start({ network: "devnet", onPromote, onDemote });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(lock.role()).toBe("leader");
+
+    // Lock stolen/expired: next renew returns null → single-failure demote.
+    lockLost = true;
+    store.delete(KEY);
+    await vi.advanceTimersByTimeAsync(10_100);
+    expect(lock.role()).toBe("standby");
+    expect(onDemote).toHaveBeenCalledWith("redis-lock-lost");
+
+    // Lock is free again; standby poll must re-acquire.
+    lockLost = false;
+    await vi.advanceTimersByTimeAsync(5_100);
+    expect(lock.role()).toBe("leader");
+    expect(onPromote).toHaveBeenCalledTimes(2);
+
+    await lock.stop();
+  });
+
+  it("stop() after demotion cancels the recovery poll — no zombie re-promotion", async () => {
+    const store = new Map<string, string>();
+    let renewShouldFail = true;
+
+    const redis: RedisLike = {
+      async set(key: string, value: string, opts: SetOpts): Promise<"OK" | null> {
+        const hasNx = "nx" in opts && opts.nx === true;
+        const hasXx = "xx" in opts && (opts as { xx?: true }).xx === true;
+        if (hasXx) {
+          if (renewShouldFail) throw new Error("Redis connection refused");
+          if (!store.has(key)) return null;
+          store.set(key, value);
+          return "OK";
+        }
+        if (hasNx && store.has(key)) return null;
+        store.set(key, value);
+        return "OK";
+      },
+      async get(key: string): Promise<string | null> {
+        return store.get(key) ?? null;
+      },
+      async del(...keys: string[]): Promise<number> {
+        let n = 0;
+        for (const k of keys) if (store.delete(k)) n++;
+        return n;
+      },
+    };
+
+    const lock = new LeaderLock(redis, "node-a", { ttlMs: 30_000, renewMs: 10_000, pollMs: 5_000 });
+    const onPromote = vi.fn();
+    lock.start({ network: "devnet", onPromote, onDemote: vi.fn() });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(lock.role()).toBe("leader");
+
+    await vi.advanceTimersByTimeAsync(10_100);
+    await vi.advanceTimersByTimeAsync(10_100);
+    expect(lock.role()).toBe("standby");
+
+    // Operator shuts the node down before the recovery poll fires.
+    await lock.stop();
+
+    // Free the lock and advance well past pollMs — a stopped node must NOT
+    // resurrect itself.
+    renewShouldFail = false;
+    store.delete(KEY);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(lock.role()).toBe("standby");
+    expect(onPromote).toHaveBeenCalledTimes(1); // only the original promote
+
+    await lock.stop();
+  });
+
+  it("does not promote when stop() lands mid-poll (use-after-stop guard)", async () => {
+    const store = new Map<string, string>(); // lock is free
+    const lock = new LeaderLock(
+      // get() shuts the node down before returning, simulating stop() landing
+      // while the poll is awaiting Redis. The post-await _stopped re-check must
+      // then prevent promotion.
+      {
+        async set(key: string, value: string, opts: SetOpts): Promise<"OK" | null> {
+          const hasNx = "nx" in opts && opts.nx === true;
+          if (hasNx && store.has(key)) return null;
+          store.set(key, value);
+          return "OK";
+        },
+        async get(key: string): Promise<string | null> {
+          // Stop the node mid-poll, then report the lock as free.
+          await lock.stop();
+          return store.get(key) ?? null;
+        },
+        async del(...keys: string[]): Promise<number> {
+          let n = 0;
+          for (const k of keys) if (store.delete(k)) n++;
+          return n;
+        },
+      },
+      "node-a",
+      { ttlMs: 30_000, renewMs: 10_000, pollMs: 5_000 },
+    );
+    const onPromote = vi.fn();
+
+    // Start as standby (another node holds the lock) so the poll loop runs.
+    store.set(KEY, "other");
+    lock.start({ network: "devnet", onPromote, onDemote: vi.fn() });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(lock.role()).toBe("standby");
+
+    // Free the lock so the poll WOULD promote if the guard were missing, then
+    // let the poll fire (its get() calls stop() mid-flight).
+    store.delete(KEY);
+    await vi.advanceTimersByTimeAsync(5_100);
+
+    expect(onPromote).not.toHaveBeenCalled();
+    expect(lock.role()).toBe("standby");
+  });
+});


### PR DESCRIPTION
## Problem

`LeaderLock._demote()` transitions a node from `leader` to `standby` and clears its timers, but — unlike `_enterStandby()` — never schedules a standby poll. A demoted node therefore has no timer running and never re-acquires leadership, even after Redis fully recovers and the lock frees.

Demotion is triggered by exactly the kind of transient failure HA is meant to ride through: two consecutive renew errors (`_demote("redis-renew-failed")`) or a renew that returns null because the TTL lapsed during a blip (`_demote("redis-lock-lost")`). Since `onDemote` runs `stopAllServices()` (crank, liquidation, monitor, fraud, ADL), a demoted node goes silently dark:

- **Single-replica HA**: one Redis blip permanently parks the only node in `standby` with all services stopped — a total outage until manual restart. `/health` keeps returning 200 (the HTTP server stays bound), so external probes don't catch it.
- **Multi-replica HA**: failover to a peer still works, but each node permanently retires the first time it is demoted; over repeated blips the live pool shrinks to zero, ending in a cluster-wide outage with no leader.

## Fix

- Capture `StartOptions` at `start()` (as `_opts`) so `_demote()` can re-enter the standby poll loop — mirroring what `_enterStandby()` already does on the initial-standby path. The poll is scheduled **before** firing `onDemote` so recovery is armed even if the handler throws; `_clearTimers()` runs first so there's no double-arm.
- Add a `_stopped` kill-switch, latched at the top of `stop()` **before** any await and checked in `_promote`/`_renew`/`_enterStandby` and after each await in `_poll`. This closes a pre-existing use-after-stop window: a poll timer that fired into the event loop microseconds before `stop()`'s `clearTimeout` would otherwise pass the `role === "standby"` guard (stop leaves the role as `standby`) and could promote a node the operator just shut down. Re-arming the poll on demote widens when polls are active, so this is closed in the same change.

The no-split-brain fail-safe (poll error → stay standby, never promote) is preserved unchanged.

## Tests

`tests/lib/leader-demote-recovery.poc.test.ts` (new):
- re-acquires leadership after a `redis-renew-failed` demotion once Redis recovers (fails on `main`: stuck in `standby`)
- re-acquires after a `redis-lock-lost` (null-renew) demotion once the lock frees
- `stop()` after demotion cancels the recovery poll — no zombie re-promotion
- no promotion when `stop()` lands mid-poll (use-after-stop guard)

All existing `tests/lib/leader.test.ts` cases remain green; full suite green (692 passed) and `tsc --noEmit` clean.

Fixes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition where the leader election system could attempt to re-acquire leadership after being stopped.
  * Improved recovery behavior when temporary connectivity issues cause a leader to be demoted.

* **Tests**
  * Added test suite validating leader demotion recovery scenarios and shutdown edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->