### PR TITLE
fix(test): update leader-demote-recovery PoC mocks to match eval CAS renew

### DIFF
--- a/tests/lib/leader-demote-recovery.poc.test.ts
+++ b/tests/lib/leader-demote-recovery.poc.test.ts
@@ -32,21 +32,13 @@ describe("LeaderLock demote recovery (PoC)", () => {
 
   it("re-acquires leadership after a transient renew failure once Redis recovers", async () => {
     const store = new Map<string, string>();
-    // Toggled true while we want the periodic RENEW (xx) to fail, simulating a
-    // transient Redis outage that costs the leader its lock.
+    // Toggled true while we want the periodic RENEW (eval CAS) to fail,
+    // simulating a transient Redis outage that costs the leader its lock.
     let renewShouldFail = true;
 
     const redis: RedisLike = {
       async set(key: string, value: string, opts: SetOpts): Promise<"OK" | null> {
         const hasNx = "nx" in opts && opts.nx === true;
-        const hasXx = "xx" in opts && (opts as { xx?: true }).xx === true;
-        if (hasXx) {
-          if (renewShouldFail) throw new Error("Redis connection refused");
-          if (!store.has(key)) return null;
-          store.set(key, value);
-          return "OK";
-        }
-        // nx acquire
         if (hasNx && store.has(key)) return null;
         store.set(key, value);
         return "OK";
@@ -58,6 +50,14 @@ describe("LeaderLock demote recovery (PoC)", () => {
         let n = 0;
         for (const k of keys) if (store.delete(k)) n++;
         return n;
+      },
+      async eval<T>(_script: string, keys: string[], args: (string | number)[]): Promise<T> {
+        // Simulate transient Redis failure during renew (CAS eval).
+        if (renewShouldFail) throw new Error("Redis connection refused");
+        // CAS: return 1 if we still own the lock, 0 otherwise.
+        const current = store.get(keys[0] ?? "");
+        if (current === args[0]) return 1 as unknown as T;
+        return 0 as unknown as T;
       },
     };
 
@@ -97,24 +97,15 @@ describe("LeaderLock demote recovery (PoC)", () => {
     await lock.stop();
   });
 
-  it("re-acquires after a stolen-lock demotion (renew returns null) once the lock frees", async () => {
+  it("re-acquires after a stolen-lock demotion (eval returns 0) once the lock frees", async () => {
     const store = new Map<string, string>();
-    store.set(KEY, "node-a"); // we hold it after acquire (set below)
-    store.delete(KEY);
-    // renew (xx) returns null while the lock is considered lost; flip to allow
+    // eval CAS returns 0 while the lock is considered lost; flip to allow
     // a fresh nx acquire on recovery.
     let lockLost = false;
 
     const redis: RedisLike = {
       async set(key: string, value: string, opts: SetOpts): Promise<"OK" | null> {
         const hasNx = "nx" in opts && opts.nx === true;
-        const hasXx = "xx" in opts && (opts as { xx?: true }).xx === true;
-        if (hasXx) {
-          if (lockLost) return null; // renew finds the key gone → lock-lost demote
-          if (!store.has(key)) return null;
-          store.set(key, value);
-          return "OK";
-        }
         if (hasNx && store.has(key)) return null;
         store.set(key, value);
         return "OK";
@@ -127,6 +118,13 @@ describe("LeaderLock demote recovery (PoC)", () => {
         for (const k of keys) if (store.delete(k)) n++;
         return n;
       },
+      async eval<T>(_script: string, keys: string[], args: (string | number)[]): Promise<T> {
+        // CAS renew: return 0 when lock is considered lost (identity mismatch/gone).
+        if (lockLost) return 0 as unknown as T;
+        const current = store.get(keys[0] ?? "");
+        if (current === args[0]) return 1 as unknown as T;
+        return 0 as unknown as T;
+      },
     };
 
     const lock = new LeaderLock(redis, "node-a", { ttlMs: 30_000, renewMs: 10_000, pollMs: 5_000 });
@@ -136,7 +134,7 @@ describe("LeaderLock demote recovery (PoC)", () => {
     await vi.advanceTimersByTimeAsync(100);
     expect(lock.role()).toBe("leader");
 
-    // Lock stolen/expired: next renew returns null → single-failure demote.
+    // Lock stolen/expired: next renew eval returns 0 → single-failure demote.
     lockLost = true;
     store.delete(KEY);
     await vi.advanceTimersByTimeAsync(10_100);
@@ -159,13 +157,6 @@ describe("LeaderLock demote recovery (PoC)", () => {
     const redis: RedisLike = {
       async set(key: string, value: string, opts: SetOpts): Promise<"OK" | null> {
         const hasNx = "nx" in opts && opts.nx === true;
-        const hasXx = "xx" in opts && (opts as { xx?: true }).xx === true;
-        if (hasXx) {
-          if (renewShouldFail) throw new Error("Redis connection refused");
-          if (!store.has(key)) return null;
-          store.set(key, value);
-          return "OK";
-        }
         if (hasNx && store.has(key)) return null;
         store.set(key, value);
         return "OK";
@@ -177,6 +168,12 @@ describe("LeaderLock demote recovery (PoC)", () => {
         let n = 0;
         for (const k of keys) if (store.delete(k)) n++;
         return n;
+      },
+      async eval<T>(_script: string, keys: string[], args: (string | number)[]): Promise<T> {
+        if (renewShouldFail) throw new Error("Redis connection refused");
+        const current = store.get(keys[0] ?? "");
+        if (current === args[0]) return 1 as unknown as T;
+        return 0 as unknown as T;
       },
     };
 
@@ -227,6 +224,10 @@ describe("LeaderLock demote recovery (PoC)", () => {
           let n = 0;
           for (const k of keys) if (store.delete(k)) n++;
           return n;
+        },
+        async eval<T>(): Promise<T> {
+          // This test starts in standby — renew (eval) is never called.
+          throw new Error("eval should not be called in this test");
         },
       },
       "node-a",


### PR DESCRIPTION
## Summary

PR#138 (already on main) replaced SET XX renewal with a Lua eval CAS script, but the PoC tests shipped in PR#186 still mocked the old SET XX path — the mocks had no `eval` method. Without it, the Lua-path throws `TypeError: this.redis.eval is not a function`, causing the wrong demotion path (`redis-renew-failed` throw instead of `redis-lock-lost` return-0), and the \"stolen-lock\" test was failing.

Fixes: all three mock `RedisLike` objects now expose an `eval()` method that correctly simulates CAS renew (throw on transient failure, return 0 on lock-lost, return 1 when healthy). The 4th test (standby-only) gets a stub that asserts `eval` is never called from the poll path.

All 4 tests in `leader-demote-recovery.poc.test.ts` now pass on current main.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>