### PR TITLE
fix(oracle): resolve Chainlink oracle accounts by owner instead of always deriving a Pyth PDA

### DIFF
--- a/src/lib/oracle-account.ts
+++ b/src/lib/oracle-account.ts
@@ -1,0 +1,94 @@
+import { PublicKey } from "@solana/web3.js";
+import type { Connection } from "@solana/web3.js";
+import { derivePythPushOraclePDA } from "@percolatorct/sdk";
+import { createLogger } from "@percolatorct/shared";
+
+const logger = createLogger("keeper:oracle-account");
+
+/**
+ * Chainlink OCR2 Store program id.
+ *
+ * The on-chain program (percolator-prog `read_engine_price_e6`) detects the
+ * oracle type by the supplied oracle account's OWNER — PYTH_RECEIVER → Pyth,
+ * CHAINLINK_OCR2 → Chainlink — and for a Chainlink market `index_feed_id` IS the
+ * aggregator account pubkey (the program checks `price_ai.key == index_feed_id`).
+ * The SDK does not export this constant, so it is pinned here against the
+ * program's `CHAINLINK_OCR2_PROGRAM_ID` (percolator.rs). A unit test asserts the
+ * literal so a drift is caught loudly.
+ */
+export const CHAINLINK_OCR2_PROGRAM_ID = new PublicKey(
+  "HEvSKofvBgfaexv23kMabbYqxasxU3mQ4ibBMEmJWHny",
+);
+
+/** Minimal feed shape — compatible with a real PublicKey and parsed-config mocks. */
+interface FeedLike {
+  toBytes(): Uint8Array;
+  toBase58(): string;
+}
+
+type OracleKind = "chainlink" | "pyth";
+
+/** feed pubkey (base58) → resolved oracle kind. The owner of a feed account is
+ *  fixed at InitMarket, so this is cached for the process lifetime; only
+ *  positively-resolved verdicts are cached (a failed lookup is retried). */
+const ownerCache = new Map<string, OracleKind>();
+
+/** Test hook: drop cached verdicts so the next resolve re-fetches. */
+export function _resetOracleAccountCache(): void {
+  ownerCache.clear();
+}
+
+function pythPushPda(feedBytes: Uint8Array): PublicKey {
+  const feedHex = Array.from(feedBytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return derivePythPushOraclePDA(feedHex)[0];
+}
+
+/**
+ * Resolve the oracle account to pass on-chain for a market that uses an EXTERNAL
+ * pinned feed (i.e. non-HYPERP, non-admin: `index_feed_id != 0`). Callers must
+ * have already handled HYPERP / admin-oracle (both → slab); this only
+ * distinguishes Pyth from Chainlink, which is indistinguishable from config
+ * alone and so requires the on-chain account owner:
+ *
+ *   - owner == CHAINLINK_OCR2  → the oracle account IS `index_feed_id` (the aggregator)
+ *   - otherwise / null / error → derive the Pyth Push PDA (pre-fix behavior)
+ *
+ * The Pyth-derive default makes this a strict correctness superset of the old
+ * code: a Pyth market is byte-for-byte unchanged, a flaky lookup never makes a
+ * working market worse, and a confirmed Chainlink owner routes correctly. A
+ * confirmed verdict is cached; an inconclusive/errored lookup is NOT cached, so
+ * a Chainlink market self-heals on the next send once the lookup succeeds.
+ */
+export async function resolveExternalOracleAccount(
+  indexFeedId: FeedLike,
+  connection: Connection,
+): Promise<PublicKey> {
+  const feedBytes = indexFeedId.toBytes();
+  const feedKey = indexFeedId.toBase58();
+
+  const cached = ownerCache.get(feedKey);
+  if (cached === "chainlink") return new PublicKey(feedBytes);
+  if (cached === "pyth") return pythPushPda(feedBytes);
+
+  try {
+    const info = await connection.getAccountInfo(new PublicKey(feedBytes));
+    const kind: OracleKind =
+      info && info.owner.equals(CHAINLINK_OCR2_PROGRAM_ID) ? "chainlink" : "pyth";
+    ownerCache.set(feedKey, kind);
+    if (kind === "chainlink") {
+      logger.info("Resolved Chainlink oracle for feed", { feed: feedKey });
+      return new PublicKey(feedBytes);
+    }
+    return pythPushPda(feedBytes);
+  } catch (err) {
+    // Inconclusive: fall back to Pyth for this send (== pre-fix behavior) but do
+    // NOT cache, so a real Chainlink market retries once the lookup recovers.
+    logger.warn("Oracle owner lookup failed — defaulting to Pyth PDA (uncached)", {
+      feed: feedKey,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return pythPushPda(feedBytes);
+  }
+}

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -13,7 +13,6 @@ import {
   encodeKeeperCrank,
   ACCOUNTS_LIQUIDATE_AT_ORACLE,
   ACCOUNTS_KEEPER_CRANK,
-  derivePythPushOraclePDA,
   type DiscoveredMarket,
 } from "@percolatorct/sdk";
 import { config, getConnection, loadKeypair, sendWithRetry, pollSignatureStatus, getRecentPriorityFees, checkTransactionSize, eventBus, createLogger, sendWarningAlert, acquireToken, getFallbackConnection, backoffMs, getErrorMessage } from "@percolatorct/shared";
@@ -27,6 +26,7 @@ import {
 } from "../lib/metrics.js";
 import type { AccountLoader } from "../lib/account-loader.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
+import { resolveExternalOracleAccount } from "../lib/oracle-account.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
 import { AlertAggregator } from "../lib/alert-aggregator.js";
 
@@ -403,14 +403,14 @@ export class LiquidationService {
       const instructions: TransactionInstruction[] = [];
 
       // N1: Determine oracle account using detectOracleMode to match crank/ADL logic.
-      // Admin-oracle markets use slabAddress regardless of indexFeedId; only
-      // pyth-pinned markets derive a Pyth PDA from the feed ID.
+      // Admin-oracle and HYPERP markets use slabAddress; pyth-pinned markets use
+      // resolveExternalOracleAccount which checks the on-chain account owner to
+      // distinguish Pyth Push PDA derivation from Chainlink (where index_feed_id
+      // IS the aggregator account and must be passed directly).
       const oracleMode = detectOracleMode(market.config);
       let oracleAccount: PublicKey;
       if (oracleMode === "pyth-pinned") {
-        const feedHex = Array.from(market.config.indexFeedId.toBytes())
-          .map(b => b.toString(16).padStart(2, "0")).join("");
-        oracleAccount = derivePythPushOraclePDA(feedHex)[0];
+        oracleAccount = await resolveExternalOracleAccount(market.config.indexFeedId, connection);
       } else {
         oracleAccount = slabAddress;
       }

--- a/tests/lib/oracle-account.test.ts
+++ b/tests/lib/oracle-account.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+
+const PYTH_PDA = PublicKey.unique();
+
+vi.mock("@percolatorct/sdk", () => ({
+  derivePythPushOraclePDA: vi.fn(() => [PYTH_PDA, 0]),
+}));
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+}));
+
+import {
+  resolveExternalOracleAccount,
+  CHAINLINK_OCR2_PROGRAM_ID,
+  _resetOracleAccountCache,
+} from "../../src/lib/oracle-account.js";
+
+const FEED = new PublicKey("Cv4T27XbjVoKUYwP72NQQanvZeA7W4YF9L4EnYT9kx5o"); // Chainlink aggregator / Pyth feed id
+const OTHER_OWNER = PublicKey.unique();
+
+/** Build a fake Connection whose getAccountInfo is a spy with the given behavior. */
+function fakeConn(getAccountInfo: any) {
+  return { getAccountInfo } as any;
+}
+
+describe("resolveExternalOracleAccount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetOracleAccountCache();
+  });
+
+  it("pins to the program's CHAINLINK_OCR2 program id", () => {
+    expect(CHAINLINK_OCR2_PROGRAM_ID.toBase58()).toBe("HEvSKofvBgfaexv23kMabbYqxasxU3mQ4ibBMEmJWHny");
+  });
+
+  it("Chainlink owner → returns index_feed_id (the aggregator account)", async () => {
+    const conn = fakeConn(vi.fn(async () => ({ owner: CHAINLINK_OCR2_PROGRAM_ID, data: new Uint8Array(0) })));
+    const acct = await resolveExternalOracleAccount(FEED, conn);
+    expect(acct.toBase58()).toBe(FEED.toBase58());
+  });
+
+  it("null account (a Pyth feed id is not an account) → derives the Pyth Push PDA", async () => {
+    const conn = fakeConn(vi.fn(async () => null));
+    const acct = await resolveExternalOracleAccount(FEED, conn);
+    expect(acct.toBase58()).toBe(PYTH_PDA.toBase58());
+  });
+
+  it("some unrelated owner → derives the Pyth Push PDA (safe default)", async () => {
+    const conn = fakeConn(vi.fn(async () => ({ owner: OTHER_OWNER, data: new Uint8Array(0) })));
+    const acct = await resolveExternalOracleAccount(FEED, conn);
+    expect(acct.toBase58()).toBe(PYTH_PDA.toBase58());
+  });
+
+  it("caches a positive verdict — getAccountInfo is called once across repeated resolves", async () => {
+    const spy = vi.fn(async () => ({ owner: CHAINLINK_OCR2_PROGRAM_ID, data: new Uint8Array(0) }));
+    const conn = fakeConn(spy);
+    await resolveExternalOracleAccount(FEED, conn);
+    await resolveExternalOracleAccount(FEED, conn);
+    await resolveExternalOracleAccount(FEED, conn);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("RPC error → falls back to Pyth PDA and does NOT cache (self-heals on retry)", async () => {
+    let call = 0;
+    const conn = fakeConn(vi.fn(async () => {
+      call++;
+      if (call === 1) throw new Error("RPC down");
+      return { owner: CHAINLINK_OCR2_PROGRAM_ID, data: new Uint8Array(0) };
+    }));
+
+    const first = await resolveExternalOracleAccount(FEED, conn);
+    expect(first.toBase58()).toBe(PYTH_PDA.toBase58()); // fallback
+
+    // The failure was not cached: the next resolve re-fetches and now sees Chainlink.
+    const second = await resolveExternalOracleAccount(FEED, conn);
+    expect(second.toBase58()).toBe(FEED.toBase58());
+  });
+});


### PR DESCRIPTION
## Summary

Clean rebase of #180 against current main. The original PR was conflicting because #N1 had already merged (fixing admin-oracle → slab routing). This PR layers on top: for pyth-pinned markets (non-zero feedId, zero oracleAuthority), it now resolves the oracle account by checking the on-chain account owner via `resolveExternalOracleAccount`, instead of blindly deriving a Pyth Push PDA.

- Chainlink markets: `index_feed_id` owner == `HEvSKofvBgfaexv23kMabbYqxasxU3mQ4ibBMEmJWHny` → use the feed pubkey directly as the oracle account (the on-chain program checks `price_ai.key == index_feed_id` for Chainlink).
- Pyth markets: all other owners → derive Pyth Push PDA (unchanged behavior for all existing Pyth markets).
- Admin/HYPERP: still routes to slab (N1 behavior preserved).

Adds `src/lib/oracle-account.ts` with owner cache (process-lifetime, only positive verdicts cached), and `tests/lib/oracle-account.test.ts`.

Closes #180

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>