### PR TITLE
fix(keeper): single-writer guard in keeperSend + clearPending on demote

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { LeaderLock, makeIdentity } from "./lib/leader.js";
 import { captureAndExit } from "./lib/exit-handlers.js";
 import { StartupTracker } from "./lib/startup-tracker.js";
 import { sharedTxQueue, DRAIN_TIMEOUT_MS } from "./lib/tx-queue.js";
-import { sharedBudget } from "./lib/keeper-send.js";
+import { sharedBudget, setLeaderCheck } from "./lib/keeper-send.js";
 import { initSharedShadowHarness, sharedShadowHarness } from "./lib/shadow-harness.js";
 import { sharedDecisionLog } from "./lib/decision-log.js";
 
@@ -118,6 +118,10 @@ const leaderLock: LeaderLock | null =
 if (haEnabled && redisClient === null) {
   logger.warn("HA_ENABLED=true but KEEPER_REDIS_URL is unset — running as standalone leader");
 }
+
+// Single-writer guard for keeperSend: only land on-chain txs while we hold
+// leadership. Reads the live LeaderLock role (standalone / no-HA → always leader).
+setLeaderCheck(() => (leaderLock ? leaderLock.role() === "leader" : true));
 
 // A5: gate /health on real readiness — Railway otherwise marks the container
 // healthy the moment the HTTP server binds, well before start() finishes
@@ -799,6 +803,10 @@ async function start() {
       },
       onDemote: (reason) => {
         logger.warn("HA: demoted from leader — stopping services", { network, reason });
+        // role() is already "standby" here (LeaderLock flips it before onDemote fires),
+        // so the keeperSend single-writer guard is already closed. Drop any queued
+        // sends so this node runs no backlog after losing leadership.
+        sharedTxQueue.clearPending();
         stopAllServices();
       },
     });

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -13,6 +13,22 @@ import { isMainnetNetwork } from "../network.js";
 
 const logger = createLogger("keeper:send");
 
+// Single-writer guard. In HA mode the keeper must only land on-chain txs while it
+// holds leadership; the on-chain programs are permissionless, so this host-local
+// gate is the actual barrier against a demoted node double-sending. Wired from
+// index.ts to read the live LeaderLock role. Defaults to always-leader so the
+// standalone (no-HA) path is unchanged.
+let _isLeader: () => boolean = () => true;
+
+/**
+ * Wire the leadership check into keeperSend. Call once at startup with a
+ * function that returns true iff this node currently holds the HA leader lock
+ * (or always-true for standalone/no-HA deployments).
+ */
+export function setLeaderCheck(fn: () => boolean): void {
+  _isLeader = fn;
+}
+
 export const BASE_FEE_LAMPORTS = 5_000;
 
 const TIER_MAP: Record<TxType, PriorityFeeTier> = {
@@ -167,6 +183,15 @@ export async function keeperSend(
   maxRetries = 3,
   keeperOpts?: KeeperSendOptions,
 ): Promise<KeeperSendResult | null> {
+  // Single-writer guard: abort before any RPC if this node has lost leadership.
+  // The guard is checked here — before estimateCost, sendWithRetry, or any
+  // external call — so a demoted node cannot land transactions it queued while
+  // still leader but only now processes.
+  if (!_isLeader()) {
+    logger.warn("keeperSend: not leader — skipping send", { txType });
+    return null;
+  }
+
   const { estimatedCost, simulatedCu } = await estimateCost(connection, instructions, signers, txType);
 
   if (!budget.canSpend(estimatedCost, txType)) {

--- a/src/lib/tx-queue.ts
+++ b/src/lib/tx-queue.ts
@@ -168,6 +168,20 @@ export class TxQueue {
     }
   }
 
+  /**
+   * Drop all queued (not-yet-started) tasks from every lane. In-flight tasks
+   * (already executing) are unaffected — they run to completion.
+   *
+   * Called on demotion so a node that loses leadership does not process a
+   * backlog of sends it queued while still leader.
+   */
+  clearPending(): void {
+    for (const lane of ALL_LANES) {
+      this._lanes[lane].clear();
+    }
+    logger.info("TxQueue: cleared all pending tasks from every lane (post-demote)");
+  }
+
   getStats(): Record<TxLane, TxLaneStats> {
     const result = {} as Record<TxLane, TxLaneStats>;
     for (const lane of ALL_LANES) {

--- a/tests/lib/keeper-send-leader-gate.test.ts
+++ b/tests/lib/keeper-send-leader-gate.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Single-writer guard: keeperSend must refuse to send when the node is not the
+ * leader (e.g. a task dequeued from sharedTxQueue after an HA demotion). This is
+ * the host-local barrier against a demoted node double-landing on-chain txs,
+ * since the on-chain programs are permissionless.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  sendWithRetryKeeper: vi.fn(async () => "mock-signature"),
+}));
+vi.mock("../../src/lib/priority-fee.js", () => {
+  class HeliusPriorityFeeEstimator { estimate = vi.fn(async () => 1_000); }
+  return { HeliusPriorityFeeEstimator };
+});
+vi.mock("../../src/lib/cu-estimator.js", () => {
+  class CuEstimator { estimate = vi.fn(async () => 200_000); }
+  return { CuEstimator };
+});
+
+import * as shared from "@percolatorct/shared";
+import { keeperSend, setLeaderCheck } from "../../src/lib/keeper-send.js";
+import { KeeperBudget } from "../../src/lib/budget.js";
+import { Keypair, TransactionInstruction, PublicKey } from "@solana/web3.js";
+
+function makeDummyIx(): TransactionInstruction {
+  return new TransactionInstruction({ programId: PublicKey.default, keys: [], data: Buffer.from([]) });
+}
+function makeConnection() {
+  return {
+    simulateTransaction: vi.fn(async () => ({ value: { unitsConsumed: 200_000, err: null, logs: [] } })),
+  } as any;
+}
+
+describe("keeperSend single-writer (leadership) gate", () => {
+  let budget: KeeperBudget;
+  let connection: ReturnType<typeof makeConnection>;
+  let keypair: Keypair;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000, maxTxPerCycle: 100 });
+    connection = makeConnection();
+    keypair = Keypair.generate();
+    process.env.NETWORK = "devnet";
+    process.env.USE_HELIUS_SENDER = "false";
+  });
+  afterEach(() => {
+    setLeaderCheck(() => true); // restore module default so other suites are unaffected
+    delete process.env.DRY_RUN;
+  });
+
+  it("returns null and does NOT send when the node is not leader", async () => {
+    setLeaderCheck(() => false);
+
+    const result = await keeperSend(connection, [makeDummyIx()], [keypair], "liquidation", budget);
+
+    expect(result).toBeNull();
+    expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+    expect(connection.simulateTransaction).not.toHaveBeenCalled(); // gated before any RPC
+    expect(budget.getStats().cycleTxCount).toBe(0); // budget not charged
+  });
+
+  it("sends normally when the node is leader", async () => {
+    setLeaderCheck(() => true);
+
+    const result = await keeperSend(connection, [makeDummyIx()], [keypair], "liquidation", budget);
+
+    expect(result).not.toBeNull();
+    expect(result?.signature).toBe("mock-signature");
+    expect(shared.sendWithRetryKeeper).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/lib/tx-queue-clear-pending.test.ts
+++ b/tests/lib/tx-queue-clear-pending.test.ts
@@ -1,0 +1,55 @@
+/**
+ * TxQueue.clearPending() drops queued-but-not-started tasks across all lanes.
+ * Used on involuntary HA demotion so a node that lost leadership does not run a
+ * backlog of doomed sends.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { TxQueue } from "../../src/lib/tx-queue.js";
+
+describe("TxQueue.clearPending", () => {
+  it("drops queued-but-not-started tasks; their fn never runs", async () => {
+    // concurrency 1 so only the first task starts; the rest sit pending.
+    const q = new TxQueue({
+      liquidation: { concurrency: 1, intervalCap: 100, interval: 1 },
+      oracle: { concurrency: 1, intervalCap: 100, interval: 1 },
+      crank: { concurrency: 1, intervalCap: 100, interval: 1 },
+    });
+
+    let releaseFirst!: () => void;
+    const block = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const ran: string[] = [];
+    // First task blocks until we release it — keeps the single slot busy.
+    const p1 = q.enqueue("liquidation", async () => { ran.push("first"); await block; });
+    // These queue behind it and must be dropped by clearPending(). Their promises
+    // never settle once cleared (p-queue drops them), so we don't await them.
+    for (const id of ["a", "b", "c"]) {
+      void q.enqueue("liquidation", async () => { ran.push(id); }).catch(() => {});
+    }
+
+    // Let the first task start (occupy the slot) so a,b,c are pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(q.getStats().liquidation.pending).toBeGreaterThan(0);
+
+    q.clearPending();
+
+    // Release the in-flight task and give the loop a few ticks — a,b,c must not run.
+    releaseFirst();
+    await p1;
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(ran).toEqual(["first"]); // only the already-started task ran
+    expect(q.getStats().liquidation.pending).toBe(0);
+  });
+
+  it("is a safe no-op on an empty queue", () => {
+    const q = new TxQueue();
+    expect(() => q.clearPending()).not.toThrow();
+    for (const lane of ["liquidation", "oracle", "crank"] as const) {
+      expect(q.getStats()[lane].pending).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Completes the HA split-brain hardening (partner to the Lua EVAL CAS in #126, closes #138):

- `keeper-send.ts`: add `_isLeader` hook + `setLeaderCheck()` export. `keeperSend()` now checks the hook before any RPC; a demoted node's in-flight and new sends are blocked host-side.
- `tx-queue.ts`: add `clearPending()` which drops all queued-but-not-yet-started tasks from every lane.
- `index.ts`: wire `setLeaderCheck()` at startup; call `sharedTxQueue.clearPending()` in `onDemote` before `stopAllServices()`.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>