### PR TITLE
crankAll wedges seedable HYPERP markets — replace stale authority pre-filter with a DEX-pool readiness check

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -993,13 +993,6 @@ export class CrankService {
 
   const MAX_CONSECUTIVE_FAILURES = 10;
 
-  // GH#1251: Load the keeper key once here so we can check authority live.
-  // We re-evaluate foreign oracle authority at crankAll time rather than relying on
-  // state.foreignOracleSkipped.  After discover() resets the flag, crankMarket() would
-  // return false (and set failed++) instead of skipped.  Checking here means those markets
-  // are categorised as skipped before they even enter the crank queue.
-  const keeperKey = this._keypair.publicKey;
-
   const toCrank: string[] = [];
 
   for (const [slabAddress, state] of this.markets) {
@@ -1015,23 +1008,31 @@ export class CrankService {
     // Skipping markets whose keeper != hyperp_authority false-skipped crankable
     // markets, so the check is gone. (skippedForeignOracle stays 0.)
 
-    // PERC-1254: Live Hyperp-no-price check.
-    // Condition: admin-oracle market where keeper IS the authority, indexFeedId=all-zeros
-    // (Hyperp mode), and on-chain authority_price_e6 is still 0.  Sending KeeperCrank in
-    // this state causes OracleInvalid (0xc).  Skip eagerly — crankMarket() would return
-    // false and the batch counts it as failed rather than skipped.
-    // The flag (state.hyperpNoPriceSkipped) is set here for the first time on new markets
-    // so crankMarket's guard also short-circuits on subsequent calls.
+    // PERC-1254: Live HYPERP-no-mark check.
+    // Skip a HYPERP market (index_feed_id == [0;32]) ONLY when it is genuinely
+    // un-seedable this cycle: its on-chain mark is still 0 AND there is no DEX
+    // pool to seed it from. A zero-mark HYPERP KeeperCrank reverts with
+    // OracleInvalid (0xc) on-chain (the engine's oracle read errors when the
+    // mark is 0), so skipping such a market avoids per-cycle failure spam.
+    //
+    // crankMarket() seeds hyperp_mark_e6 via the PERMISSIONLESS UpdateHyperpMark
+    // instruction whenever a DEX pool resolves (on-chain config.dexPool, else the
+    // Supabase fallback state.dexPoolAddress — same order crankMarket uses). So a
+    // market WITH a pool is seedable in one cycle and MUST reach crankMarket;
+    // skipping it here wedges it forever (mark stays 0 → skipped again → never
+    // cranks or liquidates). The old `isAdminOracle && keeper == oracleAuthority`
+    // gating was a pre-Phase-G artifact (oracle_authority is now the vestigial
+    // hyperp_authority and does NOT gate cranking) and was exactly what wedged
+    // keeper-authority markets — dropped here to match isHyperpOracle/crankMarket.
     {
-      const isHyperpAdminOwner =
-        this.isAdminOracle(state.market) &&
-        keeperKey.equals(state.market.config.oracleAuthority) &&
-        state.market.config.indexFeedId.toBytes().every((b: number) => b === 0);
-      const onChainPriceZero = (state.market.config.authorityPriceE6 ?? BigInt(0)) === BigInt(0);
-      if (isHyperpAdminOwner && onChainPriceZero) {
+      const isHyperp = this.isHyperpOracle(state.market);
+      const onChainMarkZero = (state.market.config.authorityPriceE6 ?? BigInt(0)) === BigInt(0);
+      const hasDexPoolToSeed =
+        state.market.config.dexPool != null || state.dexPoolAddress != null;
+      if (isHyperp && onChainMarkZero && !hasDexPoolToSeed) {
         if (!state.hyperpNoPriceSkipped) {
           state.hyperpNoPriceSkipped = true;
-          logger.debug("crankAll: Hyperp-mode market with zero authority_price_e6 — skipping to prevent OracleInvalid (0xc)", { slabAddress });
+          logger.debug("crankAll: HYPERP market with zero mark and no DEX pool to seed from — skipping to prevent OracleInvalid (0xc). Admin must call SetDexPool.", { slabAddress });
         }
         skippedHyperpNoPrice++;
         continue;

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -813,20 +813,163 @@ describe('CrankService', () => {
       }
     });
 
-    it('PERC-1254: should crank Hyperp market once fetchPrice returns a valid price', async () => {
+    it('PoC: a seedable HYPERP market (DEX pool configured, zero mark, keeper is authority) is wrongly skipped by crankAll before UpdateHyperpMark can seed it', async () => {
+      // The wedge: crankAll's pre-filter skips HYPERP markets where the keeper is
+      // the (now-vestigial) oracle authority and the mark is still 0 — BEFORE
+      // crankMarket runs. But crankMarket is where the permissionless
+      // UpdateHyperpMark (which seeds hyperp_mark_e6 from the DEX pool) lives. A
+      // market with a configured DEX pool is seedable in exactly one crank, yet
+      // it is skipped forever: mark stays 0 → skipped again next cycle. It never
+      // cranks and never liquidates.
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'mock-sig', estimatedCost: 5000, simulatedCu: 10000 } as any);
+
+      const slab = 'HyperpWedge11111111111111111111111111111';
+      const ZERO = new Uint8Array(32);
+      const KEEPER = '11111111111111111111111111111112';
+      const POOL = 'So11111111111111111111111111111111111111112';
+
+      vi.mocked(shared.loadKeypair).mockReturnValue({
+        publicKey: { toBase58: () => KEEPER, equals: (o: any) => o?.toBase58?.() === KEEPER },
+        secretKey: new Uint8Array(64),
+      } as any);
+
+      const localCrank = new CrankService(mockOracleService);
+
+      const market = {
+        slabAddress: { toBase58: () => slab, equals: (_o: any) => false },
+        programId: { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'MintWedge11111111111111111111111111111' },
+          indexFeedId: { toBytes: () => ZERO, equals: (_o: any) => false }, // HYPERP
+          // Keeper IS the (vestigial) oracle authority — the condition that pre-fix forces the skip.
+          oracleAuthority: { toBase58: () => KEEPER, equals: (o: any) => o?.toBase58?.() === KEEPER },
+          authorityPriceE6: BigInt(0), // mark not yet seeded
+          lastEffectivePriceE6: BigInt(0),
+          dexPool: { toBase58: () => POOL }, // a DEX pool IS pinned → seedable via UpdateHyperpMark
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminWedge1111111111111111111111111111' } },
+      };
+
+      vi.mocked(core.discoverMarkets).mockResolvedValue([market as any]);
+
+      try {
+        await localCrank.discover();
+        // Pre-cache pool metadata so crankMarket's UpdateHyperpMark build skips RPC.
+        const state = localCrank.getMarkets().get(slab)!;
+        state.dexPoolResolvedAddress = POOL;
+        state.dexPoolRemainingAccounts = [];
+
+        const result = await localCrank.crankAll();
+
+        // Seedable market must reach crankMarket so UpdateHyperpMark can seed it.
+        expect(keeperSendModule.keeperSend).toHaveBeenCalled(); // FAILS on main: skipped before crankMarket
+        expect(result.success).toBe(1);
+        expect(result.skipped).toBe(0);
+      } finally {
+        localCrank.stop();
+      }
+    });
+
+    it('still skips a zero-mark HYPERP market with NO DEX pool, regardless of authority (foreign authority)', async () => {
+      // Guards that the fix NARROWED the skip (now keyed on no-DEX-pool), not removed it.
+      // On main this foreign-authority case was NOT skipped (the gate required
+      // keeper==authority) → it flowed to a crank-only tx that reverts 0xc every cycle.
+      // Post-fix it is an honest skip — an improvement, not a regression.
+      const slab = 'HyperpNoPoolFA11111111111111111111111111';
+      const ZERO = new Uint8Array(32);
+      const KEEPER = '11111111111111111111111111111112';
+
+      vi.mocked(shared.loadKeypair).mockReturnValue({
+        publicKey: { toBase58: () => KEEPER, equals: (o: any) => o?.toBase58?.() === KEEPER },
+        secretKey: new Uint8Array(64),
+      } as any);
+      const localCrank = new CrankService(mockOracleService);
+
+      const market = {
+        slabAddress: { toBase58: () => slab, equals: (_o: any) => false },
+        programId: { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'MintNoPoolFA111111111111111111111111111' },
+          indexFeedId: { toBytes: () => ZERO, equals: (_o: any) => false }, // HYPERP
+          // Foreign authority — NOT the keeper.
+          oracleAuthority: { toBase58: () => 'ForeignAuthNP11111111111111111111111111', equals: (_o: any) => false },
+          authorityPriceE6: BigInt(0), // unseeded
+          lastEffectivePriceE6: BigInt(0),
+          // no dexPool, and no Supabase fallback set → genuinely un-seedable
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminNoPoolFA1111111111111111111111111' } },
+      };
+
+      vi.mocked(core.discoverMarkets).mockResolvedValue([market as any]);
+      try {
+        await localCrank.discover();
+        const result = await localCrank.crankAll();
+        expect(result.skipped).toBe(1);
+        expect(result.failed).toBe(0);
+        expect(keeperSendModule.keeperSend).not.toHaveBeenCalled();
+        expect(localCrank.getMarkets().get(slab)!.hyperpNoPriceSkipped).toBe(true);
+      } finally {
+        localCrank.stop();
+      }
+    });
+
+    it('cranks a zero-mark HYPERP market seedable only via the Supabase DEX-pool fallback (OR over both pool sources)', async () => {
+      // Exercises the second arm of hasDexPoolToSeed: on-chain config.dexPool is
+      // null but state.dexPoolAddress (Supabase) is set. An AND check would
+      // re-wedge this market; the OR check correctly routes it to crankMarket.
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'mock-sig', estimatedCost: 5000, simulatedCu: 10000 } as any);
+      const slab = 'HyperpSupabasePool1111111111111111111111';
+      const ZERO = new Uint8Array(32);
+      const KEEPER = '11111111111111111111111111111112';
+      const POOL = 'So11111111111111111111111111111111111111112';
+
+      vi.mocked(shared.loadKeypair).mockReturnValue({
+        publicKey: { toBase58: () => KEEPER, equals: (o: any) => o?.toBase58?.() === KEEPER },
+        secretKey: new Uint8Array(64),
+      } as any);
+      const localCrank = new CrankService(mockOracleService);
+
+      const market = {
+        slabAddress: { toBase58: () => slab, equals: (_o: any) => false },
+        programId: { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'MintSupaPool11111111111111111111111111' },
+          indexFeedId: { toBytes: () => ZERO, equals: (_o: any) => false }, // HYPERP
+          oracleAuthority: { toBase58: () => KEEPER, equals: (o: any) => o?.toBase58?.() === KEEPER },
+          authorityPriceE6: BigInt(0), // unseeded
+          lastEffectivePriceE6: BigInt(0),
+          dexPool: null, // no on-chain pinned pool ...
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminSupaPool1111111111111111111111111' } },
+      };
+
+      vi.mocked(core.discoverMarkets).mockResolvedValue([market as any]);
+      try {
+        await localCrank.discover();
+        const state = localCrank.getMarkets().get(slab)!;
+        state.dexPoolAddress = POOL; // ... only the Supabase fallback is available
+        state.dexPoolResolvedAddress = POOL; // pre-cache so crankMarket skips RPC
+        state.dexPoolRemainingAccounts = [];
+
+        const result = await localCrank.crankAll();
+        expect(keeperSendModule.keeperSend).toHaveBeenCalled();
+        expect(result.skipped).toBe(0);
+        expect(result.success).toBe(1);
+      } finally {
+        localCrank.stop();
+      }
+    });
+
+    it('PERC-1254: skips an unseeded HYPERP market with no DEX pool, then cranks it once a pool is configured', async () => {
       vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({ signature: 'mock-sig', estimatedCost: 5000 } as any);
 
       const slabHyperp = 'HyperpWithPrice111111111111111111111111';
       const ZERO_BYTES = new Uint8Array(32);
       const KEEPER_PUBKEY_STR2 = '11111111111111111111111111111112';
-
-      const keeperOracleAuth2 = {
-        toBase58: () => KEEPER_PUBKEY_STR2,
-        equals: (other: any) => {
-          if (other?.toBase58) return other.toBase58() === KEEPER_PUBKEY_STR2;
-          return false;
-        },
-      };
+      const POOL = 'So11111111111111111111111111111111111111112';
 
       // Set mock BEFORE constructing the local service so _keypair cache picks it up.
       vi.mocked(shared.loadKeypair).mockReturnValue({
@@ -846,12 +989,15 @@ describe('CrankService', () => {
         config: {
           collateralMint: { toBase58: () => 'Mint3111111111111111111111111111111111' },
           indexFeedId: { toBytes: () => ZERO_BYTES, equals: (o: any) => false },
-          oracleAuthority: keeperOracleAuth2,
-          authorityPriceE6: BigInt(0),
+          // Keeper is the (vestigial) authority — under the old code this forced a
+          // skip even once a pool was available; it must not anymore.
+          oracleAuthority: {
+            toBase58: () => KEEPER_PUBKEY_STR2,
+            equals: (other: any) => other?.toBase58?.() === KEEPER_PUBKEY_STR2,
+          },
+          authorityPriceE6: BigInt(0), // unseeded
           lastEffectivePriceE6: BigInt(1_000_000),
-          // New model: a HYPERP market refreshes its mark from a pinned DEX pool
-          // (UpdateHyperpMark), not an off-chain fetchPrice.
-          dexPool: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+          dexPool: null, // no pinned DEX pool yet → genuinely un-seedable this cycle
         },
         params: { maintenanceMarginBps: 500n },
         header: { admin: { toBase58: () => 'Admin311111111111111111111111111111111' } },
@@ -860,19 +1006,21 @@ describe('CrankService', () => {
       vi.mocked(core.discoverMarkets).mockResolvedValue([hyperpMarket as any]);
 
       try {
-        // First cycle: no price
-        mockOracleService.fetchPrice = vi.fn().mockResolvedValue(null);
+        // First cycle: zero mark AND no DEX pool → un-seedable → skipped (not failed).
         await localCrank.discover();
         const result1 = await localCrank.crankAll();
         expect(result1.failed).toBe(0);
-        const stateAfterSkip = localCrank.getMarkets().get(slabHyperp)!;
-        expect(stateAfterSkip.hyperpNoPriceSkipped).toBe(true);
+        expect(result1.skipped).toBe(1);
+        const state = localCrank.getMarkets().get(slabHyperp)!;
+        expect(state.hyperpNoPriceSkipped).toBe(true);
 
-        // Second cycle: the pinned DEX pool is now resolved (cached), so
-        // UpdateHyperpMark can refresh the mark. Simulate discovery resetting the flag.
-        stateAfterSkip.hyperpNoPriceSkipped = false;
-        stateAfterSkip.dexPoolResolvedAddress = 'So11111111111111111111111111111111111111112';
-        stateAfterSkip.dexPoolRemainingAccounts = [];
+        // A DEX pool is now configured (admin SetDexPool / Supabase). The market
+        // becomes seedable, so crankMarket sends UpdateHyperpMark + crank. Pre-cache
+        // the resolved pool metadata so the build skips the RPC vault lookup.
+        state.hyperpNoPriceSkipped = false;
+        state.dexPoolAddress = POOL;
+        state.dexPoolResolvedAddress = POOL;
+        state.dexPoolRemainingAccounts = [];
 
         const result2 = await localCrank.crankMarket(slabHyperp);
         expect(result2).toBe(true);


### PR DESCRIPTION
## Problem

`crankAll()` and `crankMarket()` disagreed on how to treat a HYPERP-mode market. `crankAll()`'s pre-filter skipped a market — `continue`, before `crankMarket()` ever ran — when:

```ts
isAdminOracle(market) && keeper == oracleAuthority && indexFeedId == [0;32] && authorityPriceE6 == 0
```

But `crankMarket()` is where the **permissionless** `UpdateHyperpMark` instruction lives — it seeds `hyperp_mark_e6` from the pinned DEX pool (on-chain `config.dexPool`, or the Supabase fallback `state.dexPoolAddress`). So a HYPERP market that has a DEX pool but a still-zero mark, with the keeper set as the (vestigial) oracle authority, was skipped before it could be seeded. The mark stayed 0, so it was skipped again the next cycle — **forever**. That market never cranked and never liquidated.

Two things were wrong with the pre-filter:

1. **Stale gating.** It keyed off `oracle_authority` (now the vestigial `hyperp_authority`) and `keeper == authority`. Post-Phase-G that field does not gate cranking, and `UpdateHyperpMark` has no authority check — so authority is irrelevant. This is the same stale-alias condition already removed from `isHyperpOracle`, left behind here.
2. **It skipped seedable markets.** The skip was the only thing between the market and the `crankMarket()` call that would have seeded it. Its stated rationale ("KeeperCrank → OracleInvalid") is obsolete: `crankMarket()` bundles `UpdateHyperpMark` (which seeds the mark from the DEX pool) ahead of `KeeperCrank` in the same submission.

## Fix

Replace the skip condition with the one signal that actually makes a zero-mark HYPERP market un-crankable: **no DEX pool to seed from.** Skip only when the market is HYPERP **and** its on-chain mark is 0 **and** there is no DEX pool available from either source `crankMarket()` consults (`config.dexPool` OR `state.dexPoolAddress` — same order, combined with OR so an on-chain-only pin isn't missed). The `isAdminOracle`/`keeper == authority` conditions are dropped, and the mode check now reuses `isHyperpOracle` so `crankAll()` and `crankMarket()` classify HYPERP identically.

Net effect:
- Seedable markets (a DEX pool is configured) now flow to `crankMarket()` and are seeded by `UpdateHyperpMark` in one cycle — the wedge is gone.
- Genuinely priceless markets (zero mark, no pool) are still skipped — no `OracleInvalid` failure spam — now **independent of who the authority is** (an improvement: previously a foreign-authority no-pool market fell through to a guaranteed per-cycle on-chain revert).

The now-dead live-authority `keeperKey` read in `crankAll()` is removed. The `skippedHyperpNoPrice` counter and accounting are unchanged.

## Tests (`tests/services/crank.test.ts`)

- **PoC** (fails on `main`): a seedable HYPERP market (DEX pool pinned, zero mark, keeper is authority) is no longer skipped — it reaches `crankMarket` and a tx is sent.
- a zero-mark HYPERP market with **no** DEX pool is still skipped, **regardless of authority** (foreign-authority case) — narrowed, not removed.
- a zero-mark HYPERP market seedable only via the **Supabase fallback** (on-chain `dexPool` null, `state.dexPoolAddress` set) is cranked — exercises the OR over both pool sources.
- the existing "no DEX pool → skip" coverage is rewritten to the corrected semantics (no pool → skip; pool configured → crank).

Full suite green (691 passed) and `tsc --noEmit` clean.

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HYPERP market update skip conditions to correctly evaluate DEX pool seeding availability from multiple sources
  * Fixed regression where eligible markets were incorrectly skipped during cranking with zero oracle prices

* **Tests**
  * Expanded test coverage for HYPERP market cranking with various DEX pool seeding scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->