### PR TITLE
fix(crank): M8 — add per-market in-flight guard so registerMarket cannot race the timer cycle

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -183,6 +183,16 @@ export class CrankService {
   private _isRunning = false;
   private _cycling = false;
   private _cycleStartedAt = 0;
+  // M8: per-market in-flight guard. `_cycling` is a process-wide flag for
+  // the timer-driven crankAll cycle, but other entry points (registerMarket
+  // from the /register HTTP endpoint, and potentially LaserStream debounce
+  // handlers) can call crankMarket directly — bypassing `_cycling`. Without
+  // this guard, a /register HTTP arriving mid-cycle could fire crankMarket
+  // concurrently with crankAll's fan-out on the same slab, producing
+  // duplicate KeeperCrank txs for the same market. Set/delete at crankMarket
+  // entry/exit so every code path that reaches crankMarket honors the same
+  // in-flight invariant.
+  private _inflightMarkets = new Set<string>();
   private _stalePauseCheck?: (slabAddress: string) => boolean;
   // P1 FIX: Cache keypair at construction — was reading from disk on every crank cycle (every 30s)
   private readonly _keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
@@ -671,6 +681,17 @@ export class CrankService {
   }
 
   async crankMarket(slabAddress: string): Promise<boolean> {
+    // M8: per-market in-flight guard. Bail immediately if another caller is
+    // already running crankMarket for this slab. Closes the race where the
+    // /register HTTP endpoint and the timer-driven crankAll fan-out both
+    // dispatch crankMarket for the same market — pre-fix this could produce
+    // duplicate KeeperCrank txs since `_cycling` only gates the overall
+    // crankAll loop, not the per-market work.
+    if (this._inflightMarkets.has(slabAddress)) {
+      logger.debug("crankMarket: in-flight for slab, skipping concurrent call", { slabAddress });
+      return false;
+    }
+
     const state = this.markets.get(slabAddress);
     if (!state) {
       logger.warn("Market not found", { slabAddress });
@@ -679,6 +700,7 @@ export class CrankService {
 
     const { market } = state;
 
+    this._inflightMarkets.add(slabAddress);
     try {
       const connection = getConnection();
       const keypair = this._keypair;
@@ -956,6 +978,11 @@ export class CrankService {
         error: err instanceof Error ? err.message : String(err),
       });
       return false;
+    } finally {
+      // M8: always release the per-market guard, even if the body throws or
+      // returns early. JavaScript runs finally after `return` in the try/catch
+      // above, so this fires on every code path.
+      this._inflightMarkets.delete(slabAddress);
     }
   }
 

--- a/tests/poc/m8.poc.test.ts
+++ b/tests/poc/m8.poc.test.ts
@@ -1,0 +1,134 @@
+/**
+ * M8 PoC — registerMarket bypasses _cycling, allowing duplicate KeeperCrank
+ * txs for the same slab when an HTTP /register arrives mid-cycle.
+ *
+ * THE BUG (pre-fix):
+ *   - `_cycling` is a process-wide guard preventing two crankAll cycles
+ *     from running concurrently. Set by start()'s setInterval body.
+ *   - registerMarket (called by the /register HTTP endpoint) calls
+ *     crankMarket(slabAddress) DIRECTLY at line 1222 — bypassing _cycling.
+ *   - If the timer-driven crankAll is iterating its market map at the
+ *     moment a /register HTTP arrives:
+ *       1. registerMarket.set(slab → newState) at line 1208
+ *       2. registerMarket.crankMarket(slab) at line 1222
+ *       3. crankAll's fan-out may also call crankMarket(slab) on its
+ *          next iteration, depending on Map iteration semantics
+ *     → two concurrent crankMarket calls → two concurrent KeeperCrank txs
+ *       → wasted gas + doubled funding accrual within the same window.
+ *
+ *   The single-source-of-truth `_cycling` flag was supposed to gate ALL
+ *   crank activity, but only the setInterval body honors it.
+ *
+ * THE FIX (this PR):
+ *   - Add `_inflightMarkets: Set<string>` field.
+ *   - In crankMarket, check at entry: if slab is in the set, bail
+ *     (return false). Else add to set.
+ *   - Wrap the existing try/catch with `finally { delete }` so the guard
+ *     is always released, even on throws.
+ *   - registerMarket's call to crankMarket now respects the same guard
+ *     without any code change to registerMarket itself.
+ *
+ *   This is also the deferred Option F defense-in-depth from H4 (Agent C
+ *   recommended a per-market in-flight guard alongside the watchdog fix).
+ *
+ * This PoC walks through the race at the observer-shape level.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+// Mini-reproduction of the relevant shapes.
+class Service {
+  private _inflightMarkets = new Set<string>();
+  onSend = vi.fn<(slab: string) => void>();
+
+  async crankMarket(slab: string, opts: { simulateBody: () => Promise<void> }): Promise<boolean> {
+    if (this._inflightMarkets.has(slab)) return false;
+    this._inflightMarkets.add(slab);
+    try {
+      await opts.simulateBody();
+      this.onSend(slab);
+      return true;
+    } finally {
+      this._inflightMarkets.delete(slab);
+    }
+  }
+}
+
+describe("M8 PoC — per-market in-flight guard", () => {
+  it("OLD pattern: two concurrent calls each send a tx (DUPLICATE)", async () => {
+    let sent = 0;
+    async function oldCrankMarket(): Promise<boolean> {
+      // No guard — just runs the body.
+      await new Promise((r) => setTimeout(r, 10));
+      sent++;
+      return true;
+    }
+
+    const [a, b] = await Promise.all([oldCrankMarket(), oldCrankMarket()]);
+    expect(a).toBe(true);
+    expect(b).toBe(true);
+    expect(sent).toBe(2); // ← DUPLICATE TX
+  });
+
+  it("NEW pattern: second concurrent call returns false, only ONE tx sent", async () => {
+    const svc = new Service();
+
+    let releaseBody: (value: unknown) => void;
+    const bodyHangs = new Promise((resolve) => { releaseBody = resolve; });
+
+    // First call hangs in the body; second call should see it in flight.
+    const first = svc.crankMarket("SLAB-A", { simulateBody: () => bodyHangs as Promise<void> });
+    await new Promise((r) => setTimeout(r, 0));
+    const second = await svc.crankMarket("SLAB-A", { simulateBody: async () => {} });
+
+    expect(second).toBe(false);
+    expect(svc.onSend).not.toHaveBeenCalled();
+
+    releaseBody!(undefined);
+    expect(await first).toBe(true);
+    expect(svc.onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("NEW pattern: guard is per-slab (different slabs don't block each other)", async () => {
+    const svc = new Service();
+
+    let releaseA: (value: unknown) => void;
+    const aHangs = new Promise((resolve) => { releaseA = resolve; });
+
+    // SLAB-A hangs.
+    const a = svc.crankMarket("SLAB-A", { simulateBody: () => aHangs as Promise<void> });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // SLAB-B is a DIFFERENT slab — not blocked by A.
+    const b = await svc.crankMarket("SLAB-B", { simulateBody: async () => {} });
+    expect(b).toBe(true);
+    expect(svc.onSend).toHaveBeenCalledWith("SLAB-B");
+
+    releaseA!(undefined);
+    expect(await a).toBe(true);
+    expect(svc.onSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("NEW pattern: guard releases even when the body throws", async () => {
+    const svc = new Service();
+
+    const failed = await svc.crankMarket("SLAB-C", {
+      simulateBody: async () => { throw new Error("body crashed"); },
+    }).catch(() => "threw");
+
+    // The throw propagates here in this mini-shape, but the SERVICE's
+    // finally still ran. A follow-up call on SLAB-C must work.
+    expect(failed).toBe("threw");
+
+    const recovery = await svc.crankMarket("SLAB-C", { simulateBody: async () => {} });
+    expect(recovery).toBe(true);
+  });
+
+  it("NEW pattern: sequential calls work fine (the guard is per-call, not permanent)", async () => {
+    const svc = new Service();
+
+    expect(await svc.crankMarket("SLAB-D", { simulateBody: async () => {} })).toBe(true);
+    expect(await svc.crankMarket("SLAB-D", { simulateBody: async () => {} })).toBe(true);
+    expect(await svc.crankMarket("SLAB-D", { simulateBody: async () => {} })).toBe(true);
+    expect(svc.onSend).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -395,6 +395,74 @@ describe('CrankService', () => {
         }),
       );
     });
+
+    // M8: per-market in-flight guard. The /register HTTP endpoint and the
+    // timer-driven crankAll fan-out both call crankMarket directly. Pre-fix,
+    // a /register HTTP arriving mid-cycle could fire a duplicate KeeperCrank
+    // tx for the same slab. The guard makes concurrent crankMarket calls for
+    // the same slab a no-op (second call returns false immediately).
+    //
+    // We test the contract directly via the private `_inflightMarkets` set
+    // rather than racing async timing — the latter proved fragile across
+    // machines.
+    it('M8: crankMarket bails when slab is already in _inflightMarkets (no send)', async () => {
+      const slabAddress = 'MarketM8GuardAaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      vi.mocked(core.discoverMarkets).mockResolvedValue([{
+        slabAddress: { toBase58: () => slabAddress },
+        programId: { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+          indexFeedId: { toBytes: () => new Uint8Array(32).fill(1) },
+          oracleAuthority: { toBase58: () => 'NonZeroAuth1111111111111111111111111111111' },
+          authorityPriceE6: 1_000_000n,
+          authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminM8G11111111111111111111111111111111' } },
+      }] as any);
+      await crankService.discover();
+
+      const sendSpy = vi.mocked(keeperSendModule.keeperSend);
+      sendSpy.mockClear();
+
+      // Simulate "another caller is already in flight" by pre-populating the set.
+      const inflight: Set<string> = (crankService as any)._inflightMarkets;
+      inflight.add(slabAddress);
+
+      const result = await crankService.crankMarket(slabAddress);
+
+      expect(result).toBe(false);
+      expect(sendSpy).not.toHaveBeenCalled();
+
+      // Clean up so this test doesn't pollute later tests in the suite.
+      inflight.delete(slabAddress);
+    });
+
+    it('M8: _inflightMarkets is empty before AND after a crankMarket call (released by finally)', async () => {
+      const slabAddress = 'MarketM8ReleaseAaaaaaaaaaaaaaaaaaaaaaaaa';
+      vi.mocked(core.discoverMarkets).mockResolvedValue([{
+        slabAddress: { toBase58: () => slabAddress },
+        programId: { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+          indexFeedId: { toBytes: () => new Uint8Array(32).fill(1) },
+          oracleAuthority: { toBase58: () => 'NonZeroAuth1111111111111111111111111111111' },
+          authorityPriceE6: 1_000_000n,
+          authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminM8R11111111111111111111111111111111' } },
+      }] as any);
+      await crankService.discover();
+
+      const inflight: Set<string> = (crankService as any)._inflightMarkets;
+      expect(inflight.has(slabAddress)).toBe(false);
+
+      await crankService.crankMarket(slabAddress);
+
+      // Whether the body succeeded or failed, the finally clause must release.
+      expect(inflight.has(slabAddress)).toBe(false);
+    });
   });
 
   describe('PERC-381: permanent skip cooldown', () => {


### PR DESCRIPTION
## Summary

Fixes **M8** from the internal pre-mainnet audit. Adds a per-market in-flight guard to `crankMarket` so concurrent callers (e.g., `registerMarket` via the `/register` HTTP endpoint and the timer-driven `crankAll` fan-out) can't produce duplicate KeeperCrank txs for the same slab.

## Root cause

`CrankService.registerMarket` at `src/services/crank.ts:1222` calls `await this.crankMarket(slabAddress)` directly — bypassing the process-wide `_cycling` guard that gates only the setInterval-driven `crankAll` loop. Any path that reaches `crankMarket` outside that loop (`/register` HTTP, LaserStream debounce handlers, etc.) slips past it.

A `/register` HTTP arriving mid-cycle can produce **two concurrent `crankMarket` calls for the same slab**, each building a fresh blockhash and signing independently. Solana's signature-based dedup does NOT apply (different signatures). Result: duplicate `KeeperCrank` txs, wasted priority fees, possibly doubled funding accrual within the same window if the on-chain handler is not slot-gated.

## Fix

Per-market in-flight set:

```ts
// field
private _inflightMarkets = new Set<string>();

async crankMarket(slabAddress: string): Promise<boolean> {
  if (this._inflightMarkets.has(slabAddress)) {
    logger.debug("crankMarket: in-flight for slab, skipping concurrent call", { slabAddress });
    return false;
  }
  // ...existing market/state lookup...
  this._inflightMarkets.add(slabAddress);
  try {
    // ...existing body...
  } catch (err) {
    // ...existing error handling...
    return false;
  } finally {
    this._inflightMarkets.delete(slabAddress); // released even on `return false` inside try/catch
  }
}
```

No changes needed to `registerMarket` itself — its call to `crankMarket` now respects the same guard automatically.

This also closes the deferred **Option F defense-in-depth** that Agent C recommended during the **H4** (#132) hostile reverify — a per-market guard alongside the watchdog fix.

## Files touched

- `src/services/crank.ts` — add `_inflightMarkets` field, guard check at entry, `finally { delete }` clause.
- `tests/services/crank.test.ts` — 2 new unit tests.
- `tests/poc/m8.poc.test.ts` — 5 PoC tests.

## Test plan

- [x] **`crankMarket bails when slab is already in _inflightMarkets`** — pre-populate the set, call crankMarket, verify it returns `false` and `keeperSend` is not called.
- [x] **`_inflightMarkets is empty before AND after a crankMarket call`** — verify the `finally` clause always releases.
- [x] **PoC**: OLD pattern (no guard) — two concurrent calls each send a tx (DUPLICATE).
- [x] **PoC**: NEW pattern — second concurrent call returns false, only ONE tx sent.
- [x] **PoC**: Per-slab isolation — different slabs don't block each other.
- [x] **PoC**: Guard releases on body throw.
- [x] **PoC**: Sequential calls work normally.
- [x] crank suite: 28 passed (+2 new M8 tests).
- [x] M8 PoC: 5 passed.
- [x] Full vitest suite: **619 passed / 26 skipped** — no regressions.
- [x] `pnpm build` clean.

## Severity

**MEDIUM** — real concurrency hole. Orthogonal to H4 (#132): H4 was the watchdog-clear race; M8 is the bypass-entry race. Both live in audit cluster `CL-DOUBLE-EXEC`. With both fixes in place, `crankMarket` can never run concurrently for the same slab from any code path.

## Risk

- **Backward-compatible.** Sequential calls (normal operation) are unaffected — the guard is per-call, not permanent.
- **Defense-in-depth.** Even after H4 lands, the per-market guard catches any future code path that calls `crankMarket` outside the timer loop.

## Related

- **H4** (#132) — watchdog fix that prevented `_cycling` flag flipping while `crankAll` was in-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed concurrent operation handling to prevent duplicate transactions from being submitted when multiple calls target the same market simultaneously.

* **Tests**
  * Added test coverage verifying the concurrent operation guard works correctly across various scenarios, including error conditions and sequential operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->