### PR TITLE
fix: reject ALLOW_INSECURE_RPC=true on mainnet at boot (H9)

### DIFF
--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -121,6 +121,18 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
   // http:// and ws:// transmit signed transactions and account data unencrypted,
   // enabling MITM attacks on the network path.
   const allowInsecure = env.ALLOW_INSECURE_RPC === "true";
+
+  // H9: ALLOW_INSECURE_RPC=true on mainnet exposes signed transactions to MITM.
+  // The localhost sub-case is caught by rejectLocalRpcUrl, but a remote plaintext
+  // HTTP URL (e.g. http://some-rpc.helius.xyz) with ALLOW_INSECURE_RPC=true is
+  // not caught. Reject unconditionally when NETWORK=mainnet.
+  if (allowInsecure && isMainnetEnv(env)) {
+    throw new Error(
+      "ALLOW_INSECURE_RPC=true is not permitted when NETWORK=mainnet. " +
+      "Plaintext RPC connections expose signed transactions to MITM attacks. " +
+      "Use an https:// or wss:// RPC endpoint on mainnet.",
+    );
+  }
   // A.3 (HIGH): HA leader election pins the Redis lock key to NETWORK. Legacy
   // index.ts fell back to `?? "devnet"` when NETWORK was unset, which meant a
   // mainnet keeper without NETWORK would silently share a lock with devnet

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -53,7 +53,7 @@ describe("validateKeeperEnvGuards", () => {
     expect(() => validateKeeperEnvGuards(env)).toThrow("must use wss://");
   });
 
-  it("allows insecure URLs when ALLOW_INSECURE_RPC=true", () => {
+  it("allows insecure URLs when ALLOW_INSECURE_RPC=true (non-mainnet)", () => {
     const env = {
       SOLANA_RPC_URL: "http://localhost:8899",
       SOLANA_RPC_WS_URL: "ws://localhost:8900",
@@ -61,6 +61,40 @@ describe("validateKeeperEnvGuards", () => {
     } as NodeJS.ProcessEnv;
 
     expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
+
+  // H9: ALLOW_INSECURE_RPC=true on mainnet exposes signed txs to MITM.
+  describe("H9: ALLOW_INSECURE_RPC=true rejected on mainnet", () => {
+    it("throws when ALLOW_INSECURE_RPC=true with NETWORK=mainnet", () => {
+      const env = {
+        SOLANA_RPC_URL: "http://some-rpc.helius.xyz",
+        ALLOW_INSECURE_RPC: "true",
+        NETWORK: "mainnet",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /ALLOW_INSECURE_RPC.*not permitted.*mainnet/i,
+      );
+    });
+
+    it("throws when ALLOW_INSECURE_RPC=true with NETWORK=mainnet (via network.ts normalization)", () => {
+      const env = {
+        ALLOW_INSECURE_RPC: "true",
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: "https://mainnet.rpc.example.com",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /ALLOW_INSECURE_RPC.*not permitted.*mainnet/i,
+      );
+    });
+
+    it("allows ALLOW_INSECURE_RPC=true on devnet", () => {
+      const env = {
+        ALLOW_INSECURE_RPC: "true",
+        NETWORK: "devnet",
+        SOLANA_RPC_URL: "http://localhost:8899",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
   });
 
   it("does not throw for https:// and wss:// URLs", () => {
@@ -202,12 +236,12 @@ describe("validateKeeperEnvGuards", () => {
       );
     });
 
-    it("rejects mainnet+localhost even when ALLOW_INSECURE_RPC=true (separate guard)", () => {
-      // ALLOW_INSECURE_RPC bypasses the http:// guard but NOT the mainnet+localhost guard
+    it("rejects mainnet+localhost regardless of ALLOW_INSECURE_RPC (separate guard)", () => {
+      // H9 blocks ALLOW_INSECURE_RPC=true on mainnet entirely; the localhost guard
+      // independently fires when ALLOW_INSECURE_RPC is absent. Both paths reject.
       const env = {
         NETWORK: "mainnet",
-        SOLANA_RPC_URL: "http://localhost:8899",
-        ALLOW_INSECURE_RPC: "true",
+        SOLANA_RPC_URL: "https://localhost:8899",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).toThrow(
         /SOLANA_RPC_URL points at .* but NETWORK=mainnet/,
@@ -393,14 +427,14 @@ describe("validateKeeperEnvGuards", () => {
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
 
-    // The guard is independent of ALLOW_INSECURE_RPC (which only gates http/https).
-    it("rejects a devnet fallback on mainnet even when ALLOW_INSECURE_RPC=true", () => {
+    // The guard is independent of ALLOW_INSECURE_RPC (H9 blocks ALLOW_INSECURE_RPC=true
+    // on mainnet entirely; this test verifies the devnet-host guard fires on its own).
+    it("rejects a devnet fallback on mainnet (guard is independent of ALLOW_INSECURE_RPC)", () => {
       const env = {
         NETWORK: "mainnet",
         SOLANA_RPC_URL: MAINNET,
         RPC_URL: MAINNET,
         FALLBACK_RPC_URL: "https://api.devnet.solana.com",
-        ALLOW_INSECURE_RPC: "true",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).toThrow(
         /FALLBACK_RPC_URL points at devnet\/testnet host/,

--- a/tests/network-guard-bypass.poc.test.ts
+++ b/tests/network-guard-bypass.poc.test.ts
@@ -62,7 +62,11 @@ describe("regression: all NETWORK readers agree via the canonical resolver", () 
   });
 
   it("FIXED: with NETWORK='Mainnet' (and ' mainnet '), a localhost RPC now refuses to boot", () => {
-    const base = { SOLANA_RPC_URL: "http://127.0.0.1:8899", ALLOW_INSECURE_RPC: "true" } as NodeJS.ProcessEnv;
+    // Use https:// so the http-scheme guard is not in play; the localhost guard
+    // ("refusing to boot") fires independently. ALLOW_INSECURE_RPC is omitted
+    // because H9 now blocks that flag on mainnet entirely — both are refusals,
+    // but the localhost guard's "refusing to boot" message is what this test asserts.
+    const base = { SOLANA_RPC_URL: "https://127.0.0.1:8899" } as NodeJS.ProcessEnv;
     for (const net of ["Mainnet", " mainnet ", "MAINNET"]) {
       expect(() => validateKeeperEnvGuards({ ...base, NETWORK: net }), `NETWORK=${JSON.stringify(net)}`).toThrow(
         /refusing to boot/i,


### PR DESCRIPTION
Closes #91.

## What

Adds H9 guard to `validateKeeperEnvGuards`: if `ALLOW_INSECURE_RPC=true` and `NETWORK=mainnet`, throw at boot with a clear message. Plaintext HTTP/WS on mainnet exposes signed transactions to MITM; the per-URL `https://` check was bypassable via the flag — this closes that unconditionally.

## Test evidence

```
Test Files  70 passed | 2 skipped (72)
     Tests  760 passed | 24 skipped (784)
```
`pnpm run build` → clean (zero tsc errors).

## Test changes

Two existing `env-guards.test.ts` tests and one `network-guard-bypass.poc.test.ts` test used `ALLOW_INSECURE_RPC=true` on mainnet to reach a different guard. Now that H9 fires first, those tests are restructured: `ALLOW_INSECURE_RPC` removed (or HTTPS URL used) so each test still reaches and asserts its intended guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)