### PR TITLE
fix: remove dead signature replay map from crank and liquidation (L2)

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -177,9 +177,6 @@ export class CrankService {
   private readonly oracleService: OracleService;
   private lastCycleResult = { success: 0, failed: 0, skipped: 0 };
   private lastDiscoveryTime = 0;
-  // BC1: Signature replay protection
-  private recentSignatures = new Map<string, number>(); // signature -> timestamp
-  private readonly signatureTTLMs = 60_000; // 60 seconds
   private _isRunning = false;
   private _cycling = false;
   private _cycleStartedAt = 0;
@@ -910,9 +907,6 @@ export class CrankService {
         throw err;
       }
 
-      // BC1: Track signature to prevent replay attacks
-      this.recentSignatures.set(sig, Date.now());
-
       state.lastCrankTime = Date.now();
       state.successCount++;
       state.consecutiveFailures = 0;
@@ -1132,12 +1126,6 @@ export class CrankService {
       for (const [slab, error] of batchResult.errors) {
         logger.error("Batch error detail", { slabAddress: slab, error: error.message });
       }
-    }
-
-    // P2 FIX: Clean up stale signatures every cycle (was only on success path)
-    const now = Date.now();
-    for (const [oldSig, ts] of this.recentSignatures.entries()) {
-      if (now - ts > this.signatureTTLMs) this.recentSignatures.delete(oldSig);
     }
 
     // P0 FIX: Always log cycle result with skip breakdown. Previously only logged

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -226,9 +226,6 @@ export class LiquidationService {
   // supervisor restart) already act on.
   private _inFlight: Promise<void> | null = null;
   private _scanStartedAt = 0; // start of the in-flight scan — for the watchdog WARN log only
-  // BC1: Signature replay protection
-  private recentSignatures = new Map<string, number>(); // signature -> timestamp
-  private readonly signatureTTLMs = 60_000; // 60 seconds
   // PERC-134: Exponential backoff on consecutive scan failures
   private consecutiveFailures = 0;
   private readonly maxBackoffMs = 300_000; // 5 minutes max backoff
@@ -556,16 +553,6 @@ export class LiquidationService {
         recordFailed();
         txSentTotal.inc({ result: "fail", type: "liquidation" });
         throw err;
-      }
-
-      // BC1: Track signature to prevent replay attacks
-      const now = Date.now();
-      this.recentSignatures.set(sig, now);
-      // Clean up signatures older than TTL
-      for (const [oldSig, timestamp] of this.recentSignatures.entries()) {
-        if (now - timestamp > this.signatureTTLMs) {
-          this.recentSignatures.delete(oldSig);
-        }
       }
 
       this.liquidationCount++;


### PR DESCRIPTION
Closes #97.

## What

Removes the dead `BC1` signature-replay tracking (recentSignatures Map + signatureTTLMs constant + .set() after send + per-cycle cleanup loop) from both `crank.ts` and `liquidation.ts`. The Solana runtime already rejects duplicate transactions; the local map was pure dead weight.

L1 (cache oracle keypair) is already incorporated on main — `liquidation.ts` already has `_keypair` at construction, and `oracle.ts` no longer calls `loadKeypair` per-call (pushPrice method was removed in an earlier refactor).

L7 (adl.ts pnlPct) is obsolete — AdlService is observe-only with no tx sends since #134.

## Test evidence

```
Test Files  70 passed | 2 skipped (72)
     Tests  760 passed | 24 skipped (784)
```
`pnpm run build` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)