### PR TITLE
fix: HTTP server hardening and health port validation (L3+L4)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -287,6 +287,13 @@ crankService.setOnCrankCycle(() => monitorService.notifyCrankCycle());
 // Health endpoint
 const startupTime = Date.now();
 const healthPort = Number(process.env.KEEPER_HEALTH_PORT ?? 8081);
+// L4: reject non-integer or out-of-range port values early so misconfiguration
+// is a startup failure rather than a confusing EACCES/EADDRINUSE at listen time.
+if (!Number.isInteger(healthPort) || healthPort < 1 || healthPort > 65535) {
+  throw new Error(
+    `Invalid KEEPER_HEALTH_PORT: "${process.env.KEEPER_HEALTH_PORT}" — must be an integer 1..65535`,
+  );
+}
 
 // Rate limiter for /register: max 5 failed auth attempts per IP per 60 seconds.
 // Prevents brute-force attacks against the shared secret.
@@ -812,6 +819,13 @@ async function start() {
   // B13: bind the health port only after every service is wired up. Wrapped in
   // a Promise so start() awaits the bind callback before resolving — otherwise
   // a concurrent /health probe could land between this call and start() resolving.
+  // L3: HTTP server hardening — prevent slowloris and resource exhaustion.
+  // These must be set before listen() so they take effect on the first connection.
+  healthServer.requestTimeout = 10_000;  // 10s max for entire request
+  healthServer.headersTimeout = 5_000;   // 5s max to receive all headers
+  healthServer.keepAliveTimeout = 5_000; // 5s keep-alive idle timeout
+  healthServer.maxConnections = 50;      // cap concurrent connections
+
   // In HA mode the health port still binds here; startupTracker reports
   // "starting" until services actually wire up via onPromote.
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Closes #98.

## What

**L4**: Port validation — `KEEPER_HEALTH_PORT` is validated as an integer in `1..65535` at startup. Bad value → startup failure with a clear message rather than a confusing `EACCES`/`EADDRINUSE` from Node's `listen()`.

**L3**: Server hardening — `requestTimeout`, `headersTimeout`, `keepAliveTimeout`, and `maxConnections` set on the health server before `listen()` to prevent slowloris and connection exhaustion on the health endpoint.

**Not applied (already on main or intentionally skipped):**
- L5 (delete mainnet-markets.ts): already deleted on main
- Dead-variable removal (lastSuccessfulCrankTime etc.): already removed on main  
- L6 (failureCount removal): intentionally skipped — `failureCount` is a B10 lifetime metric, deliberately preserved distinct from `consecutiveFailures`

## Test evidence

```
Test Files  70 passed | 2 skipped (72)
     Tests  760 passed | 24 skipped (784)
```
`pnpm run build` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health endpoint port configuration is now validated at startup; invalid ports prevent server startup with error messaging.

* **Chores**
  * Enhanced health endpoint server stability with request and header timeout settings, keep-alive idle timeout, and concurrent connection limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->