### PR TITLE
fix(crank): don't count transient RPC errors toward market deactivation (N2)

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -917,11 +917,35 @@ export class CrankService {
       eventBus.publish("crank.success", slabAddress, { signature: sig });
       return true;
     } catch (err) {
-      state.failureCount++;
-      state.consecutiveFailures++;
-      txSentTotal.inc({ result: "fail", type: "crank" });
-
       const errMsg = err instanceof Error ? err.message : String(err);
+      const errLower = errMsg.toLowerCase();
+
+      // N2: Classify transient RPC/network errors — these should not count toward
+      // the consecutiveFailures threshold that deactivates markets. A burst of 429s
+      // during RPC congestion should not disable a healthy market.
+      const isTransient =
+        errLower.includes("429") ||
+        errLower.includes("too many requests") ||
+        errLower.includes("rate limit") ||
+        errLower.includes("timeout") ||
+        errLower.includes("socket") ||
+        errLower.includes("econnrefused") ||
+        errLower.includes("econnreset") ||
+        errLower.includes("502") ||
+        errLower.includes("503") ||
+        errLower.includes("block height exceeded");
+
+      state.failureCount++;
+      txSentTotal.inc({ result: "fail", type: "crank" });
+      if (!isTransient) {
+        state.consecutiveFailures++;
+      } else {
+        logger.warn("Crank transient error — not counting toward deactivation", {
+          slabAddress,
+          error: errMsg.slice(0, 120),
+          consecutiveFailures: state.consecutiveFailures,
+        });
+      }
 
       // P1 FIX: Detect InsufficientDexLiquidity (error 0x33 = 51) specifically.
       // This is the program's PercolatorError ordinal for the MIN_DEX_QUOTE_LIQUIDITY


### PR DESCRIPTION
Closes #100.

## What

Adds `isTransient` classification in the crank catch block. Transient errors (429, rate-limit, timeout, socket/ECONNREFUSED/ECONNRESET, 502, 503, block-height-exceeded) increment `failureCount` (lifetime) but skip `consecutiveFailures` (the deactivation counter). A burst of RPC congestion during an outage can no longer silence healthy markets once the RPC recovers.

Pattern mirrors the `isRetryable` guard already in `liquidation.ts`.

## Test evidence

```
Test Files  70 passed | 2 skipped (72)
     Tests  760 passed | 24 skipped (784)
```
`pnpm run build` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)