### PR TITLE
Close two budget circuit-breaker bypasses: NaN cost slips canSpend, and concurrent sends overshoot caps (TOCTOU)

### DIFF
--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -89,6 +89,27 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
     }
   }
 
+  // Validate JITO_TIP_LAMPORTS at boot. It feeds estimatedCost in keeper-send
+  // (and crank/liquidation/adl) via parseInt(... ?? "200000", 10), which the
+  // KeeperBudget circuit breaker gates on. A malformed value (e.g. "abc")
+  // parses to NaN; before the canSpend NaN guard that silently disabled the
+  // breaker, and even with it the keeper would halt on first send. Reject a
+  // set-but-malformed value at boot (a clean supervisor restart) rather than
+  // discover it mid-incident. Unset/empty is fine — the read sites default to
+  // 200000. Validate with Number() (not parseInt) so "200000abc" is rejected
+  // rather than silently truncated.
+  const jitoTipRaw = env.JITO_TIP_LAMPORTS?.trim();
+  if (jitoTipRaw !== undefined && jitoTipRaw !== "") {
+    const tip = Number(jitoTipRaw);
+    if (!Number.isFinite(tip) || !Number.isInteger(tip) || tip < 0) {
+      throw new Error(
+        `JITO_TIP_LAMPORTS='${jitoTipRaw.slice(0, 20)}' is invalid — expected a ` +
+          `non-negative integer (lamports). A malformed value makes the tx-cost ` +
+          `estimate NaN and would trip the keeper spend circuit breaker.`,
+      );
+    }
+  }
+
   const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY?.trim();
 
   // K-2 (HIGH): hard-reject SUPABASE_SERVICE_ROLE_KEY being present at all.

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -54,6 +54,10 @@ export interface BudgetStats {
   hourSpend: number;
   daySpend: number;
   cycleTxCount: number;
+  /** Lamports reserved by in-flight canSpend()s not yet settled by recordTx(). */
+  reservedLamports: number;
+  /** Count of in-flight canSpend()s not yet settled by recordTx(). */
+  reservedTxCount: number;
   txSuccessRate: number | null;
   txWindowSize: number;
   halted: boolean;
@@ -68,6 +72,7 @@ export type HaltKind =
   | "day-spend-cap"
   | "cycle-tx-count-cap"
   | "tx-success-rate"
+  | "non-finite-cost"
   | "operator";
 
 export interface KeeperBudgetDeps {
@@ -153,6 +158,17 @@ export class KeeperBudget {
   private _txWindowSuccesses = 0;
   private _txWindowFailures = 0;
 
+  // In-flight reservations. canSpend() reserves the proposed cost (and one tx
+  // slot) when it admits a send; recordTx() releases it when the send settles.
+  // The cap checks count reservations so concurrent in-flight sends — booked by
+  // recordTx only AFTER their network await — cannot all clear the same
+  // pre-send snapshot and collectively overshoot a cap (TOCTOU). Reservations
+  // are kept entirely separate from _cycleSpend/_hourSpendSum/etc., so
+  // getStats().cycleSpend still equals the sum of booked (non-drop) recordTx
+  // calls — the recordTx-only accounting and its property tests are unchanged.
+  private _reservedLamports = 0;
+  private _reservedTxCount = 0;
+
   private _isHalted = false;
   private _haltKind: HaltKind | undefined;
   private _haltReason: string | undefined;
@@ -176,10 +192,29 @@ export class KeeperBudget {
   canSpend(lamports: number, txType: TxType): boolean {
     if (this._isHalted) return false;
 
+    // A non-finite or negative cost means the fee/CU/tip math produced NaN or
+    // Infinity — almost always a malformed numeric env (e.g. JITO_TIP_LAMPORTS).
+    // NaN slips every `x > cap` comparison below (NaN > cap === false), so it
+    // would otherwise be admitted, silently disabling the breaker. Treat it as a
+    // hard fault: refuse and halt so an operator fixes the config and resume()s.
+    // Checked first so the bad value never enters a comparison and never reserves.
+    if (!Number.isFinite(lamports) || lamports < 0) {
+      this._halt(
+        "non-finite-cost",
+        `proposed cost ${lamports} is not a finite non-negative number — likely a malformed fee env (txType=${txType})`,
+      );
+      return false;
+    }
+
     const nowMs = this._now();
     this._rollCycleIfElapsed(nowMs);
     this._pruneOld(nowMs);
 
+    // ── Settled-spend breaches HALT (latching, manual-resume) ──────────────
+    // These mirror the historical behavior exactly: if the ALREADY-BOOKED spend
+    // plus this one cost would breach a cap, that is a real overspend signal and
+    // the breaker latches. Reservations are intentionally excluded here so the
+    // halt semantics (and the existing cap tests) are unchanged.
     if (this._cycleSpend + lamports > this.config.maxSolPerCycle) {
       this._halt(
         "cycle-spend-cap",
@@ -218,6 +253,26 @@ export class KeeperBudget {
       return false;
     }
 
+    // ── Reservation back-pressure: REFUSE without halting ──────────────────
+    // The settled spend alone is within every cap, but in-flight (reserved)
+    // sends would push this one over. That is concurrency back-pressure, not
+    // overspend — nothing has been over-spent yet, and capacity returns as the
+    // in-flight sends settle and release. Refuse this send (the caller skips it
+    // and retries next cycle) rather than latching the breaker, which would
+    // stall the keeper during exactly the bursts it exists to handle.
+    if (
+      this._cycleSpend + this._reservedLamports + lamports > this.config.maxSolPerCycle ||
+      this._hourSpendSum + this._reservedLamports + lamports > this.config.maxSolPerHour ||
+      this._daySpendSum + this._reservedLamports + lamports > this.config.maxSolPerDay ||
+      this._cycleTxCount + this._reservedTxCount + 1 > this.config.maxTxPerCycle
+    ) {
+      return false;
+    }
+
+    // All checks passed — reserve before returning true so a concurrent
+    // canSpend() sees this in-flight cost. recordTx() releases the reservation.
+    this._reservedLamports += lamports;
+    this._reservedTxCount += 1;
     return true;
   }
 
@@ -243,6 +298,16 @@ export class KeeperBudget {
     const nowMs = this._now();
     // Roll before counting so this tx lands in the current window.
     this._rollCycleIfElapsed(nowMs);
+
+    // Release the reservation taken by the matching canSpend() (keeperSend
+    // passes the same estimatedCost to both, and guarantees exactly one
+    // recordTx per reserving canSpend via try/finally). Clamped at >= 0 so
+    // recordTx-only callers (tests, or a settled tx that was never reserved)
+    // cannot drive the tally negative — this is what keeps the cycleSpend-sum
+    // invariant exact: reservations never touch the booked spend below.
+    this._reservedLamports = Math.max(0, this._reservedLamports - lamports);
+    this._reservedTxCount = Math.max(0, this._reservedTxCount - 1);
+
     this._cycleTxCount++;
 
     if (result !== "drop") {
@@ -286,6 +351,11 @@ export class KeeperBudget {
     this._cycleSpend = 0;
     this._cycleTxCount = 0;
     this._cycleStartMs = this._now();
+    // Intentionally does NOT reset _reservedLamports / _reservedTxCount:
+    // reservations track sends that are still in flight and may straddle a cycle
+    // boundary (canSpend in cycle N, recordTx in cycle N+1). Clearing them here
+    // would orphan the pending release and let the new cycle over-admit by the
+    // number of in-flight sends. They self-clear as each in-flight recordTx lands.
   }
 
   getStats(): BudgetStats {
@@ -297,6 +367,8 @@ export class KeeperBudget {
       hourSpend: this._hourSpendSum,
       daySpend: this._daySpendSum,
       cycleTxCount: this._cycleTxCount,
+      reservedLamports: this._reservedLamports,
+      reservedTxCount: this._reservedTxCount,
       txSuccessRate: this._computeSuccessRate(),
       txWindowSize: this._txWindow.length,
       halted: this._isHalted,

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -200,83 +200,99 @@ export async function keeperSend(
       estimatedCost,
       stats: budget.getStats(),
     });
-    return null;
+    return null; // canSpend returned false → no reservation was taken
   }
 
-  // A.10 (HIGH): DRY_RUN intercepts before the real send. The shadow-keeper
-  // harness compares would-have-fired decisions against the live keeper's
-  // tx history; that comparison needs the full ix payload + accounts +
-  // estimated cost recorded against the same budget so runaway-fire is also
-  // detectable in dry runs. Logged at info so the harness can ingest it.
-  if (process.env.DRY_RUN === "true") {
-    const signature = `dry_run_${randomUUID()}`;
-    const accountKeys = instructions.flatMap((ix) =>
-      ix.keys.map((k) => k.pubkey.toBase58()),
-    );
-    logger.info("DRY_RUN: intercepted send", {
-      txType,
-      signature,
-      estimatedCost,
-      simulatedCu,
-      instructions: instructions.map((ix) => ({
-        programId: ix.programId.toBase58(),
-        accountKeys: ix.keys.map((k) => ({
-          pubkey: k.pubkey.toBase58(),
-          isSigner: k.isSigner,
-          isWritable: k.isWritable,
-        })),
-        dataBase64: Buffer.from(ix.data).toString("base64"),
-      })),
-      uniqueAccounts: Array.from(new Set(accountKeys)),
-    });
-
-    // When the shadow harness is enabled, log the decision for the comparison
-    // loop. Errors are swallowed inside DecisionLog.append() — they must never
-    // propagate here. When SHADOW_HARNESS_ENABLED is false, this branch still
-    // runs but the append is still called; the decisionLog.append itself is a
-    // no-op overhead of <1ms. If that ever becomes a concern, add the env guard
-    // inside append() rather than here to keep this path readable.
-    if (process.env.SHADOW_HARNESS_ENABLED === "true") {
-      const firstIx = instructions[0];
-      // The market is the first non-system account from the first instruction.
-      // For crank/liquidation/adl ixs the slab address is always at index 0.
-      const market = firstIx?.keys[0]?.pubkey.toBase58() ?? "unknown";
-      const instructionData =
-        firstIx !== undefined ? Buffer.from(firstIx.data).toString("base64") : "";
-      void sharedDecisionLog.append({
-        timestamp: new Date().toISOString(),
-        txType,
-        market,
-        accounts: Array.from(new Set(accountKeys)),
-        instructionData,
-        estimatedCost,
-        reasonChain: [],
-      });
-    }
-
-    budget.recordTx(estimatedCost, txType, "success");
-    return { signature, estimatedCost, simulatedCu };
-  }
-
-  const opts: KeeperSendOptions = {
-    ...keeperOpts,
-    // Saves ~20-50ms on mainnet when Helius Sender runs its own preflight downstream.
-    ...(isMainnetSender() ? { skipPreflight: true } : {}),
+  // canSpend() reserved `estimatedCost` (and one tx slot). We MUST release it
+  // with exactly one recordTx() on every exit path — a reservation that is
+  // never released leaks, silently shrinking the budget's effective cap until
+  // it wedges (worse than the TOCTOU it fixes). The idempotent `release` plus
+  // the outer try/finally guarantee the reservation is freed exactly once even
+  // on an unexpected throw between here and the send.
+  let recorded = false;
+  const release = (result: TxResult): void => {
+    if (recorded) return;
+    recorded = true;
+    budget.recordTx(estimatedCost, txType, result);
   };
 
-  let result: TxResult = "fail";
-  let signature = "";
   try {
-    signature = await sendWithRetryKeeper(connection, instructions, signers, maxRetries, opts);
-    result = "success";
-    return { signature, estimatedCost, simulatedCu };
-  } catch (err) {
-    // A landed-but-reverted tx ("Transaction failed: ...") is recorded as
-    // "reverted" so it doesn't poison the success-rate breaker; genuine
-    // never-landed failures stay "fail". The error is rethrown unchanged.
-    result = classifySendError(err);
-    throw err;
+    // A.10 (HIGH): DRY_RUN intercepts before the real send. The shadow-keeper
+    // harness compares would-have-fired decisions against the live keeper's
+    // tx history; that comparison needs the full ix payload + accounts +
+    // estimated cost recorded against the same budget so runaway-fire is also
+    // detectable in dry runs. Logged at info so the harness can ingest it.
+    if (process.env.DRY_RUN === "true") {
+      const signature = `dry_run_${randomUUID()}`;
+      const accountKeys = instructions.flatMap((ix) =>
+        ix.keys.map((k) => k.pubkey.toBase58()),
+      );
+      logger.info("DRY_RUN: intercepted send", {
+        txType,
+        signature,
+        estimatedCost,
+        simulatedCu,
+        instructions: instructions.map((ix) => ({
+          programId: ix.programId.toBase58(),
+          accountKeys: ix.keys.map((k) => ({
+            pubkey: k.pubkey.toBase58(),
+            isSigner: k.isSigner,
+            isWritable: k.isWritable,
+          })),
+          dataBase64: Buffer.from(ix.data).toString("base64"),
+        })),
+        uniqueAccounts: Array.from(new Set(accountKeys)),
+      });
+
+      // When the shadow harness is enabled, log the decision for the comparison
+      // loop. Errors are swallowed inside DecisionLog.append() — they must never
+      // propagate here. When SHADOW_HARNESS_ENABLED is false, this branch still
+      // runs but the append is still called; the decisionLog.append itself is a
+      // no-op overhead of <1ms. If that ever becomes a concern, add the env guard
+      // inside append() rather than here to keep this path readable.
+      if (process.env.SHADOW_HARNESS_ENABLED === "true") {
+        const firstIx = instructions[0];
+        // The market is the first non-system account from the first instruction.
+        // For crank/liquidation/adl ixs the slab address is always at index 0.
+        const market = firstIx?.keys[0]?.pubkey.toBase58() ?? "unknown";
+        const instructionData =
+          firstIx !== undefined ? Buffer.from(firstIx.data).toString("base64") : "";
+        void sharedDecisionLog.append({
+          timestamp: new Date().toISOString(),
+          txType,
+          market,
+          accounts: Array.from(new Set(accountKeys)),
+          instructionData,
+          estimatedCost,
+          reasonChain: [],
+        });
+      }
+
+      release("success");
+      return { signature, estimatedCost, simulatedCu };
+    }
+
+    const opts: KeeperSendOptions = {
+      ...keeperOpts,
+      // Saves ~20-50ms on mainnet when Helius Sender runs its own preflight downstream.
+      ...(isMainnetSender() ? { skipPreflight: true } : {}),
+    };
+
+    try {
+      const signature = await sendWithRetryKeeper(connection, instructions, signers, maxRetries, opts);
+      release("success");
+      return { signature, estimatedCost, simulatedCu };
+    } catch (err) {
+      // A landed-but-reverted tx ("Transaction failed: ...") is recorded as
+      // "reverted" so it doesn't poison the success-rate breaker; genuine
+      // never-landed failures stay "fail". The error is rethrown unchanged.
+      release(classifySendError(err));
+      throw err;
+    }
   } finally {
-    budget.recordTx(estimatedCost, txType, result);
+    // Safety net: if a path above reserved but never recorded (an unexpected
+    // throw before release ran), free the reservation as a drop — no spend is
+    // booked because nothing reached the chain. No-op if already released.
+    release("drop");
   }
 }

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -454,4 +454,33 @@ describe("validateKeeperEnvGuards", () => {
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
   });
+
+  // A malformed JITO_TIP_LAMPORTS makes the tx-cost estimate NaN, which slips
+  // the budget circuit breaker's cap checks. Reject it at boot.
+  it("throws on non-numeric JITO_TIP_LAMPORTS", () => {
+    expect(() =>
+      validateKeeperEnvGuards({ NETWORK: "devnet", JITO_TIP_LAMPORTS: "abc" } as NodeJS.ProcessEnv),
+    ).toThrow(/JITO_TIP_LAMPORTS/);
+  });
+
+  it("throws on negative JITO_TIP_LAMPORTS", () => {
+    expect(() =>
+      validateKeeperEnvGuards({ NETWORK: "devnet", JITO_TIP_LAMPORTS: "-1" } as NodeJS.ProcessEnv),
+    ).toThrow(/JITO_TIP_LAMPORTS/);
+  });
+
+  it("throws on non-integer / trailing-garbage JITO_TIP_LAMPORTS (e.g. 200000abc)", () => {
+    expect(() =>
+      validateKeeperEnvGuards({ NETWORK: "devnet", JITO_TIP_LAMPORTS: "200000abc" } as NodeJS.ProcessEnv),
+    ).toThrow(/JITO_TIP_LAMPORTS/);
+  });
+
+  it("accepts a valid integer JITO_TIP_LAMPORTS and accepts unset", () => {
+    expect(() =>
+      validateKeeperEnvGuards({ NETWORK: "devnet", JITO_TIP_LAMPORTS: "200000" } as NodeJS.ProcessEnv),
+    ).not.toThrow();
+    expect(() =>
+      validateKeeperEnvGuards({ NETWORK: "devnet" } as NodeJS.ProcessEnv),
+    ).not.toThrow();
+  });
 });

--- a/tests/lib/budget-gate-accuracy.poc.test.ts
+++ b/tests/lib/budget-gate-accuracy.poc.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { KeeperBudget } from "../../src/lib/budget.js";
+
+/**
+ * PoCs for two budget circuit-breaker correctness gaps. Both fail on current
+ * main and pass after the fix.
+ *
+ * G — NaN cost bypass: a malformed fee env (e.g. JITO_TIP_LAMPORTS="abc") makes
+ *     estimatedCost NaN. `NaN > cap` is false, so canSpend() admits it; recordTx
+ *     then drops it (`!Number.isFinite`). Result: every send is allowed and
+ *     nothing is recorded — the caps never trip. The breaker is silently off.
+ *
+ * B — canSpend TOCTOU: canSpend() is a pure read; spend is only booked by
+ *     recordTx() after the send's await. Concurrent in-flight sends all clear
+ *     the same pre-send snapshot and collectively overshoot the cap.
+ */
+describe("KeeperBudget gate accuracy (PoC)", () => {
+  const CFG = {
+    maxSolPerCycle: 100,
+    maxSolPerHour: 1_000_000_000,
+    maxSolPerDay: 1_000_000_000,
+    maxTxPerCycle: 1_000,
+  } as const;
+
+  it("G: a non-finite cost must not pass canSpend (and must fail safe)", () => {
+    const b = new KeeperBudget(CFG, { now: () => 1 });
+    // NaN slips every `x > cap` comparison on main → admitted.
+    expect(b.canSpend(NaN, "crank")).toBe(false); // FAILS on main: returns true
+    // A non-finite cost signals a config bug (bad fee env); fail safe by halting
+    // so an operator must fix it and resume, rather than running with the
+    // breaker silently disabled.
+    expect(b.isHalted()).toBe(true); // FAILS on main: not halted
+  });
+
+  it("B: concurrent pre-send checks must not both pass and overshoot the cycle cap", () => {
+    const b = new KeeperBudget(CFG, { now: () => 1 });
+    // Two sends of 60 are in flight at once (recordTx happens later, after the
+    // network await). Together 120 > 100 cap. The first is admitted; the second
+    // — checked before the first has recorded — must be refused.
+    expect(b.canSpend(60, "crank")).toBe(true);
+    expect(b.canSpend(60, "crank")).toBe(false); // FAILS on main: returns true (no reservation)
+  });
+
+  it("B: a reserved-then-recorded send leaves cycleSpend equal to the actual recorded amount", () => {
+    // Guards that the reservation is released on recordTx and does not double-count.
+    const b = new KeeperBudget({ ...CFG, maxSolPerCycle: 1_000_000 }, { now: () => 1 });
+    expect(b.canSpend(60, "crank")).toBe(true); // reserves 60
+    b.recordTx(60, "crank", "success"); // releases reservation, books 60
+    expect(b.getStats().cycleSpend).toBe(60);
+    // A second send is now admissible again (only 60 of the budget is used).
+    expect(b.canSpend(60, "crank")).toBe(true);
+  });
+});

--- a/tests/lib/budget.test.ts
+++ b/tests/lib/budget.test.ts
@@ -448,3 +448,107 @@ describe("KeeperBudget — counter consistency under sequential ops", () => {
     expect(stats.hourSpend).toBeLessThanOrEqual(stats.daySpend);
   });
 });
+
+describe("KeeperBudget — non-finite cost guard", () => {
+  it("canSpend(NaN) refuses and halts (fail-safe), requiring resume()", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: makeClock().now });
+    expect(b.canSpend(NaN, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(true);
+    expect(b.haltKind).toBe("non-finite-cost");
+    // stays halted for subsequent finite sends until resume()
+    expect(b.canSpend(1, "crank")).toBe(false);
+    b.resume("op");
+    expect(b.canSpend(1, "crank")).toBe(true);
+  });
+
+  it("canSpend(Infinity) refuses and halts (defense in depth)", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: makeClock().now });
+    expect(b.canSpend(Infinity, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(true);
+    expect(b.haltKind).toBe("non-finite-cost");
+  });
+
+  it("fires onHalt with kind=non-finite-cost", () => {
+    const onHalt = vi.fn();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: makeClock().now, onHalt });
+    b.canSpend(NaN, "crank");
+    expect(onHalt).toHaveBeenCalledWith("non-finite-cost", expect.any(String));
+  });
+
+  it("a NaN canSpend does not corrupt the reservation tallies", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: makeClock().now });
+    b.canSpend(NaN, "crank");
+    expect(b.getStats().reservedLamports).toBe(0);
+    expect(b.getStats().reservedTxCount).toBe(0);
+  });
+});
+
+describe("KeeperBudget — reservation / TOCTOU", () => {
+  it("a second in-flight send that only the reservation pushes over the cap is REFUSED, not halted", () => {
+    // cycle cap 1000; two 600-lamport sends in flight, neither recorded yet.
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: makeClock().now });
+    expect(b.canSpend(600, "crank")).toBe(true); // reserves 600
+    expect(b.canSpend(600, "crank")).toBe(false); // 0 + 600 reserved + 600 > 1000
+    // Concurrency back-pressure must NOT latch the breaker — nothing overspent.
+    expect(b.isHalted()).toBe(false);
+  });
+
+  it("a settled-spend breach still HALTS (unchanged semantics)", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: makeClock().now });
+    expect(b.canSpend(600, "crank")).toBe(true);
+    b.recordTx(600, "crank", "success"); // settled cycleSpend = 600, reservation released
+    // Next send's settled spend alone (600 + 600 = 1200) breaches the 1000 cap →
+    // this is a real overspend signal, so it HALTS (not mere back-pressure).
+    expect(b.canSpend(600, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(true);
+    expect(b.haltKind).toBe("cycle-spend-cap");
+  });
+
+  it("reservation released on success: cycleSpend equals recorded amount, budget re-admits", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: makeClock().now });
+    expect(b.canSpend(600, "crank")).toBe(true);
+    b.recordTx(600, "crank", "success");
+    expect(b.getStats().cycleSpend).toBe(600);
+    expect(b.getStats().reservedLamports).toBe(0);
+    expect(b.canSpend(400, "crank")).toBe(true); // 600 + 0 + 400 == 1000, not > cap
+  });
+
+  it("reservation released on drop: nothing booked, reserve cleared, full budget free", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: makeClock().now });
+    expect(b.canSpend(900, "crank")).toBe(true);
+    b.recordTx(900, "crank", "drop");
+    expect(b.getStats().cycleSpend).toBe(0); // drop books nothing
+    expect(b.getStats().reservedLamports).toBe(0);
+    expect(b.getStats().cycleTxCount).toBe(1); // still an attempt
+    expect(b.canSpend(1_000, "crank")).toBe(true);
+  });
+
+  it("recordTx without a prior canSpend never drives the reserve negative", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: makeClock().now });
+    b.recordTx(500, "crank", "success"); // no reservation existed
+    expect(b.getStats().cycleSpend).toBe(500);
+    expect(b.getStats().reservedLamports).toBe(0);
+  });
+
+  it("reserved tx-count prevents concurrent overshoot of maxTxPerCycle without halting", () => {
+    // maxTxPerCycle = 5; wide spend caps so only the count matters.
+    const b = new KeeperBudget(
+      { ...TIGHT_CONFIG, maxSolPerCycle: 1_000_000, maxSolPerHour: 1_000_000, maxSolPerDay: 1_000_000 },
+      { now: makeClock().now },
+    );
+    for (let i = 0; i < 5; i++) expect(b.canSpend(1, "crank")).toBe(true); // reserve 5 tx
+    expect(b.canSpend(1, "crank")).toBe(false); // 0 + 5 reserved + 1 > 5 → refuse
+    expect(b.isHalted()).toBe(false);
+  });
+
+  it("beginCycle does not orphan in-flight reservations", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: makeClock().now });
+    expect(b.canSpend(600, "crank")).toBe(true); // reserve 600 (in flight)
+    b.beginCycle(); // a new cycle starts while the send is still on the wire
+    expect(b.getStats().reservedLamports).toBe(600); // reservation survives
+    // the in-flight send settles into the new cycle and releases its reservation
+    b.recordTx(600, "crank", "success");
+    expect(b.getStats().reservedLamports).toBe(0);
+    expect(b.getStats().cycleSpend).toBe(600);
+  });
+});

--- a/tests/lib/keeper-send.test.ts
+++ b/tests/lib/keeper-send.test.ts
@@ -253,4 +253,66 @@ describe("keeperSend", () => {
       },
     );
   });
+
+  // Reservation-leak guard: canSpend() reserves; recordTx() must release on
+  // EVERY exit path. A leak silently shrinks the effective cap until the budget
+  // wedges, so we assert the pending tally returns to zero after each path.
+  describe("reservation release (no leak)", () => {
+    it("releases the reservation on a successful real send", async () => {
+      await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+      expect(budget.getStats().reservedLamports).toBe(0);
+      expect(budget.getStats().reservedTxCount).toBe(0);
+    });
+
+    it("releases the reservation when the send throws", async () => {
+      vi.mocked(shared.sendWithRetryKeeper).mockRejectedValueOnce(new Error("RPC error"));
+      await expect(
+        keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget),
+      ).rejects.toThrow("RPC error");
+      expect(budget.getStats().reservedLamports).toBe(0);
+      expect(budget.getStats().reservedTxCount).toBe(0);
+    });
+
+    it("releases the reservation on the DRY_RUN path", async () => {
+      process.env.DRY_RUN = "true";
+      try {
+        await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+        expect(budget.getStats().reservedLamports).toBe(0);
+        expect(budget.getStats().reservedTxCount).toBe(0);
+      } finally {
+        delete process.env.DRY_RUN;
+      }
+    });
+
+    it("makes NO reservation when canSpend refuses (returns null)", async () => {
+      budget.haltManually("test");
+      const r = await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+      expect(r).toBeNull();
+      expect(budget.getStats().reservedLamports).toBe(0);
+      expect(budget.getStats().reservedTxCount).toBe(0);
+    });
+
+    it("does not leak across many interleaved success/throw sends", async () => {
+      const wide = new KeeperBudget({
+        maxSolPerCycle: Number.MAX_SAFE_INTEGER,
+        maxSolPerHour: Number.MAX_SAFE_INTEGER,
+        maxSolPerDay: Number.MAX_SAFE_INTEGER,
+        maxTxPerCycle: 100_000,
+        txSuccessRateThreshold: 0,
+        txSuccessRateMinSamples: 1_000_000,
+      });
+      let i = 0;
+      vi.mocked(shared.sendWithRetryKeeper).mockImplementation(async () => {
+        if (i++ % 2 === 0) throw new Error("flaky");
+        return "sig";
+      });
+      await Promise.allSettled(
+        Array.from({ length: 100 }, () =>
+          keeperSend(connection, [makeDummyIx()], [keypair], "crank", wide),
+        ),
+      );
+      expect(wide.getStats().reservedLamports).toBe(0);
+      expect(wide.getStats().reservedTxCount).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The `KeeperBudget` circuit breaker caps send-path SOL spend (per cycle / hour / day + tx count) and halts until an operator resumes. Two gaps let it be silently bypassed or overshot.

**1. A non-finite cost slips `canSpend()` and is never recorded → breaker silently off.**
`estimateCost()` builds `estimatedCost` from a priority fee + CU + `parseInt(JITO_TIP_LAMPORTS ?? "200000")`. A malformed env (`"abc"`) makes the tip — and `estimatedCost` — `NaN`. `canSpend(NaN)` passes every cap check (`NaN > cap` is `false`) and returns `true`; `recordTx(NaN)` early-returns on `!Number.isFinite`. So one malformed env admits every send and records nothing — the caps never trip for the life of the process.

**2. `canSpend()` TOCTOU → concurrent sends overshoot the caps.**
`canSpend()` only reads the counters; spend is booked by `recordTx()` in the send's `finally`, after the network `await`. The tx-queue runs up to 10 liquidation + 5 oracle + 5 crank sends in flight; each calls `canSpend()` against the same pre-send snapshot, so they all pass and collectively spend past the cap before any records.

## Fix

**Non-finite cost (G):** `canSpend()` treats a non-finite/negative `lamports` as a breach — refuse and halt (fail-safe `non-finite-cost` kind), so a bad fee env surfaces immediately and requires an explicit `resume()`. `JITO_TIP_LAMPORTS` is also validated at boot (`validateKeeperEnvGuards`) so the `NaN` never reaches the hot path.

**TOCTOU (B):** `canSpend()` now reserves the proposed cost (and one tx slot) into a pending tally that the cap checks include, so concurrent in-flight sends see each other; `recordTx()` releases the reservation (clamped `>= 0`) and books the settled amount.
- A **settled-spend** breach (already-booked spend would exceed a cap) still **halts** — unchanged semantics, and all existing cap tests stay green.
- A breach driven **only by in-flight reservations** **refuses without halting** — concurrency back-pressure must not latch the breaker and stall the keeper during exactly the bursts (e.g. liquidation cascades) it exists to handle. Capacity returns automatically as in-flight sends settle.

**Why the property tests still hold:** reservations live in fields (`_reservedLamports` / `_reservedTxCount`) disjoint from `_cycleSpend`/`_hourSpendSum`/etc. `recordTx` only ever decrements them (clamped at 0), so a `recordTx`-only sequence (as the property tests use) leaves `getStats().cycleSpend` exactly equal to the sum of non-drop `recordTx` lamports.

**Leak-proofing (essential):** `keeperSend` is restructured so every reserving `canSpend` is paired with exactly one `recordTx` via an outer `try/finally` + an idempotent release closure. Without this, an unexpected throw between the gate and the send would leak a reservation, silently shrinking the effective cap until the budget wedged — worse than the TOCTOU it fixes. `beginCycle` deliberately does **not** reset reservations (in-flight sends straddle cycle boundaries and release on their own `recordTx`).

## Tests

- `tests/lib/budget-gate-accuracy.poc.test.ts` (new): the two PoCs (NaN refused+halts; second concurrent `canSpend` refused), both fail on `main`.
- `tests/lib/budget.test.ts`: non-finite halt (+ `onHalt` kind), settled-breach-still-halts vs reservation-refuses, reservation release on success/fail/drop, reserved-tx-count back-pressure, `beginCycle` does not orphan reservations.
- `tests/lib/keeper-send.test.ts`: reservation-release (no-leak) guards across success / throw / DRY_RUN / canSpend-refused / 100 interleaved sends.
- `tests/env-guards.test.ts`: `JITO_TIP_LAMPORTS` boot validation (non-numeric / negative / trailing-garbage rejected; valid & unset accepted).
- All 5 budget property-test invariants unchanged; full suite green (711 passed) and `tsc --noEmit` clean.

Fixes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)