### PR TITLE
fix(crank): M10 — refresh HYPERP slab config on 60s TTL so admin SetDexPool is picked up promptly

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -38,6 +38,16 @@ const logger = createLogger("keeper:crank");
 /** Timeout for individual RPC calls — prevents indefinite hangs on unresponsive nodes. */
 const RPC_TIMEOUT_MS = 15_000;
 
+// M10: refresh interval for HYPERP slab config (specifically `config.dexPool`).
+// On-chain SetDexPool changes the pool but the keeper's parsed config is only
+// refreshed in discover() (default 5 min). 60s is a balanced choice — picks up
+// admin SetDexPool within 60s, costs at most one extra getAccountInfo per
+// HYPERP market per minute. Configurable via env for ops experiments.
+const HYPERP_CONFIG_REFRESH_MS = parseInt(
+  process.env.KEEPER_HYPERP_CONFIG_REFRESH_MS ?? "60000",
+  10,
+);
+
 const KEEPER_SEND_OPTS = {
   skipPreflight: true,
   multiRpcBroadcast: true,
@@ -110,6 +120,15 @@ interface MarketCrankState {
   dexPoolResolvedAddress?: string;
   dexPoolType?: DexType | "unknown";
   dexPoolRemainingAccounts?: PublicKey[];
+  /**
+   * M10: wall-clock ms of the last on-chain config refresh for this market.
+   * The slab `config.dexPool` field is only refreshed during the discover()
+   * cycle (~5 min). After an admin calls SetDexPool, the keeper would otherwise
+   * send UpdateHyperpMark against the OLD pool for up to 5 min, getting
+   * rejected on-chain with OracleInvalid and burning priority fees. A shorter
+   * (60s default) per-market refresh in the HYPERP branch closes this gap.
+   */
+  lastHyperpConfigRefreshMs?: number;
 }
 
 /** Process items in batches with delay between batches.
@@ -689,6 +708,63 @@ export class CrankService {
       // UpdateHyperpMark to read DEX pool state directly on-chain. No off-chain
       // price push needed — the instruction reads Raydium/PumpSwap/Meteora pools.
       if (this.isHyperpOracle(market)) {
+        // M10: refresh slab config (specifically config.dexPool) on a shorter
+        // TTL than the 5-min discover() cycle. Without this, an admin
+        // SetDexPool change wouldn't reach the keeper for up to 5 min, during
+        // which UpdateHyperpMark txs target the OLD pool and get rejected
+        // on-chain with OracleInvalid (burning priority fees + RPC quota).
+        const now = Date.now();
+        if (
+          state.lastHyperpConfigRefreshMs === undefined ||
+          now - state.lastHyperpConfigRefreshMs >= HYPERP_CONFIG_REFRESH_MS
+        ) {
+          try {
+            const freshSlab = await withTimeout(
+              fetchSlab(connection, market.slabAddress),
+              RPC_TIMEOUT_MS,
+              `fetchSlab(M10 refresh, ${slabAddress})`,
+            );
+            const freshConfig = freshSlab ? parseConfig(freshSlab) : undefined;
+            // Defensive: if fetchSlab or parseConfig returned a falsy value
+            // (RPC blip, mock in tests), keep the cached config. The next
+            // cycle will retry. This avoids overwriting good config with
+            // undefined which would NPE on the dexPool read below.
+            if (!freshConfig) {
+              throw new Error("freshConfig was undefined after parseConfig");
+            }
+            const prevDexPool = state.market.config?.dexPool?.toBase58();
+            // Replace just the config — header/engine/params aren't oracle-
+            // routing-critical for HYPERP and discover() will refresh the
+            // rest on its normal cadence.
+            state.market.config = freshConfig;
+            state.lastHyperpConfigRefreshMs = now;
+
+            const newDexPool = state.market.config.dexPool?.toBase58();
+            if (prevDexPool !== newDexPool) {
+              logger.info("HYPERP: on-chain dexPool changed; invalidating remaining-accounts cache", {
+                slabAddress,
+                previousDexPool: prevDexPool ?? "<unset>",
+                newDexPool: newDexPool ?? "<unset>",
+              });
+              // Drop the cached remaining-accounts so the next call to
+              // resolveHyperpPoolRemainingAccounts re-fetches for the new pool.
+              state.dexPoolResolvedAddress = undefined;
+              state.dexPoolType = undefined;
+              state.dexPoolRemainingAccounts = undefined;
+              // Reset the no-price-skip flag so a previously-unconfigured pool
+              // gets a fresh chance after admin sets it.
+              state.hyperpNoPriceSkipped = false;
+            }
+          } catch (err) {
+            // Refresh failure is non-fatal — fall through with the existing
+            // cached config and let the next cycle retry.
+            logger.warn("HYPERP: failed to refresh slab config (M10) — using cached value", {
+              slabAddress,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+
         const instructions: TransactionInstruction[] = [];
 
         // UpdateHyperpMark: accounts = [slab(writable), dex_pool, clock, ...remaining]

--- a/tests/poc/m10.poc.test.ts
+++ b/tests/poc/m10.poc.test.ts
@@ -1,0 +1,189 @@
+/**
+ * M10 PoC — HYPERP dexPool config goes stale for up to 5 minutes after
+ * admin SetDexPool because the slab config is only refreshed in discover().
+ *
+ * THE BUG (pre-fix):
+ *   src/services/crank.ts:705 reads `state.market.config.dexPool` —
+ *   parsed from slab data during discover() (runs every ~5 min).
+ *   The cache in resolveHyperpPoolRemainingAccounts at line 577
+ *   invalidates ONLY when the input poolAddress differs:
+ *     if (state.dexPoolResolvedAddress === poolAddress &&
+ *         state.dexPoolRemainingAccounts !== undefined) {
+ *       return state.dexPoolRemainingAccounts;
+ *     }
+ *   So when admin calls SetDexPool to change POOL_OLD → POOL_NEW:
+ *     1. On-chain dexPool is now POOL_NEW.
+ *     2. state.market.config.dexPool stays POOL_OLD (parsed 4 min ago).
+ *     3. crankMarket reads POOL_OLD.
+ *     4. Cache returns remaining-accounts for POOL_OLD.
+ *     5. UpdateHyperpMark sent with POOL_OLD + OLD remaining accounts.
+ *     6. On-chain rejects with OracleInvalid (POOL_OLD is no longer pinned).
+ *     7. Repeats every cycle until next discover() (~5 min worst case).
+ *   Each failed tx burns priority fee + RPC quota + alert noise.
+ *
+ * THE FIX (this PR):
+ *   In the HYPERP branch of crankMarket, before reading config.dexPool,
+ *   check if the last config refresh was > HYPERP_CONFIG_REFRESH_MS ago
+ *   (60s default). If so, re-fetch the slab + reparse config + update
+ *   state.market.config. If dexPool changed, invalidate the cached
+ *   remaining-accounts so the next call refetches for the new pool.
+ *
+ * This PoC walks through the state machine.
+ */
+import { describe, it, expect } from "vitest";
+
+interface State {
+  configDexPool: string;
+  lastHyperpConfigRefreshMs?: number;
+  // Cached remaining-accounts keyed by pool address.
+  cachedPool?: string;
+  cachedRemaining?: string[];
+}
+
+const HYPERP_CONFIG_REFRESH_MS = 60_000;
+const DISCOVERY_INTERVAL_MS = 5 * 60_000;
+
+// Simulate on-chain SetDexPool by external mutation.
+function onChainSetDexPool(newPool: string): { dexPool: string } {
+  return { dexPool: newPool };
+}
+
+function oldCrankFlow(
+  state: State,
+  now: number,
+  fetchOnChainConfig: () => { dexPool: string },
+  discoverLastRunMs: number,
+): { sentToPool: string; cacheHit: boolean } {
+  // Pre-fix: only refresh config on discover() cadence.
+  if (now - discoverLastRunMs >= DISCOVERY_INTERVAL_MS) {
+    state.configDexPool = fetchOnChainConfig().dexPool;
+  }
+  const pool = state.configDexPool;
+  // Cache logic from resolveHyperpPoolRemainingAccounts.
+  const cacheHit = state.cachedPool === pool && state.cachedRemaining !== undefined;
+  if (!cacheHit) {
+    state.cachedPool = pool;
+    state.cachedRemaining = [`remaining-for-${pool}`];
+  }
+  return { sentToPool: pool, cacheHit };
+}
+
+function newCrankFlow(
+  state: State,
+  now: number,
+  fetchOnChainConfig: () => { dexPool: string },
+): { sentToPool: string; cacheHit: boolean } {
+  // M10 fix: refresh config on shorter TTL inside crankMarket's HYPERP branch.
+  if (
+    state.lastHyperpConfigRefreshMs === undefined ||
+    now - state.lastHyperpConfigRefreshMs >= HYPERP_CONFIG_REFRESH_MS
+  ) {
+    const fresh = fetchOnChainConfig();
+    const prevPool = state.configDexPool;
+    state.configDexPool = fresh.dexPool;
+    state.lastHyperpConfigRefreshMs = now;
+    if (prevPool !== fresh.dexPool) {
+      // Invalidate the remaining-accounts cache.
+      state.cachedPool = undefined;
+      state.cachedRemaining = undefined;
+    }
+  }
+  const pool = state.configDexPool;
+  const cacheHit = state.cachedPool === pool && state.cachedRemaining !== undefined;
+  if (!cacheHit) {
+    state.cachedPool = pool;
+    state.cachedRemaining = [`remaining-for-${pool}`];
+  }
+  return { sentToPool: pool, cacheHit };
+}
+
+describe("M10 PoC — HYPERP dexPool config refresh after admin SetDexPool", () => {
+  it("OLD pattern: admin SetDexPool change isn't visible to keeper for up to 5 min", () => {
+    const state: State = { configDexPool: "POOL_OLD" };
+    // discover() ran at t=0.
+    let onChain = { dexPool: "POOL_OLD" };
+
+    // t=120s: admin calls SetDexPool(POOL_NEW).
+    onChain = onChainSetDexPool("POOL_NEW");
+
+    // t=121s: crankMarket runs. Pre-fix uses cached config from discover().
+    const at121s = oldCrankFlow(state, 121_000, () => onChain, /* discoverLastRunMs */ 0);
+    expect(at121s.sentToPool).toBe("POOL_OLD"); // ← BUG: keeper sends to OLD pool
+
+    // t=240s: another cycle. Same stale config.
+    const at240s = oldCrankFlow(state, 240_000, () => onChain, 0);
+    expect(at240s.sentToPool).toBe("POOL_OLD"); // ← still stale
+
+    // t=301s: discover() finally runs (5 min cycle). NOW the keeper sees the change.
+    const at301s = oldCrankFlow(state, 301_000, () => onChain, 0);
+    expect(at301s.sentToPool).toBe("POOL_NEW");
+    // ↑ Up to 5 minutes of failed UpdateHyperpMark txs to the old pool.
+  });
+
+  it("NEW pattern: admin SetDexPool change is visible within 60 seconds", () => {
+    const state: State = { configDexPool: "POOL_OLD" };
+    let onChain = { dexPool: "POOL_OLD" };
+
+    // t=0: first crank refreshes and caches.
+    const at0 = newCrankFlow(state, 0, () => onChain);
+    expect(at0.sentToPool).toBe("POOL_OLD");
+
+    // t=30s: admin calls SetDexPool(POOL_NEW).
+    onChain = onChainSetDexPool("POOL_NEW");
+
+    // t=31s: crank runs but refresh TTL (60s) hasn't elapsed → still OLD.
+    const at31s = newCrankFlow(state, 31_000, () => onChain);
+    expect(at31s.sentToPool).toBe("POOL_OLD");
+
+    // t=61s: refresh TTL elapsed → keeper picks up POOL_NEW.
+    const at61s = newCrankFlow(state, 61_000, () => onChain);
+    expect(at61s.sentToPool).toBe("POOL_NEW");
+    // ↑ Window: up to 60s instead of up to 5 min. 5× faster recovery.
+  });
+
+  it("NEW pattern: pool change invalidates the remaining-accounts cache", () => {
+    const state: State = { configDexPool: "POOL_OLD" };
+    let onChain = { dexPool: "POOL_OLD" };
+
+    // Seed the remaining-accounts cache for POOL_OLD.
+    newCrankFlow(state, 0, () => onChain);
+    expect(state.cachedRemaining).toEqual(["remaining-for-POOL_OLD"]);
+
+    // SetDexPool to POOL_NEW.
+    onChain = onChainSetDexPool("POOL_NEW");
+
+    // Past TTL → refresh fires + cache invalidates + refetches for POOL_NEW.
+    newCrankFlow(state, 61_000, () => onChain);
+    expect(state.cachedRemaining).toEqual(["remaining-for-POOL_NEW"]);
+  });
+
+  it("NEW pattern: no pool change → cache stays warm, no extra refetches", () => {
+    const state: State = { configDexPool: "POOL_A" };
+    const onChain = { dexPool: "POOL_A" };
+
+    let calls = 0;
+    const tracked = () => { calls++; return onChain; };
+
+    // First crank fetches.
+    newCrankFlow(state, 0, tracked);
+    // Several cycles within TTL — no extra fetches.
+    newCrankFlow(state, 10_000, tracked);
+    newCrankFlow(state, 30_000, tracked);
+    newCrankFlow(state, 50_000, tracked);
+    expect(calls).toBe(1);
+
+    // Past TTL → one extra refresh, but cache stays warm (same pool).
+    newCrankFlow(state, 60_000, tracked);
+    expect(calls).toBe(2);
+    expect(state.cachedPool).toBe("POOL_A");
+    expect(state.cachedRemaining).toEqual(["remaining-for-POOL_A"]);
+  });
+
+  it("NEW pattern: env-configurable TTL (KEEPER_HYPERP_CONFIG_REFRESH_MS)", () => {
+    // The constant HYPERP_CONFIG_REFRESH_MS is initialised at module load
+    // from process.env.KEEPER_HYPERP_CONFIG_REFRESH_MS (default 60_000).
+    // Documented so operators can tune for hot vs sleepy markets.
+    expect(HYPERP_CONFIG_REFRESH_MS).toBeGreaterThanOrEqual(1);
+    expect(HYPERP_CONFIG_REFRESH_MS).toBeLessThanOrEqual(DISCOVERY_INTERVAL_MS);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **M10** from the internal pre-mainnet audit. Adds a 60s TTL refresh of the HYPERP slab config inside `crankMarket` so admin `SetDexPool` changes propagate to the keeper within 60s instead of up to 5 minutes.

## Root cause

`src/services/crank.ts:705` reads `state.market.config.dexPool` — the on-chain pinned pool that `UpdateHyperpMark` must target. This config is parsed from the slab during `discover()`, which runs every ~5 minutes by default.

The cache in `resolveHyperpPoolRemainingAccounts` (line 577) invalidates only when the input `poolAddress` differs:

```ts
if (state.dexPoolResolvedAddress === poolAddress &&
    state.dexPoolRemainingAccounts !== undefined) {
  return state.dexPoolRemainingAccounts;
}
```

After an admin calls `SetDexPool` to change `POOL_OLD → POOL_NEW`:
1. On-chain `dexPool` is now `POOL_NEW`.
2. `state.market.config.dexPool` stays `POOL_OLD` (parsed N minutes ago).
3. Each crank cycle (~30s) sends `UpdateHyperpMark` with `POOL_OLD` + remaining-accounts cached for `POOL_OLD`.
4. On-chain rejects with `OracleInvalid`.
5. Repeats for up to 5 minutes until `discover()` finally picks up the new pool.

Each failed tx burns priority fees + RPC quota + generates downstream "crank failing" alert noise.

## Fix

Inside the HYPERP branch of `crankMarket`, before reading `config.dexPool`:

```ts
if (this.isHyperpOracle(market)) {
  const now = Date.now();
  if (state.lastHyperpConfigRefreshMs === undefined ||
      now - state.lastHyperpConfigRefreshMs >= HYPERP_CONFIG_REFRESH_MS) {
    try {
      const freshSlab = await withTimeout(fetchSlab(connection, market.slabAddress), ...);
      const freshConfig = freshSlab ? parseConfig(freshSlab) : undefined;
      if (!freshConfig) throw new Error("freshConfig was undefined after parseConfig");

      const prevDexPool = state.market.config?.dexPool?.toBase58();
      state.market.config = freshConfig;
      state.lastHyperpConfigRefreshMs = now;

      const newDexPool = state.market.config.dexPool?.toBase58();
      if (prevDexPool !== newDexPool) {
        logger.info("HYPERP: on-chain dexPool changed; invalidating remaining-accounts cache", ...);
        state.dexPoolResolvedAddress = undefined;
        state.dexPoolType = undefined;
        state.dexPoolRemainingAccounts = undefined;
        state.hyperpNoPriceSkipped = false;
      }
    } catch (err) {
      logger.warn("HYPERP: failed to refresh slab config (M10) — using cached value", ...);
    }
  }
  // ...rest of HYPERP branch unchanged
}
```

- **TTL**: 60s default, env-configurable via `KEEPER_HYPERP_CONFIG_REFRESH_MS`.
- **Bounded cost**: one `getAccountInfo` per HYPERP market per minute.
- **Defensive**: undefined `freshConfig` (RPC blip, test mocks) → fall back to cached config; next cycle retries.
- **Cache invalidation**: if `dexPool` actually changed, drop the cached remaining-accounts so the next call refetches.

## Files touched

- `src/services/crank.ts` — add `HYPERP_CONFIG_REFRESH_MS` constant, `lastHyperpConfigRefreshMs` state field, refresh block in HYPERP branch.
- `tests/poc/m10.poc.test.ts` — 5 PoC tests.

## Test plan

- [x] **PoC**: OLD pattern — SetDexPool isn't visible for up to 5 min.
- [x] **PoC**: NEW pattern — SetDexPool is visible within 60s.
- [x] **PoC**: pool change invalidates the remaining-accounts cache.
- [x] **PoC**: no pool change → cache stays warm, no extra refetches.
- [x] **PoC**: env-configurable TTL.
- [x] M10 PoC: 5 passed.
- [x] Full vitest suite: **617 passed / 26 skipped** — no regressions.
- [x] `pnpm build` clean.

## Severity

**LOW–MEDIUM** — operational hygiene + resource hygiene. No security or fund-loss path. Bounded by `(HYPERP markets) × (admin SetDexPool frequency) × (~5min staleness window)`. The fix delivers **5× faster recovery** from admin pool reconfigurations with minimal RPC cost.

## Related

- **M8** (#194) + **M9** (#205) — same file, same audit cluster (`CL-DOUBLE-EXEC` for M8, `CL-STATE` for M10). M10 closes a separate cache-staleness vector orthogonal to the concurrency races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable HYPERP configuration refresh mechanism with a 60-second default interval to detect on-chain updates.
  * Configuration cache automatically invalidates when dex pool changes occur.

* **Bug Fixes**
  * Resolved issue where dex pool configuration changes took up to 5 minutes to become visible; now detects changes within ~60 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->