### PR TITLE
fix(crank): M9 — advance lastCrankTime on failure so the inactive back-off interval is honored

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -968,6 +968,17 @@ export class CrankService {
           consecutiveFailures: state.consecutiveFailures,
         });
       }
+      // M9: advance lastCrankTime on FAILURE too, not just success. Pre-fix,
+      // `isDue` checks `Date.now() - state.lastCrankTime >= interval`. With
+      // lastCrankTime only updated on success, a market that's been failing
+      // every cycle had a stale lastCrankTime (or 0 if it never succeeded),
+      // so isDue was always true. After 10 consecutive failures isActive
+      // flips to false and the keeper SHOULD back off from intervalMs (30s)
+      // to inactiveIntervalMs (120s) — but since lastCrankTime was stale,
+      // the back-off never fired. Advancing here makes the inactive interval
+      // honored: active-failing markets still retry every intervalMs (30s);
+      // deactivated markets retry every inactiveIntervalMs (120s) as designed.
+      state.lastCrankTime = Date.now();
 
       // P1 FIX: Detect InsufficientDexLiquidity (error 0x33 = 51) specifically.
       // This is the program's PercolatorError ordinal for the MIN_DEX_QUOTE_LIQUIDITY

--- a/tests/poc/m9.poc.test.ts
+++ b/tests/poc/m9.poc.test.ts
@@ -1,0 +1,151 @@
+/**
+ * M9 PoC — deactivated markets still poll at the active interval because
+ * lastCrankTime isn't advanced on failure.
+ *
+ * THE BUG (pre-fix):
+ *   `isDue(state)` at src/services/crank.ts:678 returns:
+ *     const interval = state.isActive ? this.intervalMs : this.inactiveIntervalMs;
+ *     return Date.now() - state.lastCrankTime >= interval;
+ *
+ *   On failure, the catch block at line 914+ updates `failureCount` and
+ *   `consecutiveFailures` but does NOT update `lastCrankTime`. After 10
+ *   consecutive failures `isActive` flips to false, intending to slow polls
+ *   from intervalMs (30s) to inactiveIntervalMs (120s). But the back-off
+ *   never fires because:
+ *     - If the market never succeeded once → lastCrankTime = 0 → isDue always true.
+ *     - If the market succeeded long ago → lastCrankTime is stale → isDue always true.
+ *
+ *   The dead market keeps cranking every 30s (active interval) regardless
+ *   of the isActive flag. RPC quota + priority fees burn on broken markets.
+ *
+ * THE FIX (this PR):
+ *   Add `state.lastCrankTime = Date.now()` at the top of the catch block,
+ *   right after the failureCount/consecutiveFailures increment. This
+ *   advances the time anchor on every attempt (success or failure), so
+ *   `isDue` honors the inactive interval as designed.
+ *
+ * This PoC walks through both shapes with a minimal isDue/state model.
+ */
+import { describe, it, expect } from "vitest";
+
+interface State {
+  isActive: boolean;
+  lastCrankTime: number;
+  consecutiveFailures: number;
+}
+
+const INTERVAL_MS = 30_000;          // active interval
+const INACTIVE_INTERVAL_MS = 120_000; // inactive interval
+
+function isDue(state: State, now: number): boolean {
+  const interval = state.isActive ? INTERVAL_MS : INACTIVE_INTERVAL_MS;
+  return now - state.lastCrankTime >= interval;
+}
+
+// OLD catch-block behavior: failure does NOT advance lastCrankTime.
+function oldCatch(state: State, _now: number): void {
+  state.consecutiveFailures++;
+  if (state.consecutiveFailures >= 10) state.isActive = false;
+}
+
+// NEW catch-block behavior: failure advances lastCrankTime.
+function newCatch(state: State, now: number): void {
+  state.consecutiveFailures++;
+  state.lastCrankTime = now;
+  if (state.consecutiveFailures >= 10) state.isActive = false;
+}
+
+describe("M9 PoC — lastCrankTime advances on failure to honor inactive interval", () => {
+  it("OLD pattern: market never succeeds → lastCrankTime stays 0 → isDue always true (no back-off)", () => {
+    const state: State = { isActive: true, lastCrankTime: 0, consecutiveFailures: 0 };
+
+    // Simulate 12 failed cycles, each 30s apart.
+    for (let i = 1; i <= 12; i++) {
+      const cycleTime = i * 30_000;
+      expect(isDue(state, cycleTime)).toBe(true); // always due → keeper cranks
+      oldCatch(state, cycleTime);
+    }
+
+    // After 10 failures, isActive flips to false (intent: back off).
+    expect(state.isActive).toBe(false);
+    expect(state.consecutiveFailures).toBe(12);
+
+    // BUG: at cycle 13 (T=390s = 13 × 30s), 30s after cycle 12's failure,
+    // isDue is STILL true even though isActive=false and the inactive
+    // interval is 120s. Why? Because lastCrankTime never moved from 0.
+    expect(isDue(state, 13 * 30_000)).toBe(true);
+    // ↑ Keeper keeps cranking the dead market every 30s. The 120s
+    //   inactive interval never fires.
+  });
+
+  it("NEW pattern: lastCrankTime advances on every failure → inactive back-off is honored", () => {
+    const state: State = { isActive: true, lastCrankTime: 0, consecutiveFailures: 0 };
+
+    // 10 failed cycles, each 30s apart.
+    for (let i = 1; i <= 10; i++) {
+      const cycleTime = i * 30_000;
+      expect(isDue(state, cycleTime)).toBe(true);
+      newCatch(state, cycleTime);
+    }
+
+    // After 10 failures: isActive=false, lastCrankTime=300_000 (cycle 10).
+    expect(state.isActive).toBe(false);
+    expect(state.lastCrankTime).toBe(300_000);
+
+    // Cycle 11 is 30s after cycle 10. The inactive interval is 120s.
+    // isDue checks 330_000 - 300_000 = 30_000 < 120_000 → false. SKIP.
+    expect(isDue(state, 11 * 30_000)).toBe(false);
+
+    // Cycle 12 (60s after): 60_000 < 120_000 → still skipped.
+    expect(isDue(state, 12 * 30_000)).toBe(false);
+
+    // Cycle 13 (90s after): still skipped.
+    expect(isDue(state, 13 * 30_000)).toBe(false);
+
+    // Cycle 14 (120s after): now eligible.
+    expect(isDue(state, 14 * 30_000)).toBe(true);
+
+    // ↑ The dead market polls every 120s instead of every 30s.
+    //   4× reduction in wasted RPC quota and priority-fee spend.
+  });
+
+  it("NEW pattern: active failing market is unaffected (still polls at 30s)", () => {
+    const state: State = { isActive: true, lastCrankTime: 0, consecutiveFailures: 0 };
+
+    // Fail 5 times — still active.
+    for (let i = 1; i <= 5; i++) {
+      const cycleTime = i * 30_000;
+      expect(isDue(state, cycleTime)).toBe(true);
+      newCatch(state, cycleTime);
+    }
+
+    expect(state.isActive).toBe(true);
+    expect(state.lastCrankTime).toBe(5 * 30_000);
+
+    // Next cycle 30s later: still due (active interval 30s).
+    expect(isDue(state, 6 * 30_000)).toBe(true);
+
+    // 15s later: not yet due.
+    expect(isDue(state, 5 * 30_000 + 15_000)).toBe(false);
+  });
+
+  it("NEW pattern: success after recovery resets to active and lastCrankTime advances normally", () => {
+    const state: State = { isActive: false, lastCrankTime: 1_000_000, consecutiveFailures: 15 };
+
+    // Simulate the success path's resets (production code lines 905-909).
+    function successPath(now: number) {
+      state.lastCrankTime = now;
+      state.consecutiveFailures = 0;
+      state.isActive = true;
+    }
+    successPath(2_000_000);
+
+    expect(state.isActive).toBe(true);
+    expect(state.lastCrankTime).toBe(2_000_000);
+    expect(state.consecutiveFailures).toBe(0);
+
+    // Back to active polling cadence.
+    expect(isDue(state, 2_030_000)).toBe(true); // 30s later → due
+    expect(isDue(state, 2_015_000)).toBe(false); // 15s → not yet
+  });
+});

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -318,6 +318,53 @@ describe('CrankService', () => {
       expect(isDueAt121s).toBe(true);
     });
 
+    // M9: lastCrankTime must advance on FAILURE too, not just success. Pre-fix,
+    // a market failing every cycle had a stale lastCrankTime, so the isDue
+    // back-off (from 30s active → 120s inactive after 10 failures) never
+    // actually fired — the keeper kept cranking the dead market every 30s.
+    it('M9: lastCrankTime advances on failure (inactive back-off interval is honored)', async () => {
+      const slabAddress = 'MarketM9LastCrankAaaaaaaaaaaaaaaaaaaaaaa';
+      const mockMarket = {
+        slabAddress: { toBase58: () => slabAddress },
+        programId: { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'MintM9111111111111111111111111111111111' },
+          oracleAuthority: { toBase58: () => '11111111111111111111111111111111', equals: () => true },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminM9Last1111111111111111111111111111' } },
+      };
+
+      vi.mocked(core.discoverMarkets).mockResolvedValue([mockMarket] as any);
+      await crankService.discover();
+
+      // Anchor time. A fresh market has lastCrankTime=0 (never cranked).
+      const t0 = 1_700_000_000_000;
+      vi.setSystemTime(t0);
+
+      const stateBefore = crankService.getMarkets().get(slabAddress)!;
+      expect(stateBefore.lastCrankTime).toBe(0);
+
+      // First crankMarket attempt fails. lastCrankTime must advance.
+      vi.mocked(keeperSendModule.keeperSend).mockRejectedValue(new Error('rpc error'));
+      const result = await crankService.crankMarket(slabAddress);
+      expect(result).toBe(false);
+
+      const stateAfterOneFailure = crankService.getMarkets().get(slabAddress)!;
+      expect(stateAfterOneFailure.consecutiveFailures).toBe(1);
+      expect(stateAfterOneFailure.lastCrankTime).toBe(t0);
+      //                                        ↑ pre-fix this would be 0 (never updated)
+
+      // Move time forward 15s and fail again. lastCrankTime must advance to t0+15s.
+      vi.setSystemTime(t0 + 15_000);
+      await crankService.crankMarket(slabAddress);
+      const stateAfterTwoFailures = crankService.getMarkets().get(slabAddress)!;
+      expect(stateAfterTwoFailures.lastCrankTime).toBe(t0 + 15_000);
+
+      vi.useRealTimers();
+    });
+
     it('should mark market inactive after 10 consecutive failures', async () => {
       const slabAddress = 'Market611111111111111111111111111111111';
       const mockMarket = {


### PR DESCRIPTION
Rebased from fork PR #205 (6figpsolseeker/percolator-keeper) onto current main.

## What

`state.lastCrankTime` was only updated on crank success. A market failing every cycle had a stale (or zero) `lastCrankTime`, so `isDue()` always returned `true` regardless of the `isActive` flag. After 10 consecutive failures `isActive` flips to `false` and the keeper should slow-poll at `inactiveIntervalMs` (120 s) — but the back-off never fired because `lastCrankTime` never moved. Dead markets kept cranking every 30 s, burning RPC quota and priority fees.

**Fix:** add `state.lastCrankTime = Date.now()` in the catch block, after the transient/non-transient counter split from M8/N2. Active-failing markets still retry every `intervalMs` (30 s); deactivated markets retry every `inactiveIntervalMs` (120 s) as designed.

## Rebase notes

The fork branch predated the N2 transient-error classification (`isTransient` split). The M9 line is placed after the counter block so it fires on every failure regardless of transient classification — consistent with the PR intent.

## Evidence

```
pnpm build   ✓  (tsc, 0 errors)
pnpm test    ✓  807 passed | 24 skipped (831 total)
```

Closes #205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where failed crank operations on markets could cause them to be continuously polled instead of respecting the appropriate polling interval based on their active status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->