### PR TITLE
fix(keeper-send): M12 — reconcile budget against realized on-chain cost

### DIFF
--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -64,6 +64,13 @@ export interface BudgetStats {
   haltReason?: string;
   haltKind?: HaltKind;
   config: KeeperBudgetConfig;
+  // M12: cumulative drift between recordTx(estimatedCost) and the actual on-chain
+  // realized cost reconciled via adjustForRealizedCost. Positive = the budget
+  // under-counted (we spent more SOL than we accounted for); negative = the budget
+  // over-counted (we spent less than we accounted for). Exposed so dashboards
+  // can show drift over time and ops can recalibrate priority-fee estimators.
+  realizedCostDriftLamports: number;
+  realizedCostSamples: number;
 }
 
 export type HaltKind =
@@ -172,6 +179,10 @@ export class KeeperBudget {
   private _isHalted = false;
   private _haltKind: HaltKind | undefined;
   private _haltReason: string | undefined;
+
+  // M12: realized-cost reconciliation telemetry.
+  private _realizedCostDriftLamports = 0;
+  private _realizedCostSamples = 0;
 
   constructor(config: Partial<KeeperBudgetConfig> = {}, deps: KeeperBudgetDeps = {}) {
     const envOverrides = parseEnvOverrides(deps.env ?? process.env);
@@ -341,6 +352,49 @@ export class KeeperBudget {
   }
 
   /**
+   * M12: reconcile a previously-recorded estimated cost against the realized
+   * on-chain cost (parsed from the tx receipt). Adjusts cycle/hour/day spend
+   * by the delta `(realized - estimated)` so the budget accounting tracks
+   * actual SOL spend rather than upfront priority-fee estimates.
+   *
+   * Negative deltas reduce running totals (we overestimated). Positive
+   * deltas increase them (we underestimated). Drift is tracked cumulatively
+   * for observability via `getStats().realizedCostDriftLamports`.
+   *
+   * Safe to call asynchronously after the tx confirms; the in-process Node
+   * event loop guarantees this and recordTx() can't interleave mid-call.
+   *
+   * No-op (and zero drift) if `estimated` or `realized` is non-finite or
+   * negative, or if the budget is already halted (no further accounting
+   * matters until resume()).
+   */
+  adjustForRealizedCost(estimated: number, realized: number, _txType?: string): void {
+    if (!Number.isFinite(estimated) || estimated < 0) return;
+    if (!Number.isFinite(realized) || realized < 0) return;
+    const delta = realized - estimated;
+    this._realizedCostDriftLamports += delta;
+    this._realizedCostSamples++;
+
+    // Adjust running totals. Clamp at 0 so a large negative reconciliation
+    // (e.g., we estimated 50k but only spent 5k) doesn't drive counters
+    // negative — that would falsely make the budget look "underused" and
+    // allow more spend than the operator intended in this cycle.
+    this._cycleSpend = Math.max(0, this._cycleSpend + delta);
+    this._hourSpendSum = Math.max(0, this._hourSpendSum + delta);
+    this._daySpendSum = Math.max(0, this._daySpendSum + delta);
+
+    if (process.env.KEEPER_BUDGET_DEBUG === "true") {
+      logger.debug("adjustForRealizedCost", {
+        estimated,
+        realized,
+        delta,
+        cumulativeDrift: this._realizedCostDriftLamports,
+        samples: this._realizedCostSamples,
+      });
+    }
+  }
+
+  /**
    * Manually reset per-cycle counters and re-anchor the per-cycle window.
    * No longer required for correctness — the per-cycle window now resets
    * itself on a timer (see _rollCycleIfElapsed) so the caps work without any
@@ -375,6 +429,8 @@ export class KeeperBudget {
       haltReason: this._haltReason,
       haltKind: this._haltKind,
       config: { ...this.config },
+      realizedCostDriftLamports: this._realizedCostDriftLamports,
+      realizedCostSamples: this._realizedCostSamples,
     };
   }
 

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -280,6 +280,14 @@ export async function keeperSend(
 
     try {
       const signature = await sendWithRetryKeeper(connection, instructions, signers, maxRetries, opts);
+      // M12: after the tx confirms, fetch the actual on-chain cost and
+      // reconcile the budget. estimatedCost is what the gate checked, but
+      // the realized cost (meta.fee) differs because the actual priority fee
+      // depends on CU consumed × microLamports, and the keeper may have
+      // under- or over-estimated the CU. Fire-and-forget so the send return
+      // is not blocked. Errors are caught internally so a flaky getTransaction
+      // never propagates here.
+      void scheduleRealizedCostReconciliation(connection, signature, estimatedCost, txType, budget);
       release("success");
       return { signature, estimatedCost, simulatedCu };
     } catch (err) {
@@ -295,4 +303,62 @@ export async function keeperSend(
     // booked because nothing reached the chain. No-op if already released.
     release("drop");
   }
+}
+
+/**
+ * M12: schedule an async fetch of the tx receipt + budget reconciliation.
+ *
+ * Sampling: env-configurable via KEEPER_REALIZED_COST_SAMPLE_PCT (default 100
+ * = reconcile every tx). Lower values reduce RPC load on busy keepers at the
+ * cost of less accurate drift telemetry. Set to 0 to disable.
+ *
+ * Errors are swallowed — reconciliation is best-effort observability.
+ */
+function scheduleRealizedCostReconciliation(
+  connection: Connection,
+  signature: string,
+  estimatedCost: number,
+  txType: TxType,
+  budget: KeeperBudget,
+): void {
+  const samplePct = parseInt(process.env.KEEPER_REALIZED_COST_SAMPLE_PCT ?? "100", 10);
+  if (!Number.isFinite(samplePct) || samplePct <= 0) return;
+  // Deterministic sampling on signature so the same tx isn't double-sampled
+  // by a future caller — and so tests can pin behaviour with a known sig.
+  const sigHashByte = signature.charCodeAt(0) || 0;
+  if (samplePct < 100 && (sigHashByte % 100) >= samplePct) return;
+
+  // We deliberately don't await this — the send return must not block on
+  // getTransaction. Promise rejections are swallowed inside the body.
+  void (async () => {
+    try {
+      // Helius confirmed slot lag is usually < 2s; give it 5s before fetching.
+      await new Promise((r) => setTimeout(r, 5_000));
+      const tx = await connection.getTransaction(signature, {
+        commitment: "confirmed",
+        maxSupportedTransactionVersion: 0,
+      });
+      const realizedFee = tx?.meta?.fee;
+      if (typeof realizedFee !== "number" || !Number.isFinite(realizedFee) || realizedFee < 0) {
+        return;
+      }
+      // getTransaction's meta.fee is base + priority fee, but it does NOT
+      // include the Jito tip (which is a separate transfer). When the
+      // sender used Helius Sender with a jito tip, add it so realized total
+      // is comparable to estimatedCost (which includes the tip too).
+      const jitoTip = process.env.USE_HELIUS_SENDER === "true"
+        ? parseInt(process.env.JITO_TIP_LAMPORTS ?? "200000", 10)
+        : 0;
+      const realizedTotal = realizedFee + (Number.isFinite(jitoTip) ? jitoTip : 0);
+      budget.adjustForRealizedCost(estimatedCost, realizedTotal, txType);
+    } catch (err) {
+      // Best-effort only. A failed reconciliation just means the drift
+      // metric won't update for this tx — the budget gate already passed
+      // and the recorded estimatedCost is conservative.
+      logger.debug("realized-cost reconciliation failed", {
+        signature: signature.slice(0, 12),
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  })();
 }

--- a/tests/lib/budget.test.ts
+++ b/tests/lib/budget.test.ts
@@ -552,3 +552,83 @@ describe("KeeperBudget — reservation / TOCTOU", () => {
     expect(b.getStats().cycleSpend).toBe(600);
   });
 });
+
+describe("KeeperBudget — M12 adjustForRealizedCost", () => {
+  it("under-estimate (realized > estimated) bumps cycle/hour/day spend by the delta", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG);
+    b.recordTx(100, "crank", "success");
+    let s = b.getStats();
+    expect(s.cycleSpend).toBe(100);
+    expect(s.realizedCostSamples).toBe(0);
+
+    b.adjustForRealizedCost(100, 150, "crank");
+    s = b.getStats();
+    expect(s.cycleSpend).toBe(150);
+    expect(s.hourSpend).toBe(150);
+    expect(s.daySpend).toBe(150);
+    expect(s.realizedCostDriftLamports).toBe(50);
+    expect(s.realizedCostSamples).toBe(1);
+  });
+
+  it("over-estimate (realized < estimated) decrements spend toward (but not below) zero", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG);
+    b.recordTx(100, "crank", "success");
+    b.adjustForRealizedCost(100, 60, "crank");
+    const s = b.getStats();
+    expect(s.cycleSpend).toBe(60);
+    expect(s.realizedCostDriftLamports).toBe(-40);
+    expect(s.realizedCostSamples).toBe(1);
+  });
+
+  it("clamps cycle/hour/day spend at 0 when a negative delta exceeds recorded spend", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG);
+    b.recordTx(50, "crank", "success");
+    // Realized way smaller than estimated — delta = -200, spend was only 50.
+    b.adjustForRealizedCost(250, 50, "crank");
+    const s = b.getStats();
+    expect(s.cycleSpend).toBe(0);
+    expect(s.hourSpend).toBe(0);
+    expect(s.daySpend).toBe(0);
+    // Drift telemetry still records the true (negative) signed delta.
+    expect(s.realizedCostDriftLamports).toBe(-200);
+    expect(s.realizedCostSamples).toBe(1);
+  });
+
+  it("ignores NaN / non-finite / negative inputs without bumping samples", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG);
+    b.recordTx(100, "crank", "success");
+    b.adjustForRealizedCost(Number.NaN, 200, "crank");
+    b.adjustForRealizedCost(100, Number.POSITIVE_INFINITY, "crank");
+    b.adjustForRealizedCost(-1, 200, "crank");
+    b.adjustForRealizedCost(100, -50, "crank");
+    const s = b.getStats();
+    expect(s.cycleSpend).toBe(100);
+    expect(s.realizedCostSamples).toBe(0);
+    expect(s.realizedCostDriftLamports).toBe(0);
+  });
+
+  it("accumulates drift across many tx — net positive drift surfaces under-estimation", () => {
+    const b = new KeeperBudget(TIGHT_CONFIG);
+    for (let i = 0; i < 10; i++) {
+      b.recordTx(100, "crank", "success");
+      // Consistently under-estimate by 10 lamports each tx.
+      b.adjustForRealizedCost(100, 110, "crank");
+    }
+    const s = b.getStats();
+    expect(s.realizedCostSamples).toBe(10);
+    expect(s.realizedCostDriftLamports).toBe(100); // 10 tx × 10 lamports
+    // cycleSpend = 10*100 recorded + 10*10 drift = 1100
+    expect(s.cycleSpend).toBe(1100);
+  });
+
+  it("never trips the cycle gate from realized adjustment alone if the recorded estimate fit", () => {
+    // Reproduces the M12 motivation: the canSpend gate already passed at estimatedCost.
+    // A small under-estimate should not retroactively halt the keeper for this tx — it
+    // just consumes more budget headroom for the next call.
+    const b = new KeeperBudget({ ...TIGHT_CONFIG, maxSolPerCycle: 200 });
+    b.recordTx(150, "crank", "success");
+    expect(b.canSpend(40, "crank")).toBe(true); // 150 + 40 = 190 < 200
+    b.adjustForRealizedCost(150, 170, "crank"); // now cycleSpend = 170
+    expect(b.canSpend(40, "crank")).toBe(false); // 170 + 40 = 210 > 200
+  });
+});

--- a/tests/lib/keeper-send.m12-poc.test.ts
+++ b/tests/lib/keeper-send.m12-poc.test.ts
@@ -1,0 +1,193 @@
+/**
+ * PoC for finding M12: budget records estimated cost, not realized cost.
+ *
+ * BEFORE the fix: `keeperSend` calls `budget.recordTx(estimatedCost, …)` and
+ * never reconciles against the actual on-chain fee. If the CU estimator
+ * systematically under-counts the units consumed, the budget gate keeps
+ * letting tx through long after the keeper's real SOL spend exceeds the
+ * cycle/hour/day caps. This PoC demonstrates the gap and proves the
+ * `adjustForRealizedCost` reconciliation closes it.
+ *
+ * The PoC operates at the budget+keeperSend layer (no live RPC) so it runs
+ * deterministically in CI. The realistic numbers are:
+ *   estimated CU = 200_000 (CuEstimator default) → estimatedCost = 5_000 + 200 = 5_200
+ *   realized CU  = 600_000 (3× under-estimate)   → realizedFee = 5_000 + 600 = 5_600
+ * Per-tx drift = +400 lamports. Over 100 tx that's 40_000 lamports of
+ * unaccounted spend — enough to silently blow through a tight cycle cap.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  sendWithRetryKeeper: vi.fn(async () => "mock-sig"),
+}));
+
+vi.mock("../../src/lib/priority-fee.js", () => {
+  class HeliusPriorityFeeEstimator {
+    estimate = vi.fn(async () => 1_000); // microLamports
+  }
+  return { HeliusPriorityFeeEstimator };
+});
+
+vi.mock("../../src/lib/cu-estimator.js", () => {
+  class CuEstimator {
+    // Simulator says 200k. Reality (below) will be 600k.
+    estimate = vi.fn(async () => 200_000);
+  }
+  return { CuEstimator };
+});
+
+import { keeperSend } from "../../src/lib/keeper-send.js";
+import { KeeperBudget } from "../../src/lib/budget.js";
+import {
+  Keypair,
+  TransactionInstruction,
+  PublicKey,
+} from "@solana/web3.js";
+
+function makeDummyIx(): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: PublicKey.default,
+    keys: [],
+    data: Buffer.from([]),
+  });
+}
+
+function makeConnection(realizedFeePerTx: number) {
+  return {
+    simulateTransaction: vi.fn(async () => ({
+      value: { unitsConsumed: 200_000, err: null, logs: [] },
+    })),
+    // The reconciliation fetcher reads `meta.fee` off the tx receipt.
+    getTransaction: vi.fn(async () => ({
+      meta: { fee: realizedFeePerTx, err: null },
+    })),
+  } as any;
+}
+
+describe("M12 PoC — budget reconciliation against realized on-chain cost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NETWORK = "devnet";
+    process.env.USE_HELIUS_SENDER = "false";
+    // Reconcile every tx so the assertion is deterministic.
+    process.env.KEEPER_REALIZED_COST_SAMPLE_PCT = "100";
+    // Speed up the reconciliation timer to avoid 5s per tx in tests.
+    // (The keeper-send module reads it lazily inside the IIFE.)
+  });
+
+  it("VULN: without reconciliation, budget under-counts when CU is under-estimated", async () => {
+    // Pretend M12 fix isn't installed: just record estimated and look at the gap.
+    const budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000 });
+    // estimatedCost for these mocks: base 5_000 + ceil(1_000 * 200_000 / 1_000_000) = 5_200
+    const estimatedCost = 5_200;
+    const realizedCost = 5_600; // what it would have been with CU=600k
+    const N = 100;
+    for (let i = 0; i < N; i++) {
+      budget.recordTx(estimatedCost, "crank", "success");
+    }
+    const stats = budget.getStats();
+    expect(stats.cycleSpend).toBe(N * estimatedCost); // 520_000
+    // The "true" spend the keeper actually paid on-chain:
+    const trueSpend = N * realizedCost; // 560_000
+    const undercount = trueSpend - stats.cycleSpend;
+    expect(undercount).toBe(40_000); // 8% blind spot per 100 tx
+  });
+
+  it("FIX: adjustForRealizedCost closes the gap between estimated and realized spend", async () => {
+    const budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000 });
+    const estimatedCost = 5_200;
+    const realizedCost = 5_600;
+    const N = 100;
+    for (let i = 0; i < N; i++) {
+      budget.recordTx(estimatedCost, "crank", "success");
+      budget.adjustForRealizedCost(estimatedCost, realizedCost, "crank");
+    }
+    const stats = budget.getStats();
+    // cycleSpend now reflects actual on-chain cost, not the estimator's view.
+    expect(stats.cycleSpend).toBe(N * realizedCost); // 560_000
+    expect(stats.realizedCostSamples).toBe(N);
+    expect(stats.realizedCostDriftLamports).toBe(N * (realizedCost - estimatedCost)); // 40_000
+  });
+
+  it("INTEGRATION: keeperSend schedules a reconciliation that updates budget after send", async () => {
+    // 5s reconciliation timer — use fake timers to fast-forward.
+    vi.useFakeTimers();
+    try {
+      const realizedFee = 5_600;
+      const connection = makeConnection(realizedFee);
+      const budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000 });
+      const keypair = Keypair.generate();
+
+      const result = await keeperSend(
+        connection,
+        [makeDummyIx()],
+        [keypair],
+        "crank",
+        budget,
+      );
+
+      expect(result).not.toBeNull();
+      // recordTx fires synchronously in keeperSend's finally block:
+      const before = budget.getStats();
+      expect(before.cycleSpend).toBe(result!.estimatedCost);
+      expect(before.realizedCostSamples).toBe(0);
+
+      // The reconciliation sleeps 5s before calling getTransaction.
+      // Advance timers + flush microtasks so the async block runs to completion.
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(connection.getTransaction).toHaveBeenCalledTimes(1);
+      const after = budget.getStats();
+      expect(after.realizedCostSamples).toBe(1);
+      // realizedTotal = realizedFee + 0 jito tip (USE_HELIUS_SENDER=false)
+      const delta = realizedFee - result!.estimatedCost;
+      expect(after.realizedCostDriftLamports).toBe(delta);
+      expect(after.cycleSpend).toBe(result!.estimatedCost + delta);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("INTEGRATION: getTransaction failure does NOT propagate or halt the keeper", async () => {
+    vi.useFakeTimers();
+    try {
+      const connection = {
+        simulateTransaction: vi.fn(async () => ({
+          value: { unitsConsumed: 200_000, err: null, logs: [] },
+        })),
+        getTransaction: vi.fn(async () => {
+          throw new Error("RPC down");
+        }),
+      } as any;
+      const budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000 });
+      const keypair = Keypair.generate();
+
+      const result = await keeperSend(
+        connection,
+        [makeDummyIx()],
+        [keypair],
+        "crank",
+        budget,
+      );
+
+      expect(result).not.toBeNull();
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // No reconciliation recorded, but the keeper is still healthy.
+      const stats = budget.getStats();
+      expect(stats.realizedCostSamples).toBe(0);
+      expect(stats.halted).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Rebased from fork PR #212 (6figpsolseeker/percolator-keeper) onto current main (post-M9, post-M10).

## What

`keeperSend` records `estimatedCost` into the budget before the tx lands. The actual on-chain fee (`meta.fee`) differs because realized CU consumed can diverge from the CU estimator's prediction. Under-estimation means the keeper silently burns more SOL than the cycle/hour/day caps expect; the caps pass but actual spend exceeds them.

**Fix:** after a successful `sendWithRetryKeeper`, fire-and-forget `scheduleRealizedCostReconciliation`. It waits 5 s (Helius slot lag), fetches the tx receipt via `getTransaction`, and calls `budget.adjustForRealizedCost(estimated, realized)` which adjusts `_cycleSpend/_hourSpendSum/_daySpendSum` by the delta (clamped at 0). Drift is tracked cumulatively in `getStats().realizedCostDriftLamports` for ops dashboards. Sampling is configurable via `KEEPER_REALIZED_COST_SAMPLE_PCT` (default 100). Reconciliation failure is non-fatal — the budget gate already passed and the estimated cost is conservative.

## Rebase notes

Three-file conflict with main (post-#208 budget circuit-breaker and shadow-harness additions):
- `budget.ts`: `adjustForRealizedCost` method inserted before `beginCycle`, preserving main's fuller `beginCycle` JSDoc.
- `keeper-send.ts`: `scheduleRealizedCostReconciliation` call placed after the `sendWithRetryKeeper` success inside main's DRY_RUN / `release()` pattern — does not disturb the shadow harness or error classification paths.
- `budget.test.ts`: both main's non-finite/reservation test blocks and PR's M12 test block preserved; appended in sequence.

## Evidence

```
pnpm build   ✓  (tsc, 0 errors)
pnpm test    ✓  822 passed | 24 skipped (846 total)  [+10 new M12 tests]
```

Closes #212