### PR TITLE
docs: clarify keeper environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ docker run --env-file .env percolator-keeper
 | `CRANK_KEYPAIR` | ✅ | Keeper wallet private key (base58) or path to keypair JSON |
 | `SUPABASE_URL` | ✅ | Supabase project URL |
 | `SUPABASE_KEY` | ✅ | Supabase anon key (for keeper runtime) |
-| `SUPABASE_SERVICE_ROLE_KEY` | ✅ | Supabase service role key (must differ from `SUPABASE_KEY`) |
+| `SUPABASE_SERVICE_ROLE_KEY` | ❌ | Do not provide this for keeper runtime. Use `SUPABASE_KEY` anon key only. |
 | `SENTRY_DSN` | ❌ | Sentry error tracking DSN |
 | `KEEPER_HEALTH_PORT` | ❌ | Health check port (default: 8081) |
 | `KEEPER_REGISTER_SECRET` | ❌ | Shared secret for `/register` endpoint |
 | `ADL_ENABLED` | ❌ | Set to `true` to enable ADL service |
+> Security note: Do not commit real `.env` files, private keys, RPC API keys, or Supabase secrets. Use `.env.example` as a template and keep local secrets out of git.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ docker run --env-file .env percolator-keeper
 | `KEEPER_HEALTH_PORT` | ❌ | Health check port (default: 8081) |
 | `KEEPER_REGISTER_SECRET` | ❌ | Shared secret for `/register` endpoint |
 | `ADL_ENABLED` | ❌ | Set to `true` to enable ADL service |
+
 > Security note: Do not commit real `.env` files, private keys, RPC API keys, or Supabase secrets. Use `.env.example` as a template and keep local secrets out of git.
 
 ## License


### PR DESCRIPTION
## Summary

This PR clarifies the keeper environment setup documentation.

Changes:
- Aligns the README Supabase guidance with `.env.example`
- Marks `SUPABASE_SERVICE_ROLE_KEY` as not required for keeper runtime
- Adds a short security note about not committing real `.env` files or secrets

## Validation

- [x] pnpm build
- [x] pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment variables guidance for Supabase configuration, clarifying that only the anon key is required for runtime setup.
  * Added security reminder about protecting sensitive credentials from being committed to version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->