### PR TITLE
fix(keeper-send): M13 — re-check leader before send (close HA TOCTOU window from #191)

### DIFF
--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -278,6 +278,19 @@ export async function keeperSend(
       ...(isMainnetSender() ? { skipPreflight: true } : {}),
     };
 
+    // M13: re-check leadership IMMEDIATELY before the actual send. The entry
+    // gate at line 190 fired before `await estimateCost(...)`, which can take
+    // 100-500ms for the priority-fee fetch + CU simulation. A Redis renew blip
+    // during that window can demote this node — without this second check, the
+    // demoted node still lands the tx, defeating the single-writer barrier
+    // PR #191 was designed to provide. On demotion, release the reservation as
+    // "drop" so no spend is booked and the budget stays sane.
+    if (!_isLeader()) {
+      logger.warn("keeperSend: lost leadership during estimateCost — aborting before send", { txType });
+      release("drop");
+      return null;
+    }
+
     try {
       const signature = await sendWithRetryKeeper(connection, instructions, signers, maxRetries, opts);
       release("success");

--- a/tests/lib/keeper-send.m13-poc.test.ts
+++ b/tests/lib/keeper-send.m13-poc.test.ts
@@ -1,0 +1,162 @@
+/**
+ * PoC for finding M13: TOCTOU in keeperSend single-writer guard.
+ *
+ * PR #191 added `_isLeader()` check at the ENTRY of keeperSend (line 190). But
+ * the actual on-chain `sendWithRetryKeeper` call doesn't happen until line 282,
+ * after an `await estimateCost(...)` that takes 100-500ms (priority-fee fetch +
+ * CU simulation). If the node loses leadership during that await window — a
+ * single Redis blip is enough — the demoted node still sends, defeating the
+ * host-local single-writer barrier and racing with the new leader.
+ *
+ * Threat model:
+ *   1. Node A is leader, dequeues a liquidation tx; keeperSend gate at line 190
+ *      sees leader=true.
+ *   2. estimateCost begins (~200ms: priority-fee fetch + CU sim).
+ *   3. During the await, a Redis renew blip flips Node A to standby.
+ *   4. estimateCost returns; canSpend passes; sendWithRetryKeeper at line 282
+ *      runs WITHOUT a re-check, landing the tx after demotion.
+ *   5. New leader Node B also picks up the same liquidation candidate. Double-send.
+ *
+ * Fix: re-check `_isLeader()` immediately before sendWithRetryKeeper and abort
+ * (release reservation as "drop", return null) if leadership was lost.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  sendWithRetryKeeper: vi.fn(async () => "mock-signature"),
+}));
+vi.mock("../../src/lib/priority-fee.js", () => {
+  class HeliusPriorityFeeEstimator {
+    // Slow estimate to simulate the realistic ~100-500ms fetch latency.
+    estimate = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      return 1_000;
+    });
+  }
+  return { HeliusPriorityFeeEstimator };
+});
+vi.mock("../../src/lib/cu-estimator.js", () => {
+  class CuEstimator {
+    estimate = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      return 200_000;
+    });
+  }
+  return { CuEstimator };
+});
+
+import * as shared from "@percolatorct/shared";
+import { keeperSend, setLeaderCheck } from "../../src/lib/keeper-send.js";
+import { KeeperBudget } from "../../src/lib/budget.js";
+import {
+  Keypair,
+  TransactionInstruction,
+  PublicKey,
+} from "@solana/web3.js";
+
+function makeDummyIx(): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: PublicKey.default,
+    keys: [],
+    data: Buffer.from([]),
+  });
+}
+function makeConnection() {
+  return {
+    simulateTransaction: vi.fn(async () => ({
+      value: { unitsConsumed: 200_000, err: null, logs: [] },
+    })),
+  } as any;
+}
+
+describe("M13 PoC — keeperSend leader gate TOCTOU between entry-check and send", () => {
+  let budget: KeeperBudget;
+  let connection: ReturnType<typeof makeConnection>;
+  let keypair: Keypair;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000, maxTxPerCycle: 100 });
+    connection = makeConnection();
+    keypair = Keypair.generate();
+    process.env.NETWORK = "devnet";
+    process.env.USE_HELIUS_SENDER = "false";
+  });
+  afterEach(() => {
+    setLeaderCheck(() => true);
+  });
+
+  it("REGRESSION: a node demoted DURING estimateCost must NOT call sendWithRetryKeeper", async () => {
+    // Stateful leader check: starts true (so the entry gate passes), then flips
+    // to false partway through the call to simulate a renew-driven demotion
+    // mid-flight while estimateCost is still awaiting.
+    let isLeader = true;
+    setLeaderCheck(() => isLeader);
+
+    // Kick off the send and, after a short delay, demote.
+    const sendPromise = keeperSend(
+      connection,
+      [makeDummyIx()],
+      [keypair],
+      "liquidation",
+      budget,
+    );
+    // Demote ~30ms in — well before the estimateCost mocks (50ms each, ~100ms
+    // total) finish.
+    setTimeout(() => {
+      isLeader = false;
+    }, 30);
+
+    const result = await sendPromise;
+
+    // PRE-FIX: result is non-null, sendWithRetryKeeper was called, budget charged.
+    // POST-FIX: result is null, no send, no spend booked.
+    expect(result).toBeNull();
+    expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+    // No spend should be booked on a demotion-aborted send.
+    expect(budget.getStats().cycleSpend).toBe(0);
+  });
+
+  it("REGRESSION: leadership lost between canSpend reservation and send must release the reservation", async () => {
+    // After the fix, the second leader check sits between canSpend (which
+    // reserves) and sendWithRetryKeeper. If we abort there, the reservation
+    // must be released as "drop" (no spend booked) so the budget stays sane.
+    let isLeader = true;
+    setLeaderCheck(() => isLeader);
+
+    const sendPromise = keeperSend(
+      connection,
+      [makeDummyIx()],
+      [keypair],
+      "liquidation",
+      budget,
+    );
+    setTimeout(() => {
+      isLeader = false;
+    }, 30);
+    const result = await sendPromise;
+
+    expect(result).toBeNull();
+    // Reservation drained, no settled spend.
+    expect(budget.getStats().cycleSpend).toBe(0);
+    expect(budget.getStats().reservedLamports).toBe(0);
+    expect(budget.getStats().reservedTxCount).toBe(0);
+    // Attempt was counted but it was a "drop" — no success/fail success-rate poison.
+    expect(budget.getStats().cycleTxCount).toBe(1);
+  });
+
+  it("BASELINE: when leadership is held throughout, send proceeds as normal", async () => {
+    setLeaderCheck(() => true);
+    const result = await keeperSend(
+      connection,
+      [makeDummyIx()],
+      [keypair],
+      "liquidation",
+      budget,
+    );
+    expect(result).not.toBeNull();
+    expect(shared.sendWithRetryKeeper).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Finding M13 — TOCTOU in `keeperSend` single-writer guard

**Severity:** Medium
**Cluster:** HA split-brain hardening (partner to #126, #186, #191)
**File:** [`src/lib/keeper-send.ts`](src/lib/keeper-send.ts)

### Problem

[#191](https://github.com/dcccrypto/percolator-keeper/pull/191) added a single-writer guard at the entry of `keeperSend` — a node that has lost HA leadership now refuses to send. The guard fires at [keeper-send.ts:190](src/lib/keeper-send.ts#L190):

```ts
if (!_isLeader()) {
  logger.warn("keeperSend: not leader — skipping send", { txType });
  return null;
}
const { estimatedCost, simulatedCu } = await estimateCost(...);   // 100-500ms
// ... canSpend, DRY_RUN intercept, etc. ...
const signature = await sendWithRetryKeeper(...);                  // ← still runs
```

The guard fires BEFORE the `await estimateCost(...)` (priority-fee fetch + CU sim), which takes 100-500ms in production. A Redis renew blip during that window flips this node to standby — but the awaited `estimateCost` still resolves, the budget reservation still passes, and `sendWithRetryKeeper` still runs, **landing a tx as a no-longer-leader**.

That defeats the host-local barrier #191 was designed to provide. The new leader on another host can be processing the same liquidation / crank candidate; the demoted node races it, burning priority fees + Jito tip and leaving a duplicate on-chain attempt. The on-chain programs are permissionless, so this host-local re-check is the actual barrier.

### Threat model

1. Node A is leader; sharedTxQueue dequeues a `liquidation` send and invokes `keeperSend`.
2. [keeper-send.ts:190](src/lib/keeper-send.ts#L190) entry gate fires: `_isLeader() === true`. ✓
3. `await estimateCost(...)` begins (~200ms typical).
4. During step 3, Redis renew blip → `LeaderLock._demote("redis-renew-failed")` → role flips to `"standby"`. `setLeaderCheck(...)` now returns `false`.
5. `estimateCost` resolves; `canSpend` passes; `sendWithRetryKeeper` runs at [keeper-send.ts:282](src/lib/keeper-send.ts#L282) without a re-check.
6. Node A lands a tx after demotion, racing the new leader.

### Fix

Re-check `_isLeader()` immediately before `sendWithRetryKeeper`. On demotion, release the canSpend reservation as `"drop"` (no spend booked, attempt counted) and return `null`. The window narrows from "an entire `estimateCost` await" to a single sync stack frame, and the budget invariant is preserved.

```ts
// M13: re-check leadership IMMEDIATELY before the actual send. ...
if (!_isLeader()) {
  logger.warn("keeperSend: lost leadership during estimateCost — aborting before send", { txType });
  release("drop");
  return null;
}

try {
  const signature = await sendWithRetryKeeper(...);
  ...
}
```

### Why `"drop"` and not `"fail"`/`"reverted"`

- `"success"` / `"fail"` / `"reverted"` all book lamports against the spend trackers. We didn't actually spend anything — we never sent.
- `"fail"` also feeds the tx-success-rate breaker. A demotion-aborted send is not a tx-success-rate signal.
- `"drop"` books no spend, no success-rate sample, but increments `cycleTxCount` — accurate.

### Tests

- [`tests/lib/keeper-send.m13-poc.test.ts`](tests/lib/keeper-send.m13-poc.test.ts) — 3-test PoC:
  1. **REGRESSION** — demote mid-`estimateCost`; assert `sendWithRetryKeeper` never called, result is null, no spend booked. Fails on pre-fix code.
  2. **REGRESSION** — same scenario; assert reservation cleanly released (`_reservedLamports === 0`, `_reservedTxCount === 0`); `cycleTxCount` incremented once.
  3. **BASELINE** — leader held throughout → normal send.
- Existing [`tests/lib/keeper-send-leader-gate.test.ts`](tests/lib/keeper-send-leader-gate.test.ts) (entry-gate coverage from #191) continues to pass unchanged.

### Verification

- `pnpm vitest run` — **805 passed / 0 failed** (74 files, 24 skipped).
- `pnpm build` — clean `tsc`.

### Risk

Very low. One additional sync `_isLeader()` call on the hot path. The default `_isLeader = () => true` (standalone / no-HA) makes the second check a no-op, so non-HA deployments are byte-for-byte unchanged. HA deployments benefit immediately — the demotion-driven race is closed without touching any other code path.

### Related

- #126 — fenced lease renewal (Lua EVAL CAS)
- #186 — demoted leader rejoins standby polling
- #191 — single-writer guard at `keeperSend` entry (partner to this PR — M13 closes the remaining TOCTOU window)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction sending to verify leadership status immediately before on-chain submission, preventing unintended transaction execution if leadership is lost during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->