### PR TITLE
fix(liquidation): include fee debt in keeper equity (closes #223)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -366,7 +366,12 @@ export class LiquidationService {
           // v12.17: entryPrice is always 0n (removed from on-chain struct).
           // Use account.pnl directly — it is always populated and accurate.
           const markPnl = account.pnl;
-          const equity = account.capital + markPnl;
+          // Mirror the on-chain maintenance equity: account_equity_maint_raw_wide =
+          // capital + pnl − fee_debt, where fee_debt = -feeCredits when feeCredits < 0
+          // (fee_debt_u128_checked). Omitting it overstated equity for fee-indebted
+          // accounts and silently skipped liquidating them.
+          const feeDebt = account.feeCredits < 0n ? -account.feeCredits : 0n;
+          const equity = account.capital + markPnl - feeDebt;
           const marginRatioBps = computeMarginRatioBps(equity, notional);
 
           // If margin ratio < maintenance margin, this account is liquidatable.
@@ -550,7 +555,9 @@ export class LiquidationService {
         // skipped the re-check entirely on underwater equity, missing
         // the same liquidation case the scanMarket path catches.
         const freshMarkPnl = freshAccount.pnl;
-        const equity = freshAccount.capital + freshMarkPnl;
+        // Same fee-debt correction as the scan path (mirror account_equity_maint_raw_wide).
+        const freshFeeDebt = freshAccount.feeCredits < 0n ? -freshAccount.feeCredits : 0n;
+        const equity = freshAccount.capital + freshMarkPnl - freshFeeDebt;
         const marginRatioBps = computeMarginRatioBps(equity, notional);
         if (
           notional > 0n &&


### PR DESCRIPTION
Fixes #223.

`scanMarket` (`src/services/liquidation.ts:369`) and the pre-submit recheck (`:558`) computed `equity = capital + markPnl`, dropping the fee-debt term. The program's maintenance equity is `capital + pnl − fee_debt` (`account_equity_maint_raw_wide`; `fee_debt = -feeCredits` when `feeCredits < 0`). The omission overstated equity for fee-indebted accounts, so the keeper classified genuinely-liquidatable accounts as healthy and never submitted the liquidation — leaving underwater exposure for the insurance fund / ADL to absorb.

This subtracts fee debt at both equity sites, mirroring the program formula. `feeCredits` is already a signed `bigint` on the parsed account, so the change is local and type-safe.

- `tsc --noEmit` passes.
- Happy to add a unit test asserting parity with `account_equity_maint_raw_wide` for a fee-indebted account near the maintenance boundary if you'd like it folded into this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed liquidation equity calculations to properly account for negative fee credits. When accounts have fee debt, margin ratio and liquidation checks now correctly subtract this debt from the equity calculation, ensuring accurate position evaluation during liquidation scans and rechecks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->