### PR TITLE
fix(health): bind health server to loopback by default (closes #224)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -287,6 +287,13 @@ crankService.setOnCrankCycle(() => monitorService.notifyCrankCycle());
 // Health endpoint
 const startupTime = Date.now();
 const healthPort = Number(process.env.KEEPER_HEALTH_PORT ?? 8081);
+// SECURITY: bind the health server to loopback by default (mirrors the metrics
+// server's A.8 fix). /health, /pause-status, and /shadow/report expose wallet
+// balance, HA role, budget circuit-breaker state, stale-oracle markets, and shadow
+// decision data; the legacy 2-arg listen(port, cb) defaulted to 0.0.0.0 (publicly
+// visible on any deploy without a firewall). Operators needing remote access must
+// set KEEPER_HEALTH_BIND_ADDR explicitly (and front it with auth/a proxy).
+const healthBindAddr = process.env.KEEPER_HEALTH_BIND_ADDR ?? "127.0.0.1";
 // L4: reject non-integer or out-of-range port values early so misconfiguration
 // is a startup failure rather than a confusing EACCES/EADDRINUSE at listen time.
 if (!Number.isInteger(healthPort) || healthPort < 1 || healthPort > 65535) {
@@ -830,9 +837,9 @@ async function start() {
   // "starting" until services actually wire up via onPromote.
   await new Promise<void>((resolve, reject) => {
     healthServer.once("error", reject);
-    healthServer.listen(healthPort, () => {
+    healthServer.listen(healthPort, healthBindAddr, () => {
       healthServer.off("error", reject);
-      logger.info("Health endpoint started", { port: healthPort });
+      logger.info("Health endpoint started", { port: healthPort, host: healthBindAddr });
       resolve();
     });
   });


### PR DESCRIPTION
Closes #224.

`healthServer.listen(healthPort, cb)` (`src/index.ts`) had no host argument, so Node bound `0.0.0.0` — while the sibling metrics server was explicitly hardened to `127.0.0.1` (the A.8 fix, `src/lib/metrics-server.ts`). That made the health server's endpoints **remotely reachable** on any deploy without a firewall: `/health` (#219), `/pause-status`, and `/shadow/report` — exposing wallet balance, HA role, budget circuit-breaker state, which markets have stale oracles, and (in shadow mode) the decision/liquidation roadmap.

This binds the health server to `127.0.0.1` by default (mirroring metrics-server's A.8 fix), with `KEEPER_HEALTH_BIND_ADDR` to override for operators who deliberately need remote access behind a proxy/auth. Loopback-binding closes the remote exposure of all three endpoints at once.

`tsc` passes. Per-endpoint auth (`x-shared-secret`) on `/shadow/report` and `/pause-status` is a reasonable defense-in-depth follow-up, but the bind is the core remediation for "remotely exposes."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Health endpoint now binds to localhost by default instead of all network interfaces, reducing potential security exposure. Configure the binding address using the `KEEPER_HEALTH_BIND_ADDR` environment variable if different behavior is needed. Startup logs now display the health endpoint host address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->