### PR TITLE
Fix v17 liquidation dedup by portfolio

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -367,8 +367,10 @@ export class LiquidationService {
   private readonly _debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly _DEBOUNCE_MS = 1_000;
   private _unsubLoader?: () => void;
-  // C1 (post-mainnet-audit): per-cycle dedup keyed on (slabAddress, accountIdx)
-  // — the unique on-chain identifier of a User sub-account in Percolator. The
+  // C1 (post-mainnet-audit): per-cycle dedup keyed on the unique on-chain
+  // liquidation target. Legacy slabs use (slabAddress, accountIdx); v17 markets
+  // use (slabAddress, portfolioPubkey) because assetIndex is not a unique
+  // portfolio identifier and is commonly 0 for single-asset markets. The
   // previous "B4" key was the owner pubkey, which silently dropped liquidations
   // of every additional sub-account belonging to the same owner; with multiple
   // sub-accounts per owner being normal usage on a perp DEX, owner-keyed dedup
@@ -600,7 +602,9 @@ export class LiquidationService {
       scanPriceE6: bigint;
     },
   ): Promise<string | null> {
-    const positionKey = `${candidate.slabAddress}:${candidate.accountIdx}`;
+    const positionKey = candidate.v17PortfolioPubkey
+      ? `${candidate.slabAddress}:v17:${candidate.v17PortfolioPubkey.toBase58()}`
+      : `${candidate.slabAddress}:v12:${candidate.accountIdx}`;
     if (this._cycleSeenPositions.has(positionKey)) {
       logger.debug("Skipping position already targeted this cycle", {
         positionKey,

--- a/tests/v17-liquidation-dedup.poc.test.ts
+++ b/tests/v17-liquidation-dedup.poc.test.ts
@@ -1,0 +1,82 @@
+import { PublicKey } from "@solana/web3.js";
+import { describe, expect, it, vi } from "vitest";
+import { LiquidationService } from "../src/services/liquidation.js";
+
+function pubkey(byte: number): PublicKey {
+  return new PublicKey(new Uint8Array(32).fill(byte));
+}
+
+function makeHarness(): {
+  service: LiquidationService & {
+    gatedLiquidate: (
+      market: unknown,
+      candidate: {
+        slabAddress: string;
+        accountIdx: number;
+        owner: string;
+        v17PortfolioPubkey?: PublicKey;
+        scanPriceE6: bigint;
+      },
+    ) => Promise<string | null>;
+    _cycleSeenPositions: Set<string>;
+    _cycleOwnerCounts: Map<string, number>;
+    liquidate: ReturnType<typeof vi.fn>;
+  };
+} {
+  const service = Object.create(LiquidationService.prototype);
+  service._cycleSeenPositions = new Set<string>();
+  service._cycleOwnerCounts = new Map<string, number>();
+  service.liquidate = vi.fn(async () => `sig-${service.liquidate.mock.calls.length}`);
+  return { service };
+}
+
+describe("PoC: v17 liquidation dedup must key by portfolio pubkey", () => {
+  it("does not suppress a second v17 portfolio with the same single-asset accountIdx", async () => {
+    const { service } = makeHarness();
+    const slabAddress = pubkey(1).toBase58();
+
+    const first = await service.gatedLiquidate({} as never, {
+      slabAddress,
+      accountIdx: 0,
+      owner: pubkey(2).toBase58(),
+      v17PortfolioPubkey: pubkey(10),
+      scanPriceE6: 100_000_000n,
+    });
+
+    const second = await service.gatedLiquidate({} as never, {
+      slabAddress,
+      accountIdx: 0,
+      owner: pubkey(3).toBase58(),
+      v17PortfolioPubkey: pubkey(11),
+      scanPriceE6: 100_000_000n,
+    });
+
+    expect(first).toBe("sig-1");
+    expect(second).toBe("sig-2");
+    expect(service.liquidate).toHaveBeenCalledTimes(2);
+  });
+
+  it("still dedups the same legacy slab slot within one cycle", async () => {
+    const { service } = makeHarness();
+    const slabAddress = pubkey(4).toBase58();
+    const owner = pubkey(5).toBase58();
+
+    const first = await service.gatedLiquidate({} as never, {
+      slabAddress,
+      accountIdx: 42,
+      owner,
+      scanPriceE6: 100_000_000n,
+    });
+
+    const second = await service.gatedLiquidate({} as never, {
+      slabAddress,
+      accountIdx: 42,
+      owner,
+      scanPriceE6: 100_000_000n,
+    });
+
+    expect(first).toBe("sig-1");
+    expect(second).toBeNull();
+    expect(service.liquidate).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #234.

v17 liquidation candidates carry both:

- `accountIdx`: the v17 leg asset index used by the instruction; commonly `0` for single-asset markets.
- `v17PortfolioPubkey`: the actual target portfolio account.

The per-cycle dedup key previously used `(slabAddress, accountIdx)` for all candidates, which suppressed every additional liquidatable v17 portfolio in the same single-asset market after the first one. This PR keys v17 dedup by `(slabAddress, v17PortfolioPubkey)` and keeps the legacy `(slabAddress, accountIdx)` behavior for v12 slabs.

## Tests

```bash
pnpm exec vitest run tests/v17-liquidation-dedup.poc.test.ts
pnpm run build
```

Note: the full `pnpm test` suite currently has unrelated pre-existing `tests/sdk-smoke.test.ts` failures around removed v17 SDK instruction encoders (`encodeLiquidateAtOracle`, `encodeUpdateHyperpMark`).
