### PR TITLE
Fix v17 liquidation risk params parsing

### DIFF
--- a/src/lib/v17-risk.ts
+++ b/src/lib/v17-risk.ts
@@ -1,0 +1,68 @@
+const V17_HEADER_LEN = 16;
+const V17_WRAPPER_CONFIG_LEN = 432;
+const V17_MARKET_GROUP_OFF = V17_HEADER_LEN + V17_WRAPPER_CONFIG_LEN;
+const V17_MARKET_GROUP_ID_LEN = 32;
+const V17_ENGINE_CONFIG_OFF = V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_ID_LEN;
+
+const V17_ENGINE_CONFIG_H_MIN_OFF = 38;
+const V17_ENGINE_CONFIG_H_MAX_OFF = 46;
+const V17_ENGINE_CONFIG_MAINTENANCE_MARGIN_BPS_OFF = 54;
+const V17_ENGINE_CONFIG_LIQUIDATION_FEE_BPS_OFF = 78;
+
+const V17_WRAPPER_MAINTENANCE_FEE_PER_SLOT_OFF = V17_HEADER_LEN + 96;
+
+export const V17_RISK_PARAMS_MIN_DATA_LEN =
+  V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_LIQUIDATION_FEE_BPS_OFF + 8;
+
+function readU64LE(data: Uint8Array, offset: number): bigint {
+  if (offset < 0 || offset + 8 > data.length) {
+    throw new Error(`readU64LE out of bounds at ${offset}`);
+  }
+  let value = 0n;
+  for (let i = 0; i < 8; i++) {
+    value |= BigInt(data[offset + i]!) << (8n * BigInt(i));
+  }
+  return value;
+}
+
+function readU128LE(data: Uint8Array, offset: number): bigint {
+  const lo = readU64LE(data, offset);
+  const hi = readU64LE(data, offset + 8);
+  return lo | (hi << 64n);
+}
+
+export function parseV17RiskParams(data: Uint8Array): {
+  warmupPeriodSlots: bigint;
+  maintenanceMarginBps: bigint;
+  hMin: bigint;
+  hMax: bigint;
+  openInterestCap: bigint;
+  maintenanceFeePerSlot: bigint;
+  liquidationFeeShareBps: bigint;
+  adlFillCapBps: bigint;
+  minPositionSize: bigint;
+} {
+  if (data.length < V17_RISK_PARAMS_MIN_DATA_LEN) {
+    throw new Error(
+      `parseV17RiskParams: data too short — need ${V17_RISK_PARAMS_MIN_DATA_LEN} bytes, got ${data.length}`,
+    );
+  }
+
+  return {
+    warmupPeriodSlots: 0n,
+    maintenanceMarginBps: readU64LE(
+      data,
+      V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_MAINTENANCE_MARGIN_BPS_OFF,
+    ),
+    hMin: readU64LE(data, V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_H_MIN_OFF),
+    hMax: readU64LE(data, V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_H_MAX_OFF),
+    openInterestCap: 0n,
+    maintenanceFeePerSlot: readU128LE(data, V17_WRAPPER_MAINTENANCE_FEE_PER_SLOT_OFF),
+    liquidationFeeShareBps: readU64LE(
+      data,
+      V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_LIQUIDATION_FEE_BPS_OFF,
+    ),
+    adlFillCapBps: 0n,
+    minPositionSize: 0n,
+  };
+}

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -35,6 +35,7 @@ import {
 import type { AccountLoader } from "../lib/account-loader.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
+import { parseV17RiskParams, V17_RISK_PARAMS_MIN_DATA_LEN } from "../lib/v17-risk.js";
 
 const logger = createLogger("keeper:crank");
 
@@ -223,7 +224,7 @@ async function discoverV17Markets(
             },
           },
         ],
-        dataSlice: { offset: 0, length: 512 }, // Enough for header(16) + config(432) + some market group
+        dataSlice: { offset: 0, length: V17_RISK_PARAMS_MIN_DATA_LEN },
       }),
       RPC_TIMEOUT_MS * 2,
       `discoverV17Markets(${programId.toBase58().slice(0, 8)})`,
@@ -246,9 +247,10 @@ async function discoverV17Markets(
       const wrapperCfg = parseWrapperConfigV17(data);
       const marketConfig = wrapperConfigV17ToMarketConfig(wrapperCfg);
 
-      // Stub engine/params/header with zero values — these fields are read from
-      // the market group account's dynamic section (beyond the 512-byte slice).
-      // For crank purposes (oracle resolution, discovery) only config is needed.
+      // Stub engine/header with zero values — these fields are read from
+      // the market group account's dynamic section. Risk params are parsed
+      // from the v17 market-group header below, because liquidation logic
+      // must not assume every market uses the 500 bps default.
       const stubEngine = {
         vault: 0n, insuranceFund: { balance: 0n, feeRevenue: 0n, isolatedBalance: 0n, isolationBps: 0 },
         currentSlot: 0n, fundingIndexQpbE6: 0n, lastFundingSlot: 0n,
@@ -264,12 +266,7 @@ async function discoverV17Markets(
         resolvedKLongTerminalDelta: 0n, resolvedKShortTerminalDelta: 0n, resolvedLivePrice: 0n,
         numUsedAccounts: 0, nextAccountId: 0n,
       };
-      const stubParams = {
-        warmupPeriodSlots: 0n, maintenanceMarginBps: 500n, // 5% maintenance margin default
-        hMin: 0n, hMax: 0n, openInterestCap: 0n,
-        maintenanceFeePerSlot: 0n, liquidationFeeShareBps: 0n,
-        adlFillCapBps: 0n, minPositionSize: 0n,
-      };
+      const v17Params = parseV17RiskParams(data);
       const stubHeader = {
         magic: 0n, version: 16, kind: 1,
         marketCreatedSlot: 0n, resolvedSlot: 0n,
@@ -281,7 +278,7 @@ async function discoverV17Markets(
         header: stubHeader as never,
         config: marketConfig,
         engine: stubEngine as never,
-        params: stubParams as never,
+        params: v17Params as never,
       };
       // Attach raw v17 config for multi-leg HYBRID_AFTER_HOURS oracle tail construction.
       market._rawV17Config = wrapperCfg;
@@ -328,19 +325,14 @@ function parseMarketFromAccountData(
         resolvedKLongTerminalDelta: 0n, resolvedKShortTerminalDelta: 0n, resolvedLivePrice: 0n,
         numUsedAccounts: 0, nextAccountId: 0n,
       };
-      const stubParams = {
-        warmupPeriodSlots: 0n, maintenanceMarginBps: 500n,
-        hMin: 0n, hMax: 0n, openInterestCap: 0n,
-        maintenanceFeePerSlot: 0n, liquidationFeeShareBps: 0n,
-        adlFillCapBps: 0n, minPositionSize: 0n,
-      };
+      const v17Params = parseV17RiskParams(data);
       const stubHeader = { magic: 0n, version: 16, kind: 1, marketCreatedSlot: 0n, resolvedSlot: 0n };
       const market: DiscoveredMarket & { _rawV17Config?: ReturnType<typeof parseWrapperConfigV17> } = {
         slabAddress: pubkey, programId,
         header: stubHeader as never,
         config: marketConfig,
         engine: stubEngine as never,
-        params: stubParams as never,
+        params: v17Params as never,
       };
       market._rawV17Config = wrapperCfg;
       return market;

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -29,6 +29,7 @@ import type { AccountLoader } from "../lib/account-loader.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
 import { AlertAggregator } from "../lib/alert-aggregator.js";
+import { parseV17RiskParams } from "../lib/v17-risk.js";
 
 const logger = createLogger("keeper:liquidation");
 
@@ -419,7 +420,8 @@ export class LiquidationService {
       if (isV17Account(data)) {
         // Resolve price from the v17 config (markEwmaE6 acts as lastEffectivePriceE6)
         const price = market.config.lastEffectivePriceE6 ?? market.config.authorityPriceE6 ?? 0n;
-        const maintenanceMarginBps = market.params.maintenanceMarginBps;
+        const v17Params = parseV17RiskParams(data);
+        const maintenanceMarginBps = v17Params.maintenanceMarginBps;
         const connection = getConnection();
         const v17Candidates = await scanV17Portfolios(
           connection,
@@ -740,7 +742,8 @@ export class LiquidationService {
           // (wasted fee). Mirrors the v12.x recheck below and uses the same fee-debt-aware
           // equity as the scanner (#230). scanPriceE6 is the scan-time price; if it's
           // unavailable (0) we keep the leg-active check + rely on the on-chain program.
-          const reMmBps = market.params.maintenanceMarginBps;
+          const freshMarketData = await fetchSlabWithRetry(slabAddress);
+          const reMmBps = parseV17RiskParams(freshMarketData).maintenanceMarginBps;
           if (scanPriceE6 > 0n && reMmBps > 0n) {
             const feeDebt = pf.feeCredits < 0n ? -pf.feeCredits : 0n;
             const equity = pf.capital + pf.pnl - feeDebt;

--- a/tests/v17-risk-params.poc.test.ts
+++ b/tests/v17-risk-params.poc.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { parseV17RiskParams, V17_RISK_PARAMS_MIN_DATA_LEN } from "../src/lib/v17-risk.js";
+
+const V17_HEADER_LEN = 16;
+const V17_WRAPPER_CONFIG_LEN = 432;
+const V17_MARKET_GROUP_OFF = V17_HEADER_LEN + V17_WRAPPER_CONFIG_LEN;
+const V17_MARKET_GROUP_ID_LEN = 32;
+const V17_ENGINE_CONFIG_OFF = V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_ID_LEN;
+
+function writeU64LE(data: Uint8Array, offset: number, value: bigint): void {
+  for (let i = 0; i < 8; i++) {
+    data[offset + i] = Number((value >> (8n * BigInt(i))) & 0xffn);
+  }
+}
+
+function writeU128LE(data: Uint8Array, offset: number, value: bigint): void {
+  writeU64LE(data, offset, value & ((1n << 64n) - 1n));
+  writeU64LE(data, offset + 8, value >> 64n);
+}
+
+describe("PoC: v17 risk params are parsed from the market-group header", () => {
+  it("proves the previous 512-byte discovery slice cannot include maintenance_margin_bps", () => {
+    expect(() => parseV17RiskParams(new Uint8Array(512))).toThrow(/data too short/i);
+    expect(V17_RISK_PARAMS_MIN_DATA_LEN).toBeGreaterThan(512);
+  });
+
+  it("decodes the actual on-chain maintenance margin instead of assuming 500 bps", () => {
+    const data = new Uint8Array(V17_RISK_PARAMS_MIN_DATA_LEN);
+
+    writeU128LE(data, V17_HEADER_LEN + 96, 7n);
+    writeU64LE(data, V17_ENGINE_CONFIG_OFF + 38, 100n);
+    writeU64LE(data, V17_ENGINE_CONFIG_OFF + 46, 86_400n);
+    writeU64LE(data, V17_ENGINE_CONFIG_OFF + 54, 1_000n);
+    writeU64LE(data, V17_ENGINE_CONFIG_OFF + 78, 75n);
+
+    const params = parseV17RiskParams(data);
+
+    expect(params.maintenanceMarginBps).toBe(1_000n);
+    expect(params.maintenanceMarginBps).not.toBe(500n);
+    expect(params.hMin).toBe(100n);
+    expect(params.hMax).toBe(86_400n);
+    expect(params.maintenanceFeePerSlot).toBe(7n);
+    expect(params.liquidationFeeShareBps).toBe(75n);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #237.

Parses v17 risk params from the market-group header instead of hardcoding `maintenanceMarginBps: 500n`.

Changes:

- adds a small v17 risk-param parser for the market-group header
- increases v17 discovery slice length so it includes the risk bytes
- uses parsed v17 params during discovery and `MARKETS_FILTER` parsing
- reparses fresh v17 risk params in `scanMarket()` and the v17 pre-submit liquidation recheck
- adds a regression proving the old 512-byte slice cannot contain `maintenance_margin_bps`, and that a 1000 bps market decodes as 1000 rather than 500

## Tests

```bash
pnpm run build
pnpm exec vitest run tests/v17-risk-params.poc.test.ts
```
