### PR TITLE
Fix v17 liquidation oracle tails for multi-leg hybrid markets

### DIFF
--- a/src/lib/v17-oracle-tail.ts
+++ b/src/lib/v17-oracle-tail.ts
@@ -1,0 +1,40 @@
+import { PublicKey, type Connection } from "@solana/web3.js";
+import { resolveExternalOracleAccount } from "./oracle-account.js";
+
+export type V17OracleTailMarket = {
+  _rawV17Config?: {
+    oracleMode: number;
+    oracleLegCount: number;
+    oracleLegFeeds: PublicKey[];
+  };
+};
+
+export function getV17OracleTailFeeds(
+  market: V17OracleTailMarket,
+  fallbackOracle: PublicKey,
+): PublicKey[] {
+  const rawCfg = market._rawV17Config;
+  if (rawCfg && rawCfg.oracleMode === 1 && rawCfg.oracleLegCount > 1) {
+    const feeds: PublicKey[] = [];
+    for (let i = 0; i < rawCfg.oracleLegCount; i++) {
+      feeds.push(rawCfg.oracleLegFeeds[i] ?? fallbackOracle);
+    }
+    return feeds;
+  }
+  return [fallbackOracle];
+}
+
+export async function resolveV17OracleTail(
+  market: V17OracleTailMarket,
+  fallbackOracle: PublicKey,
+  connection: Connection,
+): Promise<PublicKey[]> {
+  const feeds = getV17OracleTailFeeds(market, fallbackOracle);
+  return Promise.all(
+    feeds.map((feed) => (
+      feed.equals(fallbackOracle)
+        ? fallbackOracle
+        : resolveExternalOracleAccount(feed, connection)
+    )),
+  );
+}

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -35,6 +35,7 @@ import {
 import type { AccountLoader } from "../lib/account-loader.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
+import { resolveV17OracleTail } from "../lib/v17-oracle-tail.js";
 
 const logger = createLogger("keeper:crank");
 
@@ -1276,25 +1277,13 @@ export class CrankService {
       { pubkey: portfolio,            isSigner: false, isWritable: true  },
     ];
 
-    // For HYBRID_AFTER_HOURS (oracle_mode=1) with multiple oracle legs, derive a Pyth
-    // push-oracle PDA for each leg feed and append them all in order.
-    // oracle_leg_count is available via the raw config; fall back to single oracleKey
-    // for all other modes (MANUAL=0, EWMA_MARK=2, AUTH_MARK=3).
-    const rawCfg = (market as unknown as { _rawV17Config?: ReturnType<typeof parseWrapperConfigV17> })._rawV17Config;
-    if (rawCfg && rawCfg.oracleMode === 1 && rawCfg.oracleLegCount > 1) {
-      for (let i = 0; i < rawCfg.oracleLegCount; i++) {
-        const feed = rawCfg.oracleLegFeeds[i];
-        if (feed) {
-          // #179: resolve each leg feed by on-chain owner too (a Chainlink leg gets the
-          // aggregator account; a Pyth leg gets its push-oracle PDA).
-          const legOracle = await resolveExternalOracleAccount(feed, getConnection());
-          fixed.push({ pubkey: legOracle, isSigner: false, isWritable: false });
-        } else {
-          fixed.push({ pubkey: oracleKey, isSigner: false, isWritable: false });
-        }
-      }
-    } else {
-      fixed.push({ pubkey: oracleKey, isSigner: false, isWritable: false });
+    const oracleTail = await resolveV17OracleTail(
+      market as unknown as Parameters<typeof resolveV17OracleTail>[0],
+      oracleKey,
+      getConnection(),
+    );
+    for (const pubkey of oracleTail) {
+      fixed.push({ pubkey, isSigner: false, isWritable: false });
     }
 
     return fixed;

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -29,6 +29,7 @@ import type { AccountLoader } from "../lib/account-loader.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
 import { AlertAggregator } from "../lib/alert-aggregator.js";
+import { resolveV17OracleTail } from "../lib/v17-oracle-tail.js";
 
 const logger = createLogger("keeper:liquidation");
 
@@ -696,12 +697,18 @@ export class LiquidationService {
       // For v12.x markets, keep the legacy placeholder (slabAddress).
       const portfolioAccount = v17PortfolioPubkey ?? slabAddress;
 
-      // v17 layout: [owner(s,w), market(w), portfolio(w), oracle(r)]
+      const oracleTail = await resolveV17OracleTail(
+        market as unknown as Parameters<typeof resolveV17OracleTail>[0],
+        oracleAccount,
+        connection,
+      );
+
+      // v17 layout: [owner(s,w), market(w), portfolio(w), ...oracleTail(r)]
       const crankKeys: { pubkey: PublicKey; isSigner: boolean; isWritable: boolean }[] = [
         { pubkey: keypair.publicKey, isSigner: true,  isWritable: true  },
         { pubkey: slabAddress,       isSigner: false, isWritable: true  },
         { pubkey: portfolioAccount,  isSigner: false, isWritable: true  },
-        { pubkey: oracleAccount,     isSigner: false, isWritable: false },
+        ...oracleTail.map((pubkey) => ({ pubkey, isSigner: false, isWritable: false })),
       ];
 
       const instructions: TransactionInstruction[] = [

--- a/tests/v17-oracle-tail.poc.test.ts
+++ b/tests/v17-oracle-tail.poc.test.ts
@@ -1,0 +1,47 @@
+import { PublicKey } from "@solana/web3.js";
+import { describe, expect, it } from "vitest";
+import { getV17OracleTailFeeds } from "../src/lib/v17-oracle-tail.js";
+
+function pubkey(byte: number): PublicKey {
+  return new PublicKey(new Uint8Array(32).fill(byte));
+}
+
+describe("PoC: v17 oracle tail construction", () => {
+  it("returns every configured oracle leg for multi-leg hybrid markets", () => {
+    const fallback = pubkey(1);
+    const leg0 = pubkey(2);
+    const leg1 = pubkey(3);
+
+    const feeds = getV17OracleTailFeeds(
+      {
+        _rawV17Config: {
+          oracleMode: 1,
+          oracleLegCount: 2,
+          oracleLegFeeds: [leg0, leg1],
+        },
+      },
+      fallback,
+    );
+
+    expect(feeds.map((feed) => feed.toBase58())).toEqual([
+      leg0.toBase58(),
+      leg1.toBase58(),
+    ]);
+  });
+
+  it("keeps the single fallback oracle for non-hybrid markets", () => {
+    const fallback = pubkey(4);
+    const feeds = getV17OracleTailFeeds(
+      {
+        _rawV17Config: {
+          oracleMode: 2,
+          oracleLegCount: 2,
+          oracleLegFeeds: [pubkey(5), pubkey(6)],
+        },
+      },
+      fallback,
+    );
+
+    expect(feeds.map((feed) => feed.toBase58())).toEqual([fallback.toBase58()]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #239.

Moves v17 oracle-tail selection into a shared helper and uses it from both:

- regular `PermissionlessCrank` construction in `CrankService`
- v17 liquidation instruction construction in `LiquidationService`

For `HYBRID_AFTER_HOURS` / hybrid multi-leg markets, liquidation now appends every configured oracle leg in order instead of always passing a single oracle account.

## Tests

```bash
pnpm run build
pnpm exec vitest run tests/v17-oracle-tail.poc.test.ts
```
