### PR TITLE
fix(keeper): request 128KB heap frame on all wrapper txs (v17 cutover)

### DIFF
--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { ComputeBudgetProgram } from "@solana/web3.js";
 import type { Connection, TransactionInstruction, Keypair } from "@solana/web3.js";
 import { sendWithRetryKeeper, createLogger, sendCriticalAlert } from "@percolatorct/shared";
 import type { KeeperSendOptions } from "@percolatorct/shared";
@@ -191,6 +192,19 @@ export async function keeperSend(
     logger.warn("keeperSend: not leader — skipping send", { txType });
     return null;
   }
+
+  // v17 cutover (issue #176): the wrapper program installs a custom 128KB heap
+  // allocator and aborts ("Access violation in heap section") on its first heap
+  // allocation unless the transaction requests the matching heap frame. Every
+  // keeper send path (crank InitUser/CrankLpVaultFees/RestartAssetOracle/
+  // PermissionlessCrank + liquidation Liquidate) carries a wrapper instruction,
+  // so prepend the request here as the FIRST instruction. 131072 = 128*1024 ==
+  // the program's V16_HEAP_FRAME_BYTES. The CU limit is left to estimateCost /
+  // simulatedCu, so no setComputeUnitLimit is added here.
+  instructions = [
+    ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }),
+    ...instructions,
+  ];
 
   const { estimatedCost, simulatedCu } = await estimateCost(connection, instructions, signers, txType);
 


### PR DESCRIPTION
## v17 deploy blocker fix (client-side) — issue #176

The v17 wrapper program installs a custom **128KB** `BumpAllocator` (`V16_HEAP_FRAME_BYTES`) that bumps *down* from `heap_base+128KB`. The entrypoint's `deserialize()` makes the first heap allocation on **every** instruction, so any tx to the wrapper **aborts** ("Access violation in heap section") under Solana's default 32KB heap — unless the tx includes `ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 })`.

No client requested one. This PR adds it to every wrapper-transaction send site in this repo. Single central edit in `keeperSend` prepends the heap frame to every keeper tx (crank InitUser/CrankLpVaultFees/RestartAssetOracle/PermissionlessCrank + liquidation Liquidate). Runs before `estimateCost` so CU simulation stays accurate.

**Verification:** `pnpm exec tsc --noEmit` PASS; verified no ad-hoc send path bypasses keeperSend.

⚠️ **DO NOT MERGE until the v17 cutover is human-gated** — this repo deploys to prod on merge. Draft until then. The change is forward-compatible (harmless on the current program; required for v17).

Refs dcccrypto/percolator-stake#176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)