### PR TITLE
fix: retry v17 keeper portfolio on LaserStream fast path

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -921,6 +921,22 @@ export class CrankService {
               // Ignore parse errors — market state stays at last known good.
             }
           }
+
+          // v17 markets need a keeper-owned portfolio before PermissionlessCrank
+          // can run. Normal rediscovery retries this when keeperPortfolio is
+          // still null; keep the LaserStream fast path consistent so a transient
+          // provisioning failure does not leave an already-known market
+          // discovered-but-uncrankable until the next full rediscovery.
+          const header = state.market.header as
+            | { version?: number | bigint; kind?: number | bigint }
+            | undefined;
+          const isV17Market =
+            Boolean((state.market as DiscoveredMarket & { _rawV17Config?: unknown })._rawV17Config) ||
+            (header !== undefined && Number(header.version) === 16 && Number(header.kind) === 1);
+
+          if (isV17Market && !state.keeperPortfolio) {
+            this.ensureKeeperPortfolio(key, state.market);
+          }
         }
         this.lastDiscoveryTime = now;
         logger.debug("LaserStream fast-path discover complete", {

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -158,6 +158,109 @@ describe('CrankService', () => {
       expect(crankService.getMarkets().size).toBe(1);
     });
 
+    it('LaserStream fast-path retries v17 keeper portfolio provisioning when keeperPortfolio is null', async () => {
+      const prevLaserStream = process.env.KEEPER_USE_LASERSTREAM;
+      process.env.KEEPER_USE_LASERSTREAM = 'true';
+
+      try {
+        const slabAddress = new PublicKey('11111111111111111111111111111111');
+
+        const mockCache = {
+          getOwnerVerified: vi.fn(() => null),
+        };
+
+        const mockAccountLoader = {
+          getCache: vi.fn(() => mockCache),
+          getStats: vi.fn(() => ({ lastSlot: 123 })),
+          getProgramId: vi.fn(() => new PublicKey('11111111111111111111111111111111')),
+        };
+
+        const service = new CrankService(mockOracleService, undefined, mockAccountLoader as any);
+
+        const mockMarket = {
+          slabAddress,
+          programId: new PublicKey('11111111111111111111111111111111'),
+          config: {
+            collateralMint: new PublicKey('11111111111111111111111111111111'),
+            oracleAuthority: PublicKey.default,
+            indexFeedId: { toBytes: () => new Uint8Array(32) },
+          },
+          params: { maintenanceMarginBps: 500n },
+          header: { admin: PublicKey.default, version: 16, kind: 1 },
+          _rawV17Config: {},
+        };
+
+        const legacySlabAddress = new PublicKey('So11111111111111111111111111111111111111112');
+        const legacyMarket = {
+          ...mockMarket,
+          slabAddress: legacySlabAddress,
+          header: { admin: PublicKey.default, version: 12, kind: 0 },
+          _rawV17Config: undefined,
+        };
+
+        // Simulate a v17 market already discovered earlier, but portfolio provisioning failed.
+        // In this state, crankMarket() skips because keeperPortfolio is still null.
+        (service as any).markets.set(slabAddress.toBase58(), {
+          market: mockMarket,
+          lastCrankTime: 0,
+          successCount: 0,
+          failureCount: 0,
+          consecutiveFailures: 0,
+          isActive: true,
+          missingDiscoveryCount: 0,
+          keeperPortfolio: null,
+        });
+
+        // Also include a legacy/non-v17 market with keeperPortfolio null.
+        // The fast-path retry must not attempt v17 portfolio provisioning for it.
+        (service as any).markets.set(legacySlabAddress.toBase58(), {
+          market: legacyMarket,
+          lastCrankTime: 0,
+          successCount: 0,
+          failureCount: 0,
+          consecutiveFailures: 0,
+          isActive: true,
+          missingDiscoveryCount: 0,
+          keeperPortfolio: null,
+        });
+
+        // Keep discover() inside the LaserStream fast-path instead of full rediscovery.
+        (service as any)._lastFullRediscoverTime = Date.now();
+
+        const getProgramAccounts = vi.fn().mockResolvedValue([]);
+        const getMinimumBalanceForRentExemption = vi.fn().mockResolvedValue(1);
+
+        vi.mocked(shared.getConnection).mockClear();
+        vi.mocked(shared.getConnection).mockReturnValueOnce({
+          getAccountInfo: vi.fn(),
+          getSlot: vi.fn().mockResolvedValue(200),
+          getProgramAccounts,
+          getMinimumBalanceForRentExemption,
+        } as any);
+
+        await service.discover();
+
+        // The fast-path should retry the v17 portfolio provisioning path only once:
+        // for the v17 market with keeperPortfolio=null, not for the legacy market.
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(shared.getConnection).toHaveBeenCalledTimes(1);
+        expect(getProgramAccounts).toHaveBeenCalledTimes(1);
+        expect(getProgramAccounts.mock.calls[0]?.[0]).toBe(mockMarket.programId);
+        expect(getProgramAccounts.mock.calls[0]?.[1]?.filters).toContainEqual({ dataSize: 9347 });
+
+        service.stop();
+      } finally {
+        if (prevLaserStream === undefined) {
+          delete process.env.KEEPER_USE_LASERSTREAM;
+        } else {
+          process.env.KEEPER_USE_LASERSTREAM = prevLaserStream;
+        }
+      }
+    });
+
     it('should handle discovery errors per program without crashing', async () => {
       vi.mocked(core.discoverMarkets)
         .mockRejectedValueOnce(new Error('Program 1 failed'))


### PR DESCRIPTION
## Summary

Fixes #253.

This PR makes the LaserStream fast-path discovery retry v17 keeper portfolio provisioning for already-discovered markets whose `keeperPortfolio` is still `null`.

Without this retry, a transient provisioning failure could leave a v17 market present in memory but uncrankable until the next full rediscovery, because the v17 crank path skips markets without a keeper portfolio.

## Why

The normal rediscovery path already retries keeper portfolio provisioning when `keeperPortfolio` is still missing.

The LaserStream fast-path returns existing in-memory markets before the normal rediscovery branch runs. It refreshes cached account data, but previously did not retry `ensureKeeperPortfolio()` for markets whose keeper portfolio was still missing.

This keeps the LaserStream fast-path consistent with the normal rediscovery behavior.

## Changes

* Retry `ensureKeeperPortfolio()` inside the LaserStream fast-path when `state.keeperPortfolio` is still `null`.
* Keep the existing owner-verified cache refresh logic unchanged.
* Add a regression test covering an already-discovered v17 market with `keeperPortfolio: null` while `KEEPER_USE_LASERSTREAM=true`.

## How to test

1. Run the targeted regression test:

```bash
pnpm exec vitest run tests/services/crank.test.ts -t "LaserStream fast-path retries"
```

2. Run the full crank service test file:

```bash
pnpm exec vitest run tests/services/crank.test.ts
```

3. Run the full test suite:

```bash
pnpm test
```

## Checklist

* [x] Linked issue included: Fixes #253
* [x] Regression test added
* [x] Targeted regression test passes
* [x] `tests/services/crank.test.ts` passes
* [x] Full test suite passes
* [x] No unrelated files changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keeper portfolio provisioning reliability by ensuring proper initialization during accelerated market discovery operations.

* **Tests**
  * Added test coverage for keeper portfolio provisioning edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->