### PR TITLE
fix: refresh v17 liquidation scan price

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -12,6 +12,7 @@ import {
   CrankAction,
   // v17 portfolio scanning (DESYNC-3 / DESYNC-4 fixes)
   isV17Account,
+  parseWrapperConfigV17,
   parsePortfolioV17,
   type DiscoveredMarket,
 } from "@percolatorct/sdk";
@@ -318,6 +319,26 @@ function resolveMarketPrice(
   return { price: cfg.lastEffectivePriceE6, stale: true };
 }
 
+function resolveV17ScanPrice(
+  cfg: ReturnType<typeof parseWrapperConfigV17>,
+  nowSec: bigint,
+): bigint {
+  // Program enum (v16_program.rs): MANUAL=0, HYBRID_AFTER_HOURS=1,
+  // EWMA_MARK=2, AUTH_MARK=3. AUTH_MARK is the only v17 mode whose fresh
+  // authority target should beat the EWMA fallback during liquidation scans.
+  if (cfg.oracleMode === 3) {
+    const maxStalenessSecs = cfg.maxStalenessSecs > 0n ? cfg.maxStalenessSecs : 60n;
+    const priceAge = cfg.oracleTargetPublishTime > 0n
+      ? nowSec - cfg.oracleTargetPublishTime
+      : nowSec;
+    if (cfg.oracleTargetPriceE6 > 0n && priceAge <= maxStalenessSecs) {
+      return cfg.oracleTargetPriceE6;
+    }
+  }
+
+  return cfg.markEwmaE6;
+}
+
 interface LiquidationCandidate {
   slabAddress: string;
   accountIdx: number;
@@ -421,11 +442,12 @@ export class LiquidationService {
 
       // DESYNC-3 FIX: Route v17 accounts through the portfolio-based scanner.
       if (isV17Account(data)) {
-        // Resolve price from the v17 config (markEwmaE6 acts as lastEffectivePriceE6)
-        const price = market.config.lastEffectivePriceE6 ?? market.config.authorityPriceE6 ?? 0n;
+        const connection = getConnection();
+        const nowSec = await fetchClusterUnixTimeSec(connection);
+        const wrapperCfg = parseWrapperConfigV17(data);
+        const price = resolveV17ScanPrice(wrapperCfg, nowSec);
         const v17Params = parseV17RiskParams(data);
         const maintenanceMarginBps = v17Params.maintenanceMarginBps;
-        const connection = getConnection();
         const v17Candidates = await scanV17Portfolios(
           connection,
           market.programId,

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -54,6 +54,7 @@ vi.mock('@percolatorct/sdk', () => ({
   IX_TAG: { TradeNoCpi: 1, TradeCpi: 2 },
   // v17 additions — default false so legacy-path tests continue to work.
   isV17Account: vi.fn(() => false),
+  parseWrapperConfigV17: vi.fn(),
   parsePortfolioV17: vi.fn(),
 }));
 
@@ -127,6 +128,20 @@ vi.mock('../../src/lib/keeper-send.js', async () => {
     sharedBudget: new KeeperBudget(),
   };
 });
+
+vi.mock('../../src/lib/v17-risk.js', () => ({
+  parseV17RiskParams: vi.fn(() => ({
+    warmupPeriodSlots: 0n,
+    maintenanceMarginBps: 500n,
+    hMin: 0n,
+    hMax: 0n,
+    openInterestCap: 0n,
+    maintenanceFeePerSlot: 0n,
+    liquidationFeeShareBps: 0n,
+    adlFillCapBps: 0n,
+    minPositionSize: 0n,
+  })),
+}));
 
 import { PublicKey, ComputeBudgetProgram } from '@solana/web3.js';
 import { LiquidationService } from '../../src/services/liquidation.js';
@@ -393,6 +408,75 @@ describe('LiquidationService', () => {
       const candidates = await liquidationService.scanMarket(mockMarket as any);
 
       expect(candidates).toHaveLength(0); // Skipped due to stale price and no fallback
+    });
+
+    it('uses the fresh v17 AUTH_MARK price instead of cached zero market.config price', async () => {
+      const nowSec = BigInt(Math.floor(Date.now() / 1000));
+      const clockData = Buffer.alloc(40);
+      clockData.writeBigInt64LE(nowSec, 32);
+      const portfolioPubkey = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+      const owner = new PublicKey('So11111111111111111111111111111111111111112');
+      const connection = {
+        getAccountInfo: vi.fn(async () => ({ data: clockData })),
+        getProgramAccounts: vi.fn(async () => [
+          { pubkey: portfolioPubkey, account: { data: new Uint8Array([1, 2, 3]) } },
+        ]),
+      };
+
+      vi.mocked(shared.getConnection)
+        .mockReturnValueOnce(connection as any)
+        .mockReturnValueOnce(connection as any);
+      vi.mocked(core.fetchSlab).mockResolvedValueOnce(new Uint8Array(512));
+      vi.mocked(core.isV17Account).mockReturnValueOnce(true);
+      vi.mocked(core.parseWrapperConfigV17).mockReturnValueOnce({
+        oracleMode: 3, // AUTH_MARK
+        maxStalenessSecs: 60n,
+        oracleTargetPriceE6: 2_000_000n,
+        oracleTargetPublishTime: nowSec,
+        markEwmaE6: 0n,
+      } as any);
+      vi.mocked(core.parsePortfolioV17).mockReturnValueOnce({
+        owner,
+        capital: 1_000_000n,
+        pnl: 0n,
+        feeCredits: 0n,
+        legs: [
+          {
+            active: true,
+            basisPosQ: 100_000_000_000n,
+            assetIndex: 0,
+          },
+        ],
+      } as any);
+
+      const mockMarket = {
+        slabAddress: new PublicKey('11111111111111111111111111111111'),
+        programId: new PublicKey('11111111111111111111111111111111'),
+        config: {
+          collateralMint: owner,
+          oracleAuthority: mockNonZeroKey(),
+          indexFeedId: mockZeroKey(),
+          // Regression guard: cached discovery-time price is unusable, but the
+          // freshly fetched v17 wrapper has a valid AUTH_MARK target above.
+          lastEffectivePriceE6: 0n,
+          authorityPriceE6: 0n,
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: mockZeroKey() },
+      };
+
+      const candidates = await liquidationService.scanMarket(mockMarket as any);
+
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]!.scanPriceE6).toBe(2_000_000n);
+      expect(connection.getProgramAccounts).toHaveBeenCalledWith(
+        mockMarket.programId,
+        expect.objectContaining({
+          filters: expect.arrayContaining([
+            expect.objectContaining({ dataSize: 9347 }),
+          ]),
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #257.

`scanMarket()` now derives the v17 liquidation scan price from the freshly fetched wrapper account data instead of stale discovery-time `market.config`. For AUTH_MARK v17 markets it uses a fresh `oracleTargetPriceE6` when the wrapper timestamp is within staleness bounds, otherwise it falls back to the EWMA mark.

## Proof / Tests

Added a regression test proving that a cached zero `market.config.lastEffectivePriceE6` no longer suppresses a fresh v17 AUTH_MARK authority price.

```bash
pnpm exec vitest run tests/services/liquidation.test.ts
pnpm exec tsc --noEmit
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated liquidation pricing for v17 accounts to fetch fresh oracle prices at scan time with a 60-second freshness check, automatically falling back to alternative pricing when oracle data is stale.

* **Tests**
  * Added test coverage for v17 oracle pricing behavior in liquidation scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->