### PR TITLE
fix: reject tx queue tasks cleared on demotion

### DIFF
--- a/src/lib/tx-queue.ts
+++ b/src/lib/tx-queue.ts
@@ -73,6 +73,7 @@ export class TxQueue {
   private readonly _lanes: Record<TxLane, PQueue>;
   private readonly _completed: Record<TxLane, number>;
   private readonly _failed: Record<TxLane, number>;
+  private readonly _queuedRejectors: Record<TxLane, Set<(reason: Error) => void>>;
 
   constructor(config: TxQueueConfig = {}) {
     const liqCfg = {
@@ -99,6 +100,11 @@ export class TxQueue {
 
     this._completed = { liquidation: 0, oracle: 0, crank: 0 };
     this._failed = { liquidation: 0, oracle: 0, crank: 0 };
+    this._queuedRejectors = {
+      liquidation: new Set(),
+      oracle: new Set(),
+      crank: new Set(),
+    };
 
     for (const lane of ALL_LANES) {
       const q = this._lanes[lane];
@@ -120,25 +126,53 @@ export class TxQueue {
     const enqueuedAt = Date.now();
     const q = this._lanes[lane];
 
-    return q.add(async (): Promise<T> => {
-      const waitMs = Date.now() - enqueuedAt;
-      txQueueWaitSeconds.observe({ lane }, waitMs / 1000);
-      txQueueActive.set({ lane }, q.pending);
+    return new Promise<T>((resolve, reject) => {
+      let started = false;
+      let settled = false;
+      const rejectQueued = (reason: Error): void => {
+        if (started || settled) return;
+        settled = true;
+        reject(reason);
+      };
+      this._queuedRejectors[lane].add(rejectQueued);
 
-      try {
-        const result = await fn();
-        this._completed[lane]++;
-        txQueueCompletedTotal.inc({ lane });
-        return result;
-      } catch (err) {
-        this._failed[lane]++;
-        txQueueFailedTotal.inc({ lane });
-        throw err;
-      } finally {
+      const queued = q.add(async (): Promise<T> => {
+        started = true;
+        this._queuedRejectors[lane].delete(rejectQueued);
+        const waitMs = Date.now() - enqueuedAt;
+        txQueueWaitSeconds.observe({ lane }, waitMs / 1000);
         txQueueActive.set({ lane }, q.pending);
-        txQueuePending.set({ lane }, q.size);
-      }
-    }) as Promise<T>;
+
+        try {
+          const result = await fn();
+          this._completed[lane]++;
+          txQueueCompletedTotal.inc({ lane });
+          return result;
+        } catch (err) {
+          this._failed[lane]++;
+          txQueueFailedTotal.inc({ lane });
+          throw err;
+        } finally {
+          txQueueActive.set({ lane }, q.pending);
+          txQueuePending.set({ lane }, q.size);
+        }
+      }) as Promise<T>;
+
+      queued.then(
+        (value) => {
+          if (settled) return;
+          settled = true;
+          this._queuedRejectors[lane].delete(rejectQueued);
+          resolve(value);
+        },
+        (err: unknown) => {
+          if (settled) return;
+          settled = true;
+          this._queuedRejectors[lane].delete(rejectQueued);
+          reject(err);
+        },
+      );
+    });
   }
 
   async drain(timeoutMs: number): Promise<void> {
@@ -176,8 +210,14 @@ export class TxQueue {
    * backlog of sends it queued while still leader.
    */
   clearPending(): void {
+    const err = new Error("TxQueue task cleared before dispatch");
     for (const lane of ALL_LANES) {
       this._lanes[lane].clear();
+      for (const rejectQueued of this._queuedRejectors[lane]) {
+        rejectQueued(err);
+      }
+      this._queuedRejectors[lane].clear();
+      txQueuePending.set({ lane }, 0);
     }
     logger.info("TxQueue: cleared all pending tasks from every lane (post-demote)");
   }

--- a/tests/lib/tx-queue-clear-pending.test.ts
+++ b/tests/lib/tx-queue-clear-pending.test.ts
@@ -23,11 +23,10 @@ describe("TxQueue.clearPending", () => {
     const ran: string[] = [];
     // First task blocks until we release it — keeps the single slot busy.
     const p1 = q.enqueue("liquidation", async () => { ran.push("first"); await block; });
-    // These queue behind it and must be dropped by clearPending(). Their promises
-    // never settle once cleared (p-queue drops them), so we don't await them.
-    for (const id of ["a", "b", "c"]) {
-      void q.enqueue("liquidation", async () => { ran.push(id); }).catch(() => {});
-    }
+    // These queue behind it and must be dropped by clearPending().
+    const dropped = ["a", "b", "c"].map((id) =>
+      q.enqueue("liquidation", async () => { ran.push(id); }),
+    );
 
     // Let the first task start (occupy the slot) so a,b,c are pending.
     await Promise.resolve();
@@ -35,6 +34,8 @@ describe("TxQueue.clearPending", () => {
     expect(q.getStats().liquidation.pending).toBeGreaterThan(0);
 
     q.clearPending();
+
+    await expect(Promise.all(dropped)).rejects.toThrow("TxQueue task cleared before dispatch");
 
     // Release the in-flight task and give the loop a few ticks — a,b,c must not run.
     releaseFirst();


### PR DESCRIPTION
## Summary

Fixes #259.

`TxQueue.enqueue()` now wraps queued jobs so `clearPending()` can reject tasks that have not started yet. In-flight tasks are untouched and still complete normally. This prevents HA demotion from orphaning promises awaited by crank/liquidation/provisioning flows.

## Proof / Tests

The clear-pending regression now asserts that dropped queued jobs reject promptly while their functions never run.

```bash
pnpm exec vitest run tests/lib/tx-queue-clear-pending.test.ts tests/lib/tx-queue.test.ts tests/lib/tx-queue.property.test.ts
pnpm exec tsc --noEmit
```