### PR TITLE
fix: wire LaserStream loader in keeper entrypoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { sharedTxQueue, DRAIN_TIMEOUT_MS } from "./lib/tx-queue.js";
 import { sharedBudget, setLeaderCheck } from "./lib/keeper-send.js";
 import { initSharedShadowHarness, sharedShadowHarness } from "./lib/shadow-harness.js";
 import { sharedDecisionLog } from "./lib/decision-log.js";
+import { createLaserStreamAccountLoader } from "./lib/laserstream-entrypoint.js";
 
 // Monitoring — alerts to Discord on threshold breaches
 export const monitors = createServiceMonitors("Keeper");
@@ -88,8 +89,15 @@ if (isMainnet()) {
 logger.info("Keeper service starting");
 
 const oracleService = new OracleService();
-const crankService = new CrankService(oracleService);
-const liquidationService = new LiquidationService(oracleService);
+const accountLoader = createLaserStreamAccountLoader({
+  env: process.env,
+  programId: config.programId,
+  getConnection,
+  logger,
+  sendWarningAlert,
+});
+const crankService = new CrankService(oracleService, undefined, accountLoader ?? undefined);
+const liquidationService = new LiquidationService(oracleService, undefined, accountLoader ?? undefined);
 const monitorService = new MonitorService();
 const fraudDetector = new FraudDetectorService(oracleService, () => crankService.getMarkets());
 
@@ -746,6 +754,10 @@ async function start() {
   activeMarketsCount.set(markets.length);
 
   async function startAllServices(): Promise<void> {
+    if (accountLoader) {
+      await accountLoader.start();
+      logger.info("LaserStream account loader started");
+    }
     await crankService.start();
     logger.info("Crank service started");
     liquidationService.start(() => crankService.getMarkets());
@@ -758,7 +770,7 @@ async function start() {
     // ADL service removed in v17.
   }
 
-  function stopAllServices(): void {
+  async function stopAllServices(): Promise<void> {
     // ADL service removed in v17.
     crankService.stop();
     logger.info("Crank service stopped (HA demote)");
@@ -768,6 +780,10 @@ async function start() {
     logger.info("MonitorService stopped (HA demote)");
     fraudDetector.stop();
     logger.info("FraudDetectorService stopped (HA demote)");
+    if (accountLoader) {
+      await accountLoader.stop();
+      logger.info("LaserStream account loader stopped (HA demote)");
+    }
   }
 
   if (leaderLock) {
@@ -790,7 +806,7 @@ async function start() {
         // so the keeperSend single-writer guard is already closed. Drop any queued
         // sends so this node runs no backlog after losing leadership.
         sharedTxQueue.clearPending();
-        stopAllServices();
+        void stopAllServices();
       },
     });
     logger.info("HA leader election active", { network, haEnabled: true });
@@ -941,7 +957,12 @@ async function shutdown(signal: string): Promise<void> {
     // Stop liquidation service (clears timers)
     logger.info("Stopping liquidation service");
     liquidationService.stop();
-    
+
+    if (accountLoader) {
+      logger.info("Stopping LaserStream account loader");
+      await accountLoader.stop();
+    }
+
     // Note: Solana connection doesn't need explicit cleanup
     // Oracle service has no persistent state to clean up
     

--- a/src/lib/laserstream-entrypoint.ts
+++ b/src/lib/laserstream-entrypoint.ts
@@ -1,0 +1,77 @@
+import type { Connection } from "@solana/web3.js";
+import { AccountLoader, type AccountLoaderOptions } from "./account-loader.js";
+
+type Logger = {
+  warn(message: string, meta?: Record<string, unknown>): void;
+};
+
+type WarningAlert = (
+  title: string,
+  fields: Array<{ name: string; value: string; inline?: boolean }>,
+) => Promise<unknown>;
+
+type AccountLoaderCtor = new (opts: AccountLoaderOptions) => AccountLoader;
+
+export interface CreateLaserStreamAccountLoaderParams {
+  env?: NodeJS.ProcessEnv;
+  programId: string;
+  getConnection: () => Connection;
+  logger?: Logger;
+  sendWarningAlert?: WarningAlert;
+  Loader?: AccountLoaderCtor;
+}
+
+export function laserStreamEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.KEEPER_USE_LASERSTREAM === "true";
+}
+
+export function parseLaserStreamAdditionalAccounts(raw: string | undefined): string[] {
+  return (raw ?? "")
+    .split(/[\s,]+/)
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+}
+
+export function createLaserStreamAccountLoader(
+  params: CreateLaserStreamAccountLoaderParams,
+): AccountLoader | null {
+  const env = params.env ?? process.env;
+  if (!laserStreamEnabled(env)) return null;
+
+  const apiKey = env.HELIUS_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("KEEPER_USE_LASERSTREAM=true requires HELIUS_API_KEY");
+  }
+
+  const endpoint = env.HELIUS_LASERSTREAM_ENDPOINT?.trim();
+  if (!endpoint) {
+    throw new Error("KEEPER_USE_LASERSTREAM=true requires HELIUS_LASERSTREAM_ENDPOINT");
+  }
+
+  const programId = params.programId.trim();
+  if (!programId) {
+    throw new Error("KEEPER_USE_LASERSTREAM=true requires a configured programId");
+  }
+
+  const connection = params.getConnection();
+  const additionalAccounts = parseLaserStreamAdditionalAccounts(
+    env.KEEPER_LASERSTREAM_ADDITIONAL_ACCOUNTS ?? env.KEEPER_LASERSTREAM_ACCOUNTS,
+  );
+
+  const Loader = params.Loader ?? AccountLoader;
+  return new Loader({
+    apiKey,
+    endpoint,
+    programId,
+    additionalAccounts,
+    connection,
+    getRpcSlot: () => connection.getSlot("confirmed"),
+    onDriftAlert: (drift) => {
+      params.logger?.warn("LaserStream slot drift exceeds threshold", { drift });
+      void params.sendWarningAlert?.("LaserStream stream lagging RPC", [
+        { name: "Slot Drift", value: drift.toString(), inline: true },
+        { name: "Program", value: programId, inline: false },
+      ]).catch(() => {});
+    },
+  });
+}

--- a/tests/poc/laserstream-entrypoint.poc.test.ts
+++ b/tests/poc/laserstream-entrypoint.poc.test.ts
@@ -1,0 +1,124 @@
+/**
+ * PoC — KEEPER_USE_LASERSTREAM=true did not activate LaserStream in production.
+ *
+ * Before the fix, CrankService and LiquidationService had AccountLoader-aware
+ * fast paths, but src/index.ts still constructed both services without an
+ * AccountLoader and never started one. Setting KEEPER_USE_LASERSTREAM=true in
+ * production therefore left the event-driven cache and liquidation trigger dead.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createLaserStreamAccountLoader,
+  laserStreamEnabled,
+  parseLaserStreamAdditionalAccounts,
+} from "../../src/lib/laserstream-entrypoint.js";
+
+class FakeLoader {
+  static lastOpts: unknown;
+  constructor(opts: unknown) {
+    FakeLoader.lastOpts = opts;
+  }
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+}
+
+describe("LaserStream production entrypoint wiring", () => {
+  it("PoC: index.ts injects and starts the AccountLoader when LaserStream is enabled", () => {
+    const source = readFileSync(resolve(__dirname, "../../src/index.ts"), "utf8");
+
+    expect(source).toContain("createLaserStreamAccountLoader");
+    expect(source).toMatch(/new CrankService\(oracleService,\s*undefined,\s*accountLoader \?\? undefined\)/);
+    expect(source).toMatch(/new LiquidationService\(oracleService,\s*undefined,\s*accountLoader \?\? undefined\)/);
+    expect(source).toContain("await accountLoader.start()");
+    expect(source).toContain("await accountLoader.stop()");
+  });
+
+  it("does not construct a loader unless KEEPER_USE_LASERSTREAM is explicitly true", () => {
+    const getConnection = vi.fn();
+    const loader = createLaserStreamAccountLoader({
+      env: { KEEPER_USE_LASERSTREAM: "false" },
+      programId: "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv",
+      getConnection,
+      Loader: FakeLoader as never,
+    });
+
+    expect(loader).toBeNull();
+    expect(getConnection).not.toHaveBeenCalled();
+  });
+
+  it("fails closed at boot when the feature flag is set without LaserStream credentials", () => {
+    expect(() =>
+      createLaserStreamAccountLoader({
+        env: { KEEPER_USE_LASERSTREAM: "true" },
+        programId: "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv",
+        getConnection: vi.fn(),
+        Loader: FakeLoader as never,
+      }),
+    ).toThrow(/HELIUS_API_KEY/);
+
+    expect(() =>
+      createLaserStreamAccountLoader({
+        env: { KEEPER_USE_LASERSTREAM: "true", HELIUS_API_KEY: "key" },
+        programId: "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv",
+        getConnection: vi.fn(),
+        Loader: FakeLoader as never,
+      }),
+    ).toThrow(/HELIUS_LASERSTREAM_ENDPOINT/);
+  });
+
+  it("builds AccountLoader options from production env and wires drift alerts", async () => {
+    const warn = vi.fn();
+    const sendWarningAlert = vi.fn(async () => {});
+    const connection = { getSlot: vi.fn(async () => 4242) };
+
+    const loader = createLaserStreamAccountLoader({
+      env: {
+        KEEPER_USE_LASERSTREAM: "true",
+        HELIUS_API_KEY: " helius-key ",
+        HELIUS_LASERSTREAM_ENDPOINT: " https://laserstream.example ",
+        KEEPER_LASERSTREAM_ADDITIONAL_ACCOUNTS: "So11111111111111111111111111111111111111112, EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      },
+      programId: "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv",
+      getConnection: () => connection as never,
+      logger: { warn },
+      sendWarningAlert,
+      Loader: FakeLoader as never,
+    });
+
+    expect(loader).toBeInstanceOf(FakeLoader);
+    const opts = FakeLoader.lastOpts as {
+      apiKey: string;
+      endpoint: string;
+      programId: string;
+      additionalAccounts: string[];
+      connection: typeof connection;
+      getRpcSlot: () => Promise<number>;
+      onDriftAlert: (drift: number) => void;
+    };
+
+    expect(opts.apiKey).toBe("helius-key");
+    expect(opts.endpoint).toBe("https://laserstream.example");
+    expect(opts.programId).toBe("ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv");
+    expect(opts.additionalAccounts).toEqual([
+      "So11111111111111111111111111111111111111112",
+      "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    ]);
+    expect(opts.connection).toBe(connection);
+    await expect(opts.getRpcSlot()).resolves.toBe(4242);
+
+    opts.onDriftAlert(77);
+    expect(warn).toHaveBeenCalledWith("LaserStream slot drift exceeds threshold", { drift: 77 });
+    expect(sendWarningAlert).toHaveBeenCalledWith(
+      "LaserStream stream lagging RPC",
+      expect.arrayContaining([{ name: "Slot Drift", value: "77", inline: true }]),
+    );
+  });
+
+  it("parses feature flag and additional-account env shape", () => {
+    expect(laserStreamEnabled({ KEEPER_USE_LASERSTREAM: "true" })).toBe(true);
+    expect(laserStreamEnabled({ KEEPER_USE_LASERSTREAM: "TRUE" })).toBe(false);
+    expect(parseLaserStreamAdditionalAccounts(" a,b   c\n\td ")).toEqual(["a", "b", "c", "d"]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #261.

This wires the existing LaserStream `AccountLoader` into the production keeper entrypoint:

- creates the loader when `KEEPER_USE_LASERSTREAM=true`
- fails boot if LaserStream is enabled without `HELIUS_API_KEY` / `HELIUS_LASERSTREAM_ENDPOINT`
- injects the loader into `CrankService` and `LiquidationService`
- starts the loader before the services use it
- stops the loader on HA demotion and shutdown

## PoC / Tests

```bash
pnpm exec vitest run tests/poc/laserstream-entrypoint.poc.test.ts
pnpm exec tsc --noEmit
```

The PoC pins the production wiring that was missing on main: loader creation, service injection, start, and stop.
