### PR TITLE
fix: honor SOLANA_RPC_URL for priority fees

### DIFF
--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -210,9 +210,9 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
     rejectLocalRpcUrl("SOLANA_RPC_URL", env.SOLANA_RPC_URL?.trim());
     rejectLocalRpcUrl("SOLANA_RPC_WS_URL", env.SOLANA_RPC_WS_URL?.trim());
     rejectLocalRpcUrl("FALLBACK_RPC_URL", env.FALLBACK_RPC_URL?.trim());
-    // A.7: @percolatorct/shared and src/lib/priority-fee.ts read RPC_URL
-    // (not SOLANA_RPC_URL). Without this guard a RPC_URL=http://localhost
-    // on mainnet would be accepted while the other vars are caught.
+    // A.7: @percolatorct/shared and src/lib/priority-fee.ts accept RPC_URL
+    // as a compatibility alias. Without this guard a RPC_URL=http://localhost
+    // on mainnet would be accepted while the SOLANA_* vars are caught.
     rejectLocalRpcUrl("RPC_URL", env.RPC_URL?.trim());
 
     // A8: reject devnet/testnet hosts on every connection a mainnet keeper opens

--- a/src/lib/priority-fee.ts
+++ b/src/lib/priority-fee.ts
@@ -83,7 +83,12 @@ export class HeliusPriorityFeeEstimator implements PriorityFeeEstimator {
   private readonly _cache = new Map<string, { value: number; expiresAt: number }>();
 
   constructor(rpcUrl?: string, opts?: { cacheMs?: number }) {
-    this._rpcUrl = rpcUrl ?? process.env.HELIUS_RPC_URL ?? process.env.RPC_URL ?? "";
+    this._rpcUrl =
+      rpcUrl ??
+      process.env.HELIUS_RPC_URL ??
+      process.env.SOLANA_RPC_URL ??
+      process.env.RPC_URL ??
+      "";
     this._cacheMs =
       opts?.cacheMs ??
       parseInt(process.env.KEEPER_PRIORITY_FEE_CACHE_MS ?? String(DEFAULT_CACHE_MS), 10);

--- a/tests/lib/priority-fee.test.ts
+++ b/tests/lib/priority-fee.test.ts
@@ -147,6 +147,35 @@ describe("HeliusPriorityFeeEstimator", () => {
     expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
+  it("uses SOLANA_RPC_URL when no explicit or Helius RPC URL is provided", async () => {
+    const origHelius = process.env.HELIUS_RPC_URL;
+    const origSolana = process.env.SOLANA_RPC_URL;
+    const origRpc = process.env.RPC_URL;
+    delete process.env.HELIUS_RPC_URL;
+    delete process.env.RPC_URL;
+    process.env.SOLANA_RPC_URL = "https://solana-rpc.example.com";
+
+    try {
+      const fetchFn = mockFetch(HELIUS_SUCCESS_RESPONSE);
+      global.fetch = fetchFn;
+      const estimator = new HeliusPriorityFeeEstimator(undefined, { cacheMs: 0 });
+
+      await estimator.estimate(["acc1"], "crank");
+
+      expect(fetchFn).toHaveBeenCalledWith(
+        "https://solana-rpc.example.com",
+        expect.objectContaining({ method: "POST" }),
+      );
+    } finally {
+      if (origHelius === undefined) delete process.env.HELIUS_RPC_URL;
+      else process.env.HELIUS_RPC_URL = origHelius;
+      if (origSolana === undefined) delete process.env.SOLANA_RPC_URL;
+      else process.env.SOLANA_RPC_URL = origSolana;
+      if (origRpc === undefined) delete process.env.RPC_URL;
+      else process.env.RPC_URL = origRpc;
+    }
+  });
+
   it("reads percentile overrides from env", async () => {
     const origEnv = process.env.KEEPER_PRIORITY_FEE_PERCENTILE_CRANK;
     // Override crank to p95 (veryHigh)


### PR DESCRIPTION
## Summary

Fixes #263.

`HeliusPriorityFeeEstimator` now honors the documented `SOLANA_RPC_URL` env var when no explicit URL or `HELIUS_RPC_URL` override is supplied. `RPC_URL` remains supported as a compatibility alias.

## Proof / Tests

Added a regression test that sets only `SOLANA_RPC_URL` and asserts the priority-fee request is sent there instead of falling back through an empty URL.

```bash
pnpm exec vitest run tests/lib/priority-fee.test.ts
pnpm exec tsc --noEmit
```