### PR TITLE
fix: skip legacy monitor checks for v17 markets

### DIFF
--- a/src/services/monitor.ts
+++ b/src/services/monitor.ts
@@ -16,6 +16,7 @@
 import { PublicKey } from "@solana/web3.js";
 import {
   fetchSlab,
+  isV17Account,
   parseEngine,
   parseConfig,
 } from "@percolatorct/sdk";
@@ -61,6 +62,7 @@ export interface MarketInvariantResult {
   /** Shortfall: engineVault - vaultTokenBalance (0n when ok) */
   shortfall: string;
   checkedAt: number;
+  skippedReason?: string;
 }
 
 export interface AdlStalenessResult {
@@ -69,6 +71,7 @@ export interface AdlStalenessResult {
   cycleSinceLastAdl: number;
   stale: boolean;
   checkedAt: number;
+  skippedReason?: string;
 }
 
 interface PerMarketState {
@@ -192,6 +195,29 @@ export class MonitorService {
           MONITOR_RPC_TIMEOUT_MS,
           `fetchSlab(${slabAddress.slice(0, 8)})`,
         );
+        if (isV17Account(data)) {
+          this._invariantResults.set(slabAddress, {
+            slabAddress,
+            ok: true,
+            vaultTokenBalance: "0",
+            engineVault: "0",
+            shortfall: "0",
+            checkedAt: now,
+            skippedReason: "v17 market account: legacy engine.vault invariant is not applicable",
+          });
+          this._adlStalenessResults.set(slabAddress, {
+            slabAddress,
+            adlNeeded: false,
+            cycleSinceLastAdl: 0,
+            stale: false,
+            checkedAt: now,
+            skippedReason: "v17 removed ExecuteAdl; legacy ADL staleness check is not applicable",
+          });
+          logger.debug("MonitorService skipped legacy v12 checks for v17 market", {
+            slabAddress: slabAddress.slice(0, 8),
+          });
+          return;
+        }
         const engine = parseEngine(data);
         const cfg = parseConfig(data);
 

--- a/tests/services/monitor.test.ts
+++ b/tests/services/monitor.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+
+vi.mock("@percolatorct/sdk", () => ({
+  fetchSlab: vi.fn(),
+  isV17Account: vi.fn(() => false),
+  parseEngine: vi.fn(),
+  parseConfig: vi.fn(),
+}));
+
+vi.mock("@percolatorct/shared", () => ({
+  getConnection: vi.fn(() => ({ id: "connection" })),
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  sendCriticalAlert: vi.fn(),
+  sendWarningAlert: vi.fn(),
+}));
+
+vi.mock("../../src/lib/metrics.js", () => ({
+  cycleDurationSeconds: { observe: vi.fn() },
+}));
+
+import { MonitorService } from "../../src/services/monitor.js";
+import * as sdk from "@percolatorct/sdk";
+
+describe("MonitorService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("records an explicit skip for v17 markets instead of running legacy v12 parsers", async () => {
+    const service = new MonitorService();
+    const slabAddress = "11111111111111111111111111111111";
+    const market = {
+      slabAddress: new PublicKey(slabAddress),
+    };
+    const markets = new Map([
+      [slabAddress, { market }],
+    ]);
+
+    vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array([1, 2, 3]));
+    vi.mocked(sdk.isV17Account).mockReturnValue(true);
+    vi.mocked(sdk.parseEngine).mockImplementation(() => {
+      throw new Error("legacy parser should not run for v17");
+    });
+
+    service.setMarketSource(() => markets as any);
+    await (service as any)._runChecks();
+
+    const status = service.getStatus();
+    expect(sdk.parseEngine).not.toHaveBeenCalled();
+    expect(sdk.parseConfig).not.toHaveBeenCalled();
+    expect(status.invariants).toEqual([
+      expect.objectContaining({
+        slabAddress,
+        ok: true,
+        skippedReason: expect.stringContaining("v17 market account"),
+      }),
+    ]);
+    expect(status.adlStaleness).toEqual([
+      expect.objectContaining({
+        slabAddress,
+        adlNeeded: false,
+        stale: false,
+        skippedReason: expect.stringContaining("v17 removed ExecuteAdl"),
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #265.

`MonitorService` now detects v17 market accounts before running legacy v12 `parseEngine`/`parseConfig` checks. For v17 markets, it records explicit skipped invariant and ADL-staleness results with reasons instead of logging a parser failure and leaving monitor status empty.

## Proof / Tests

Added a monitor regression test proving that v17 accounts do not call legacy parsers and do produce explicit skipped status entries.

```bash
pnpm exec vitest run tests/services/monitor.test.ts
pnpm exec tsc --noEmit
```