### PR TITLE
fix(keeper): record shadow decisions against wrapper market

### DIFF
--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -109,6 +109,10 @@ function isMainnetSender(): boolean {
   );
 }
 
+function firstProgramInstruction(instructions: TransactionInstruction[]): TransactionInstruction | undefined {
+  return instructions.find((ix) => !ix.programId.equals(ComputeBudgetProgram.programId));
+}
+
 interface EstimateCostResult {
   estimatedCost: number;
   simulatedCu: number;
@@ -265,12 +269,11 @@ export async function keeperSend(
       // no-op overhead of <1ms. If that ever becomes a concern, add the env guard
       // inside append() rather than here to keep this path readable.
       if (process.env.SHADOW_HARNESS_ENABLED === "true") {
-        const firstIx = instructions[0];
-        // The market is the first non-system account from the first instruction.
-        // For crank/liquidation/adl ixs the slab address is always at index 0.
-        const market = firstIx?.keys[0]?.pubkey.toBase58() ?? "unknown";
+        const decisionIx = firstProgramInstruction(instructions);
+        // Keeper wrapper ixs use keys[0] for the signer and keys[1] for the slab/market.
+        const market = decisionIx?.keys[1]?.pubkey.toBase58() ?? "unknown";
         const instructionData =
-          firstIx !== undefined ? Buffer.from(firstIx.data).toString("base64") : "";
+          decisionIx !== undefined ? Buffer.from(decisionIx.data).toString("base64") : "";
         void sharedDecisionLog.append({
           timestamp: new Date().toISOString(),
           txType,

--- a/tests/lib/keeper-send.test.ts
+++ b/tests/lib/keeper-send.test.ts
@@ -26,8 +26,9 @@ vi.mock("../../src/lib/cu-estimator.js", () => {
 
 import * as shared from "@percolatorct/shared";
 import { keeperSend, classifySendError } from "../../src/lib/keeper-send.js";
+import { sharedDecisionLog } from "../../src/lib/decision-log.js";
 import { KeeperBudget } from "../../src/lib/budget.js";
-import { Keypair, TransactionInstruction, PublicKey } from "@solana/web3.js";
+import { ComputeBudgetProgram, Keypair, TransactionInstruction, PublicKey } from "@solana/web3.js";
 
 function makeDummyIx(): TransactionInstruction {
   return new TransactionInstruction({
@@ -226,6 +227,45 @@ describe("keeperSend", () => {
       ]);
       const uniq = new Set(sigs.map((r) => r!.signature));
       expect(uniq.size).toBe(3);
+    });
+
+    it("logs the wrapper market and payload instead of the prepended heap-frame ix", async () => {
+      const originalShadowHarness = process.env.SHADOW_HARNESS_ENABLED;
+      process.env.SHADOW_HARNESS_ENABLED = "true";
+
+      const market = Keypair.generate().publicKey;
+      const portfolio = Keypair.generate().publicKey;
+      const oracle = Keypair.generate().publicKey;
+      const payload = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+      const wrapperIx = new TransactionInstruction({
+        programId: Keypair.generate().publicKey,
+        keys: [
+          { pubkey: keypair.publicKey, isSigner: true, isWritable: true },
+          { pubkey: market, isSigner: false, isWritable: true },
+          { pubkey: portfolio, isSigner: false, isWritable: true },
+          { pubkey: oracle, isSigner: false, isWritable: false },
+        ],
+        data: payload,
+      });
+      const heapFramePayload = Buffer.from(
+        ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }).data,
+      ).toString("base64");
+      const appendSpy = vi.spyOn(sharedDecisionLog, "append").mockResolvedValue();
+
+      try {
+        await keeperSend(connection, [wrapperIx], [keypair], "crank", budget);
+
+        expect(appendSpy).toHaveBeenCalledTimes(1);
+        const entry = appendSpy.mock.calls[0]![0];
+        expect(entry.market).toBe(market.toBase58());
+        expect(entry.market).not.toBe(keypair.publicKey.toBase58());
+        expect(entry.instructionData).toBe(payload.toString("base64"));
+        expect(entry.instructionData).not.toBe(heapFramePayload);
+      } finally {
+        appendSpy.mockRestore();
+        if (originalShadowHarness === undefined) delete process.env.SHADOW_HARNESS_ENABLED;
+        else process.env.SHADOW_HARNESS_ENABLED = originalShadowHarness;
+      }
     });
 
     it.skipIf(!process.env.STRESS)(


### PR DESCRIPTION
Closes #246

## Summary

- Skip the prepended `ComputeBudgetProgram.requestHeapFrame` instruction when the dry-run shadow harness extracts decision metadata.
- Record the wrapper instruction market from `keys[1]`, since `keys[0]` is the keeper signer.
- Record the wrapper instruction payload instead of the heap-frame payload.

## Proof

`keeperSend` now prepends a heap-frame compute-budget instruction before every keeper transaction. The old shadow harness read `instructions[0]`, so after the heap-frame cutover it no longer read the wrapper instruction at all. Even before that cutover, issue #246 correctly noted that wrapper `keys[0]` is the keeper wallet and `keys[1]` is the slab/market.

The regression test constructs a wrapper-shaped instruction with this account layout:

```ts
[
  keeper signer,
  market/slab,
  portfolio,
  oracle,
]
```

It runs through `keeperSend` with `DRY_RUN=true` and `SHADOW_HARNESS_ENABLED=true`, then asserts that the appended decision uses the market/slab key and the wrapper payload, not the keeper signer or the prepended heap-frame payload.

## Verification

```bash
pnpm vitest run tests/lib/keeper-send.test.ts
pnpm build
```