### PR TITLE
fix: provision v17 portfolio on hot register

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -835,35 +835,35 @@ export class CrankService {
    * Provisioning can fail transiently, so discovery calls this on first insert and
    * again on rediscovery while keeperPortfolio is still null.
    */
-  private ensureKeeperPortfolio(key: string, market: DiscoveredMarket): void {
-    void (async () => {
-      try {
-        const connection = getConnection();
-        const keypair = this._keypair;
-        const portfolio = await provisionKeeperPortfolio(
-          connection,
-          market.programId,
-          market.slabAddress,
-          keypair.publicKey,
-          keypair,
-        );
-        const state = this.markets.get(key);
-        if (state) {
-          state.keeperPortfolio = portfolio;
-          if (portfolio) {
-            logger.info("Keeper portfolio provisioned", {
-              market: key.slice(0, 8),
-              portfolio: portfolio.toBase58().slice(0, 8),
-            });
-          }
+  private async ensureKeeperPortfolio(key: string, market: DiscoveredMarket): Promise<PublicKey | null> {
+    try {
+      const connection = getConnection();
+      const keypair = this._keypair;
+      const portfolio = await provisionKeeperPortfolio(
+        connection,
+        market.programId,
+        market.slabAddress,
+        keypair.publicKey,
+        keypair,
+      );
+      const state = this.markets.get(key);
+      if (state) {
+        state.keeperPortfolio = portfolio;
+        if (portfolio) {
+          logger.info("Keeper portfolio provisioned", {
+            market: key.slice(0, 8),
+            portfolio: portfolio.toBase58().slice(0, 8),
+          });
         }
-      } catch (provErr) {
-        logger.debug("Portfolio provisioning deferred", {
-          market: key.slice(0, 8),
-          error: provErr instanceof Error ? provErr.message : String(provErr),
-        });
       }
-    })();
+      return portfolio;
+    } catch (provErr) {
+      logger.debug("Portfolio provisioning deferred", {
+        market: key.slice(0, 8),
+        error: provErr instanceof Error ? provErr.message : String(provErr),
+      });
+      return null;
+    }
   }
 
   /**
@@ -935,7 +935,7 @@ export class CrankService {
             (header !== undefined && Number(header.version) === 16 && Number(header.kind) === 1);
 
           if (isV17Market && !state.keeperPortfolio) {
-            this.ensureKeeperPortfolio(key, state.market);
+            void this.ensureKeeperPortfolio(key, state.market);
           }
         }
         this.lastDiscoveryTime = now;
@@ -1156,12 +1156,12 @@ export class CrankService {
         // The provisioning result updates state.keeperPortfolio in place.
         // If provisioning fails (network error or portfolio already being created),
         // the market will be skipped this cycle and retried on next discovery.
-        this.ensureKeeperPortfolio(key, market);
+        void this.ensureKeeperPortfolio(key, market);
       } else {
         const state = this.markets.get(key)!;
         state.market = market;
         if (!state.keeperPortfolio) {
-          this.ensureKeeperPortfolio(key, market);
+          void this.ensureKeeperPortfolio(key, market);
         }
         // Update mainnetCA from Supabase on every discovery.
         // Use explicit undefined check so a DB null/removal clears stale values (not just truthy-set).
@@ -1841,12 +1841,16 @@ export class CrankService {
     }
 
     try {
-      const header = parseHeader(data);
-      const marketConfig = parseConfig(data);
-      const engine = parseEngine(data);
-      const params = parseParams(data);
-
-      const market: DiscoveredMarket = { slabAddress: slabPubkey, programId, header, config: marketConfig, engine, params };
+      const market = parseMarketFromAccountData(slabPubkey, programId, data);
+      if (!market) {
+        throw new Error("Unrecognized or unsupported market account layout");
+      }
+      const header = market.header as
+        | { version?: number | bigint; kind?: number | bigint }
+        | undefined;
+      const isV17Market =
+        Boolean((market as DiscoveredMarket & { _rawV17Config?: unknown })._rawV17Config) ||
+        (header !== undefined && Number(header.version) === 16 && Number(header.kind) === 1);
 
       this.markets.set(slabAddress, {
         market,
@@ -1863,8 +1867,18 @@ export class CrankService {
 
       logger.info("Hot-registered new market", { slabAddress, programId: programId.toBase58() });
 
+      if (isV17Market) {
+        await this.ensureKeeperPortfolio(slabAddress, market);
+      }
+
       // Trigger immediate oracle push + crank so price is live within seconds
-      await this.crankMarket(slabAddress);
+      const cranked = await this.crankMarket(slabAddress);
+      if (!cranked) {
+        return {
+          success: true,
+          message: "Market registered; initial crank was not executed",
+        };
+      }
 
       return { success: true, message: "Market registered and initial crank triggered" };
     } catch (err) {

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -25,9 +25,27 @@ vi.mock('@percolatorct/sdk', () => ({
   parseConfig: vi.fn(),
   parseEngine: vi.fn(),
   parseParams: vi.fn(),
+  isV17Account: vi.fn(() => false),
+  parseWrapperConfigV17: vi.fn(),
+  parsePortfolioV17: vi.fn(),
   detectDexType: vi.fn(() => null),
   parseDexPool: vi.fn(),
   ACCOUNTS_PUSH_ORACLE_PRICE: {},
+}));
+
+vi.mock('../../src/lib/v17-risk.js', () => ({
+  V17_RISK_PARAMS_MIN_DATA_LEN: 538,
+  parseV17RiskParams: vi.fn(() => ({
+    warmupPeriodSlots: 0n,
+    maintenanceMarginBps: 500n,
+    hMin: 0n,
+    hMax: 0n,
+    openInterestCap: 0n,
+    maintenanceFeePerSlot: 0n,
+    liquidationFeeShareBps: 0n,
+    adlFillCapBps: 0n,
+    minPositionSize: 0n,
+  })),
 }));
 
 vi.mock('@percolatorct/shared', () => ({
@@ -1191,6 +1209,62 @@ describe('CrankService', () => {
       await crankService.discover();
       const stateAfter = crankService.getMarkets().get(slabHyperp)!;
       expect(stateAfter.hyperpNoPriceSkipped).toBe(false);
+    });
+  });
+
+  describe('registerMarket', () => {
+    it('provisions a v17 keeper portfolio before reporting the initial hot-register crank', async () => {
+      const slabAddress = 'So11111111111111111111111111111111111111112';
+      const programId = new PublicKey('11111111111111111111111111111111');
+      const portfolio = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+      const marketData = new Uint8Array(600);
+      const connection = {
+        getAccountInfo: vi.fn(async () => ({
+          data: marketData,
+          owner: programId,
+        })),
+        getProgramAccounts: vi.fn(async () => [
+          { pubkey: portfolio, account: { data: new Uint8Array([1, 2, 3]) } },
+        ]),
+      };
+
+      vi.mocked(shared.getConnection)
+        .mockReturnValueOnce(connection as any)
+        .mockReturnValueOnce(connection as any);
+      vi.mocked(core.isV17Account).mockReturnValueOnce(true);
+      vi.mocked(core.parseWrapperConfigV17).mockReturnValueOnce({
+        marketauth: PublicKey.default,
+        collateralMint: programId,
+        oracleMode: 2,
+        oracleLegFeeds: [],
+        maxStalenessSecs: 60n,
+        confFilterBps: 0,
+        invert: 0,
+        unitScale: 1,
+        oracleTargetPriceE6: 0n,
+        oracleTargetPublishTime: 0n,
+        markEwmaE6: 1_000_000n,
+      } as any);
+      vi.mocked(core.parsePortfolioV17).mockReturnValueOnce({
+        owner: { equals: () => true },
+      } as any);
+
+      const crankSpy = vi.spyOn(crankService, 'crankMarket').mockImplementation(async (slab) => {
+        const state = (crankService as any).markets.get(slab);
+        expect(state.keeperPortfolio).toBe(portfolio);
+        return true;
+      });
+
+      const result = await crankService.registerMarket(slabAddress);
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Market registered and initial crank triggered',
+      });
+      expect(core.parseHeader).not.toHaveBeenCalled();
+      expect(core.parseWrapperConfigV17).toHaveBeenCalledWith(marketData);
+      expect(connection.getProgramAccounts).toHaveBeenCalled();
+      expect(crankSpy).toHaveBeenCalledWith(slabAddress);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #244.

`registerMarket()` now routes hot-register account bytes through the same v17-aware parser used by discovery, awaits keeper portfolio provisioning for v17 markets, and only reports the initial crank as triggered when `crankMarket()` actually runs.

## Proof / Tests

Added a hot-register regression test that returns an existing keeper portfolio from `getProgramAccounts()` and asserts that the portfolio is set before the initial crank is attempted.

```bash
pnpm exec vitest run tests/services/crank.test.ts -t "hot-register"
pnpm exec vitest run tests/services/crank.test.ts
pnpm exec tsc --noEmit
```