### PR TITLE
fix: apply v17 liquidation drift recheck

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -12,6 +12,7 @@ import {
   CrankAction,
   // v17 portfolio scanning (DESYNC-3 / DESYNC-4 fixes)
   isV17Account,
+  parseWrapperConfigV17,
   parsePortfolioV17,
   type DiscoveredMarket,
 } from "@percolatorct/sdk";
@@ -316,6 +317,22 @@ function resolveMarketPrice(
   }
   // Authority stale — fall back to lastEffectivePriceE6 (mirrors on-chain behavior)
   return { price: cfg.lastEffectivePriceE6, stale: true };
+}
+
+function resolveV17WrapperPrice(
+  cfg: ReturnType<typeof parseWrapperConfigV17>,
+  nowSec: bigint,
+): bigint {
+  if (cfg.oracleMode === 3) {
+    const maxStalenessSecs = cfg.maxStalenessSecs > 0n ? cfg.maxStalenessSecs : 60n;
+    const priceAge = cfg.oracleTargetPublishTime > 0n
+      ? nowSec - cfg.oracleTargetPublishTime
+      : nowSec;
+    if (cfg.oracleTargetPriceE6 > 0n && priceAge <= maxStalenessSecs) {
+      return cfg.oracleTargetPriceE6;
+    }
+  }
+  return cfg.markEwmaE6;
 }
 
 interface LiquidationCandidate {
@@ -755,14 +772,40 @@ export class LiquidationService {
           // unavailable (0) we keep the leg-active check + rely on the on-chain program.
           const freshMarketData = await fetchSlabWithRetry(slabAddress);
           const reMmBps = parseV17RiskParams(freshMarketData).maintenanceMarginBps;
-          if (scanPriceE6 > 0n && reMmBps > 0n) {
+          const freshNowSec = await fetchClusterUnixTimeSec(connection);
+          const freshPrice = resolveV17WrapperPrice(parseWrapperConfigV17(freshMarketData), freshNowSec);
+          if (freshPrice === 0n) {
+            logger.warn("v17 liquidate: no fresh price available for pre-submit recheck, aborting", {
+              portfolio: v17PortfolioPubkey.toBase58().slice(0, 8),
+              slabAddress: slabAddress.toBase58().slice(0, 8),
+            });
+            return null;
+          }
+          if (MAX_LIQUIDATION_DRIFT_BPS > 0n && scanPriceE6 > 0n) {
+            const delta = freshPrice > scanPriceE6
+              ? freshPrice - scanPriceE6
+              : scanPriceE6 - freshPrice;
+            const driftBps = delta * BPS_MULTIPLIER / scanPriceE6;
+            if (driftBps > MAX_LIQUIDATION_DRIFT_BPS) {
+              logger.warn("Aborting v17 liquidation: oracle drift exceeds limit", {
+                portfolio: v17PortfolioPubkey.toBase58().slice(0, 8),
+                slabAddress: slabAddress.toBase58(),
+                scanPriceE6: scanPriceE6.toString(),
+                freshPriceE6: freshPrice.toString(),
+                driftBps: driftBps.toString(),
+                limitBps: MAX_LIQUIDATION_DRIFT_BPS.toString(),
+              });
+              return null;
+            }
+          }
+          if (reMmBps > 0n) {
             const feeDebt = pf.feeCredits < 0n ? -pf.feeCredits : 0n;
             const equity = pf.capital + pf.pnl - feeDebt;
             let stillLiquidatable = false;
             for (const leg of pf.legs) {
               if (!leg.active || leg.basisPosQ === 0n) continue;
               const absPos = leg.basisPosQ < 0n ? -leg.basisPosQ : leg.basisPosQ;
-              const notional = absPos * scanPriceE6 / PRICE_E6_DIVISOR;
+              const notional = absPos * freshPrice / PRICE_E6_DIVISOR;
               if (notional === 0n) continue;
               if (computeMarginRatioBps(equity, notional) < reMmBps) {
                 stillLiquidatable = true;

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -54,6 +54,7 @@ vi.mock('@percolatorct/sdk', () => ({
   IX_TAG: { TradeNoCpi: 1, TradeCpi: 2 },
   // v17 additions — default false so legacy-path tests continue to work.
   isV17Account: vi.fn(() => false),
+  parseWrapperConfigV17: vi.fn(),
   parsePortfolioV17: vi.fn(),
 }));
 
@@ -127,6 +128,20 @@ vi.mock('../../src/lib/keeper-send.js', async () => {
     sharedBudget: new KeeperBudget(),
   };
 });
+
+vi.mock('../../src/lib/v17-risk.js', () => ({
+  parseV17RiskParams: vi.fn(() => ({
+    warmupPeriodSlots: 0n,
+    maintenanceMarginBps: 500n,
+    hMin: 0n,
+    hMax: 0n,
+    openInterestCap: 0n,
+    maintenanceFeePerSlot: 0n,
+    liquidationFeeShareBps: 0n,
+    adlFillCapBps: 0n,
+    minPositionSize: 0n,
+  })),
+}));
 
 import { PublicKey, ComputeBudgetProgram } from '@solana/web3.js';
 import { LiquidationService } from '../../src/services/liquidation.js';
@@ -397,6 +412,70 @@ describe('LiquidationService', () => {
   });
 
   describe('liquidate', () => {
+    it('aborts v17 liquidation when fresh wrapper price drifts beyond the configured limit', async () => {
+      const nowSec = BigInt(Math.floor(Date.now() / 1000));
+      const clockData = Buffer.alloc(40);
+      clockData.writeBigInt64LE(nowSec, 32);
+      const slabAddress = new PublicKey('11111111111111111111111111111111');
+      const portfolioPubkey = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+      const connection = {
+        getSlot: vi.fn(async () => 200),
+        getAccountInfo: vi.fn(async (pubkey: PublicKey) => {
+          if (pubkey.toBase58() === portfolioPubkey.toBase58()) {
+            return { data: new Uint8Array([1, 2, 3]) };
+          }
+          return { data: clockData };
+        }),
+      };
+
+      vi.mocked(shared.getConnection)
+        .mockReturnValueOnce(connection as any)
+        .mockReturnValueOnce(connection as any);
+      vi.mocked(core.fetchSlab).mockResolvedValueOnce(new Uint8Array(512));
+      vi.mocked(core.parsePortfolioV17).mockReturnValueOnce({
+        owner: new PublicKey('So11111111111111111111111111111111111111112'),
+        capital: 1_000_000n,
+        pnl: 0n,
+        feeCredits: 0n,
+        legs: [
+          {
+            active: true,
+            basisPosQ: 100_000_000_000n,
+            assetIndex: 0,
+          },
+        ],
+      } as any);
+      vi.mocked(core.parseWrapperConfigV17).mockReturnValueOnce({
+        oracleMode: 2, // EWMA_MARK
+        maxStalenessSecs: 60n,
+        oracleTargetPriceE6: 0n,
+        oracleTargetPublishTime: 0n,
+        markEwmaE6: 2_000_000n,
+      } as any);
+
+      const market = {
+        slabAddress,
+        programId: slabAddress,
+        config: {
+          collateralMint: slabAddress,
+          oracleAuthority: mockNonZeroKey(),
+          indexFeedId: mockZeroKey(),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: mockZeroKey() },
+      };
+
+      const sig = await liquidationService.liquidate(
+        market as any,
+        0,
+        portfolioPubkey,
+        1_000_000n,
+      );
+
+      expect(sig).toBeNull();
+      expect(keeperSendModule.keeperSend).not.toHaveBeenCalled();
+    });
+
     it('should execute liquidation with multi-instruction transaction', async () => {
       const mockMarket = {
         slabAddress: { toBase58: () => 'Market311111111111111111111111111111111' },


### PR DESCRIPTION
## Summary

Fixes #245.

The v17 liquidation pre-submit branch now parses fresh wrapper data, resolves a fresh v17 price, applies the same drift guard used by the legacy path, and uses that fresh price for the final margin recheck.

## Proof / Tests

Added a v17 regression test where scan-time price is 1.0 and fresh wrapper price is 2.0. The liquidation now aborts before `keeperSend()` because drift exceeds `LIQUIDATION_MAX_ORACLE_DRIFT_BPS`.

```bash
pnpm exec vitest run tests/services/liquidation.test.ts -t "fresh wrapper price drifts"
pnpm exec vitest run tests/services/liquidation.test.ts
pnpm exec tsc --noEmit
```