### PR TITLE
fix(keeper,v17): #244 hot-register portfolio provision + #245 liq oracle-drift guard + #246/#247

### DIFF
--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -265,12 +265,19 @@ export async function keeperSend(
       // no-op overhead of <1ms. If that ever becomes a concern, add the env guard
       // inside append() rather than here to keep this path readable.
       if (process.env.SHADOW_HARNESS_ENABLED === "true") {
-        const firstIx = instructions[0];
-        // The market is the first non-system account from the first instruction.
-        // For crank/liquidation/adl ixs the slab address is always at index 0.
-        const market = firstIx?.keys[0]?.pubkey.toBase58() ?? "unknown";
+        // #246: the market (slab) is at account index 1, not 0. Account index 0
+        // is the keeper wallet signer. instructions[0] is itself the prepended
+        // ComputeBudget requestHeapFrame ix (zero keys), so we must skip past any
+        // ComputeBudget ixs to the first wrapper ix and read its keys[1]
+        // (layout: [owner(s,w), market(w), portfolio(w), ...oracleTail]).
+        const COMPUTE_BUDGET_ID = ComputeBudgetProgram.programId.toBase58();
+        const programIx = instructions.find(
+          (ix) => ix.programId.toBase58() !== COMPUTE_BUDGET_ID,
+        );
+        const market = programIx?.keys[1]?.pubkey.toBase58() ?? "unknown";
+        // Record the wrapper ix payload (not the prepended ComputeBudget ix data).
         const instructionData =
-          firstIx !== undefined ? Buffer.from(firstIx.data).toString("base64") : "";
+          programIx !== undefined ? Buffer.from(programIx.data).toString("base64") : "";
         void sharedDecisionLog.append({
           timestamp: new Date().toISOString(),
           txType,

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -834,36 +834,38 @@ export class CrankService {
    * v17 markets need a keeper-owned portfolio before PermissionlessCrank can run.
    * Provisioning can fail transiently, so discovery calls this on first insert and
    * again on rediscovery while keeperPortfolio is still null.
+   *
+   * Returns a promise that always resolves (never rejects — all errors are swallowed
+   * and logged), so the fire-and-forget discovery callers may safely ignore it while
+   * the hot-register path can `await` it to provision before the initial crank (#244).
    */
-  private ensureKeeperPortfolio(key: string, market: DiscoveredMarket): void {
-    void (async () => {
-      try {
-        const connection = getConnection();
-        const keypair = this._keypair;
-        const portfolio = await provisionKeeperPortfolio(
-          connection,
-          market.programId,
-          market.slabAddress,
-          keypair.publicKey,
-          keypair,
-        );
-        const state = this.markets.get(key);
-        if (state) {
-          state.keeperPortfolio = portfolio;
-          if (portfolio) {
-            logger.info("Keeper portfolio provisioned", {
-              market: key.slice(0, 8),
-              portfolio: portfolio.toBase58().slice(0, 8),
-            });
-          }
+  private async ensureKeeperPortfolio(key: string, market: DiscoveredMarket): Promise<void> {
+    try {
+      const connection = getConnection();
+      const keypair = this._keypair;
+      const portfolio = await provisionKeeperPortfolio(
+        connection,
+        market.programId,
+        market.slabAddress,
+        keypair.publicKey,
+        keypair,
+      );
+      const state = this.markets.get(key);
+      if (state) {
+        state.keeperPortfolio = portfolio;
+        if (portfolio) {
+          logger.info("Keeper portfolio provisioned", {
+            market: key.slice(0, 8),
+            portfolio: portfolio.toBase58().slice(0, 8),
+          });
         }
-      } catch (provErr) {
-        logger.debug("Portfolio provisioning deferred", {
-          market: key.slice(0, 8),
-          error: provErr instanceof Error ? provErr.message : String(provErr),
-        });
       }
-    })();
+    } catch (provErr) {
+      logger.debug("Portfolio provisioning deferred", {
+        market: key.slice(0, 8),
+        error: provErr instanceof Error ? provErr.message : String(provErr),
+      });
+    }
   }
 
   /**
@@ -935,7 +937,8 @@ export class CrankService {
             (header !== undefined && Number(header.version) === 16 && Number(header.kind) === 1);
 
           if (isV17Market && !state.keeperPortfolio) {
-            this.ensureKeeperPortfolio(key, state.market);
+            // Fire-and-forget on the discovery fast path; retried each cycle.
+            void this.ensureKeeperPortfolio(key, state.market);
           }
         }
         this.lastDiscoveryTime = now;
@@ -1156,12 +1159,12 @@ export class CrankService {
         // The provisioning result updates state.keeperPortfolio in place.
         // If provisioning fails (network error or portfolio already being created),
         // the market will be skipped this cycle and retried on next discovery.
-        this.ensureKeeperPortfolio(key, market);
+        void this.ensureKeeperPortfolio(key, market);
       } else {
         const state = this.markets.get(key)!;
         state.market = market;
         if (!state.keeperPortfolio) {
-          this.ensureKeeperPortfolio(key, market);
+          void this.ensureKeeperPortfolio(key, market);
         }
         // Update mainnetCA from Supabase on every discovery.
         // Use explicit undefined check so a DB null/removal clears stale values (not just truthy-set).
@@ -1862,6 +1865,13 @@ export class CrankService {
       });
 
       logger.info("Hot-registered new market", { slabAddress, programId: programId.toBase58() });
+
+      // #244: v17 markets need a keeper-owned portfolio before PermissionlessCrank
+      // can run. The discovery paths provision it; the hot-register path must too,
+      // otherwise the immediate crank below runs against a market whose
+      // keeperPortfolio is still null and is silently skipped until the next full
+      // discovery cycle. Await it so the initial crank can actually proceed.
+      await this.ensureKeeperPortfolio(slabAddress, market);
 
       // Trigger immediate oracle push + crank so price is live within seconds
       await this.crankMarket(slabAddress);

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -751,18 +751,61 @@ export class LiquidationService {
           // that a leg is active. The owner may have topped up capital between scan and submit;
           // without this the keeper submits a liquidation the on-chain program then rejects
           // (wasted fee). Mirrors the v12.x recheck below and uses the same fee-debt-aware
-          // equity as the scanner (#230). scanPriceE6 is the scan-time price; if it's
-          // unavailable (0) we keep the leg-active check + rely on the on-chain program.
+          // equity as the scanner (#230).
           const freshMarketData = await fetchSlabWithRetry(slabAddress);
           const reMmBps = parseV17RiskParams(freshMarketData).maintenanceMarginBps;
-          if (scanPriceE6 > 0n && reMmBps > 0n) {
+
+          // #245: oracle-drift guard. The previous recheck reused the stale
+          // scan-time price (scanPriceE6) for the notional, so a market that
+          // moved between scan and submit was rechecked against a price the
+          // on-chain program no longer sees. Re-resolve a FRESH price from the
+          // just-fetched slab config (same source as scanMarket's v17 path:
+          // lastEffectivePriceE6 ?? authorityPriceE6), fail-safe when no price
+          // is available, abort on excessive drift, and use the fresh price in
+          // the notional — mirroring the v12.x path below.
+          const freshCfg = parseConfig(freshMarketData);
+          const freshPrice =
+            freshCfg.lastEffectivePriceE6 ?? freshCfg.authorityPriceE6 ?? 0n;
+
+          // Fail-safe: no usable fresh price → refuse to submit (mirror v12.x H2).
+          if (freshPrice === 0n) {
+            logger.warn(
+              "v17 liquidate: no fresh price available for pre-submit recheck, aborting",
+              {
+                portfolio: v17PortfolioPubkey.toBase58().slice(0, 8),
+                slabAddress: slabAddress.toBase58().slice(0, 8),
+              },
+            );
+            return null;
+          }
+
+          // Abort if the oracle drifted beyond MAX_LIQUIDATION_DRIFT_BPS since scan.
+          if (MAX_LIQUIDATION_DRIFT_BPS > 0n && scanPriceE6 > 0n) {
+            const delta = freshPrice > scanPriceE6
+              ? freshPrice - scanPriceE6
+              : scanPriceE6 - freshPrice;
+            const driftBps = delta * BPS_MULTIPLIER / scanPriceE6;
+            if (driftBps > MAX_LIQUIDATION_DRIFT_BPS) {
+              logger.warn("v17 liquidate: aborting — oracle drift exceeds limit", {
+                portfolio: v17PortfolioPubkey.toBase58().slice(0, 8),
+                slabAddress: slabAddress.toBase58().slice(0, 8),
+                scanPriceE6: scanPriceE6.toString(),
+                freshPriceE6: freshPrice.toString(),
+                driftBps: driftBps.toString(),
+                limitBps: MAX_LIQUIDATION_DRIFT_BPS.toString(),
+              });
+              return null;
+            }
+          }
+
+          if (reMmBps > 0n) {
             const feeDebt = pf.feeCredits < 0n ? -pf.feeCredits : 0n;
             const equity = pf.capital + pf.pnl - feeDebt;
             let stillLiquidatable = false;
             for (const leg of pf.legs) {
               if (!leg.active || leg.basisPosQ === 0n) continue;
               const absPos = leg.basisPosQ < 0n ? -leg.basisPosQ : leg.basisPosQ;
-              const notional = absPos * scanPriceE6 / PRICE_E6_DIVISOR;
+              const notional = absPos * freshPrice / PRICE_E6_DIVISOR;
               if (notional === 0n) continue;
               if (computeMarginRatioBps(equity, notional) < reMmBps) {
                 stillLiquidatable = true;
@@ -1002,12 +1045,14 @@ export class LiquidationService {
       );
 
       for (let j = 0; j < batchResults.length; j++) {
-        scanned++;
         const result = batchResults[j]!;
         if (result.status === "rejected") {
+          // #247: a rejected scan is not a scan that happened — count only
+          // fulfilled scans so `scanned` reflects markets actually inspected.
           logger.error("Market scan rejected", { error: result.reason });
           continue;
         }
+        scanned++;
         const candidates = result.value;
         candidateCount += candidates.length;
 

--- a/tests/lib/keeper-send-shadow-market.test.ts
+++ b/tests/lib/keeper-send-shadow-market.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// #246 regression: the shadow-harness DRY_RUN intercept in keeperSend must
+// record the MARKET (slab) — account index 1 of the wrapper instruction —
+// not the keeper-wallet signer (index 0) and not the prepended ComputeBudget
+// requestHeapFrame instruction (which carries zero keys).
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  sendWithRetryKeeper: vi.fn(async () => "mock-signature"),
+}));
+
+vi.mock("../../src/lib/priority-fee.js", () => {
+  class HeliusPriorityFeeEstimator {
+    estimate = vi.fn(async () => 1_000);
+  }
+  return { HeliusPriorityFeeEstimator };
+});
+
+vi.mock("../../src/lib/cu-estimator.js", () => {
+  class CuEstimator {
+    estimate = vi.fn(async () => 200_000);
+  }
+  return { CuEstimator };
+});
+
+// Capture every decision appended by the DRY_RUN intercept.
+const appendedEntries: Array<{ market: string; instructionData: string }> = [];
+vi.mock("../../src/lib/decision-log.js", () => ({
+  sharedDecisionLog: {
+    append: vi.fn(async (entry: { market: string; instructionData: string }) => {
+      appendedEntries.push(entry);
+    }),
+  },
+}));
+
+import { keeperSend } from "../../src/lib/keeper-send.js";
+import { KeeperBudget } from "../../src/lib/budget.js";
+import {
+  Keypair,
+  TransactionInstruction,
+  PublicKey,
+} from "@solana/web3.js";
+
+const WRAPPER_PROGRAM_ID = new PublicKey(
+  "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv",
+);
+
+function makeConnection() {
+  return {
+    simulateTransaction: vi.fn(async () => ({
+      value: { unitsConsumed: 200_000, err: null, logs: [] },
+    })),
+  } as any;
+}
+
+describe("keeperSend DRY_RUN shadow recording — #246 market field", () => {
+  let budget: KeeperBudget;
+  let connection: ReturnType<typeof makeConnection>;
+  let keeperWallet: Keypair;
+  let slab: PublicKey;
+  let portfolio: PublicKey;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appendedEntries.length = 0;
+    budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000, maxTxPerCycle: 100 });
+    connection = makeConnection();
+    keeperWallet = Keypair.generate();
+    slab = Keypair.generate().publicKey;
+    portfolio = Keypair.generate().publicKey;
+    process.env.NETWORK = "devnet";
+    process.env.USE_HELIUS_SENDER = "false";
+    process.env.DRY_RUN = "true";
+    process.env.SHADOW_HARNESS_ENABLED = "true";
+  });
+
+  afterEach(() => {
+    delete process.env.DRY_RUN;
+    delete process.env.SHADOW_HARNESS_ENABLED;
+  });
+
+  function makeWrapperIx(): TransactionInstruction {
+    // v17 PermissionlessCrank/Liquidate layout:
+    //   [owner(s,w), market(w), portfolio(w), ...oracleTail(r)]
+    return new TransactionInstruction({
+      programId: WRAPPER_PROGRAM_ID,
+      keys: [
+        { pubkey: keeperWallet.publicKey, isSigner: true, isWritable: true },
+        { pubkey: slab, isSigner: false, isWritable: true },
+        { pubkey: portfolio, isSigner: false, isWritable: true },
+      ],
+      data: Buffer.from([5, 1, 2, 3]),
+    });
+  }
+
+  it("records the slab (keys[1]) as the market, not the keeper wallet (keys[0])", async () => {
+    await keeperSend(connection, [makeWrapperIx()], [keeperWallet], "liquidation", budget);
+
+    expect(appendedEntries).toHaveLength(1);
+    const entry = appendedEntries[0]!;
+    expect(entry.market).toBe(slab.toBase58());
+    // Guard against the original bug: must NOT be the keeper-wallet signer.
+    expect(entry.market).not.toBe(keeperWallet.publicKey.toBase58());
+    // And must not collapse to "unknown" (which the empty-keyed ComputeBudget
+    // ix at instructions[0] would otherwise produce).
+    expect(entry.market).not.toBe("unknown");
+  });
+
+  it("skips the prepended ComputeBudget heap-frame ix and reads the wrapper ix payload", async () => {
+    await keeperSend(connection, [makeWrapperIx()], [keeperWallet], "crank", budget);
+
+    expect(appendedEntries).toHaveLength(1);
+    const entry = appendedEntries[0]!;
+    // The recorded instructionData must be the wrapper ix's data (base64 of
+    // [5,1,2,3]), never the empty ComputeBudget requestHeapFrame data.
+    expect(entry.instructionData).toBe(Buffer.from([5, 1, 2, 3]).toString("base64"));
+    expect(entry.market).toBe(slab.toBase58());
+  });
+});

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -28,6 +28,8 @@ vi.mock('@percolatorct/sdk', () => ({
   detectDexType: vi.fn(() => null),
   parseDexPool: vi.fn(),
   ACCOUNTS_PUSH_ORACLE_PRICE: {},
+  // #244: provisioning parses an existing portfolio account to confirm ownership.
+  parsePortfolioV17: vi.fn(),
 }));
 
 vi.mock('@percolatorct/shared', () => ({
@@ -83,7 +85,7 @@ vi.mock('../../src/lib/keeper-send.js', async () => {
   };
 });
 
-import { PublicKey } from '@solana/web3.js';
+import { PublicKey, Keypair } from '@solana/web3.js';
 import { CrankService } from '../../src/services/crank.js';
 import * as core from '@percolatorct/sdk';
 import * as shared from '@percolatorct/shared';
@@ -1504,6 +1506,95 @@ describe('CrankService', () => {
       expect(stats.misses).toBeGreaterThanOrEqual(1);
 
       service.stop();
+    });
+  });
+
+  // ─── #244: registerMarket must provision the v17 keeper portfolio ─────────
+  // The hot-register path previously set keeperPortfolio: null and went straight
+  // to crankMarket(), which then skipped the market (no send) because the
+  // portfolio was never provisioned — leaving a freshly-created market
+  // uncrankable until the next full discovery cycle.
+  describe('registerMarket — #244 keeper portfolio provisioning', () => {
+    const SLAB = Keypair.generate().publicKey.toBase58();
+    const EXISTING_PORTFOLIO = new PublicKey('9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin');
+
+    // Read the keeper pubkey straight off the service under test so the
+    // provisioned-portfolio owner check matches regardless of which loadKeypair
+    // mock implementation other tests in this file left behind.
+    function keeperKey(): string {
+      return (crankService as any)._keypair.publicKey.toBase58();
+    }
+
+    function wireRegisterMocks() {
+      const KEEPER_KEY = keeperKey();
+      // Slab account owned by a known program (PublicKey.default base58 is the
+      // first allowlisted id).
+      const getProgramAccounts = vi.fn().mockResolvedValue([
+        { pubkey: EXISTING_PORTFOLIO, account: { data: Buffer.alloc(9347) } },
+      ]);
+      // mockReset() drops any queued mockReturnValueOnce(...) from earlier tests
+      // (the LaserStream provisioning test uses mockReturnValueOnce), which would
+      // otherwise be consumed by registerMarket's first getConnection() call.
+      vi.mocked(shared.getConnection).mockReset();
+      vi.mocked(shared.getConnection).mockReturnValue({
+        getAccountInfo: vi.fn().mockResolvedValue({
+          data: Buffer.alloc(64),
+          owner: PublicKey.default, // base58 = '111...11' → allowlisted
+        }),
+        getSlot: vi.fn().mockResolvedValue(200),
+        getProgramAccounts,
+        getMinimumBalanceForRentExemption: vi.fn().mockResolvedValue(1),
+      } as any);
+
+      vi.mocked(core.parseHeader).mockReturnValue({ version: 16, kind: 1 } as any);
+      vi.mocked(core.parseConfig).mockReturnValue({
+        collateralMint: { toBase58: () => 'Mint' },
+        oracleAuthority: { toBase58: () => KEEPER_KEY, equals: () => true },
+        indexFeedId: { toBytes: () => new Uint8Array(32), toBase58: () => 'feed' },
+      } as any);
+      vi.mocked(core.parseEngine).mockReturnValue({} as any);
+      vi.mocked(core.parseParams).mockReturnValue({ maintenanceMarginBps: 500n } as any);
+
+      // Provisioning confirms the found account is owned by the keeper.
+      vi.mocked(core.parsePortfolioV17).mockReturnValue({
+        owner: {
+          toBase58: () => KEEPER_KEY,
+          equals: (other: any) => other?.toBase58?.() === KEEPER_KEY,
+        },
+      } as any);
+
+      return { getProgramAccounts };
+    }
+
+    it('provisions the keeper portfolio (sets state.keeperPortfolio) before the initial crank', async () => {
+      const { getProgramAccounts } = wireRegisterMocks();
+
+      const result = await crankService.registerMarket(SLAB);
+
+      expect(result.success).toBe(true);
+
+      // The provisioning RPC ran on the register path (pre-fix: never called).
+      expect(getProgramAccounts).toHaveBeenCalled();
+      expect(getProgramAccounts.mock.calls[0]?.[1]?.filters).toContainEqual({ dataSize: 9347 });
+
+      // keeperPortfolio is now set, so the market is crankable — not left null.
+      const state = crankService.getMarkets().get(SLAB);
+      expect(state?.keeperPortfolio).not.toBeNull();
+      expect(state?.keeperPortfolio?.toBase58()).toBe(EXISTING_PORTFOLIO.toBase58());
+    });
+
+    it('the initial crank actually sends (not skipped) because the portfolio was provisioned first', async () => {
+      wireRegisterMocks();
+      vi.mocked(keeperSendModule.keeperSend).mockResolvedValue({
+        signature: 'mock-reg-crank-sig',
+        estimatedCost: 5000,
+      } as any);
+
+      await crankService.registerMarket(SLAB);
+
+      // crankMarket() only sends when keeperPortfolio is set; pre-fix it was
+      // null at crank time and the market was silently skipped (no send).
+      expect(keeperSendModule.keeperSend).toHaveBeenCalled();
     });
   });
 });

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -128,7 +128,23 @@ vi.mock('../../src/lib/keeper-send.js', async () => {
   };
 });
 
-import { PublicKey, ComputeBudgetProgram } from '@solana/web3.js';
+// #245: mock the v17 risk-param reader so the v17 liquidate recheck can run
+// against arbitrary fresh slab bytes without needing a byte-perfect fixture.
+vi.mock('../../src/lib/v17-risk.js', () => ({
+  parseV17RiskParams: vi.fn(() => ({
+    warmupPeriodSlots: 0n,
+    maintenanceMarginBps: 500n,
+    hMin: 0n,
+    hMax: 0n,
+    openInterestCap: 0n,
+    maintenanceFeePerSlot: 0n,
+    liquidationFeeShareBps: 0n,
+    adlFillCapBps: 0n,
+    minPositionSize: 0n,
+  })),
+}));
+
+import { PublicKey, ComputeBudgetProgram, Keypair } from '@solana/web3.js';
 import { LiquidationService } from '../../src/services/liquidation.js';
 import * as core from '@percolatorct/sdk';
 import * as shared from '@percolatorct/shared';
@@ -603,6 +619,128 @@ describe('LiquidationService', () => {
         expect(sig).not.toBeNull();
       });
     });
+
+    // ─── #245: v17 liquidate must apply an oracle-drift guard ──────────────
+    // The v17 recheck previously reused the stale scan-time price and had no
+    // fresh-price fetch, no fail-safe, and no drift guard. These tests assert
+    // the new behavior mirrors the v12.x path.
+    describe('#245: v17 oracle-drift guard', () => {
+      const V17_PORTFOLIO = Keypair.generate().publicKey;
+
+      function makeV17Market() {
+        return {
+          slabAddress: { toBase58: () => 'MarketV17111111111111111111111111111111111', toBytes: () => new Uint8Array(32), equals: () => false },
+          programId: { toBase58: () => 'Program11111111111111111111111111111111' },
+          config: {
+            collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+            oracleAuthority: mockNonZeroKey(),
+            indexFeedId: mockZeroKey(), // isAllZeros → oracle tail = slab, no RPC
+          },
+          params: { maintenanceMarginBps: 500n },
+          header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+        };
+      }
+
+      // A portfolio with one active, liquidatable leg.
+      function stubV17Portfolio() {
+        vi.mocked(core.parsePortfolioV17).mockReturnValue({
+          owner: { toBase58: () => 'UserV17111111111111111111111111111111111', equals: () => false },
+          capital: 100n,
+          pnl: -50n,
+          feeCredits: 0n,
+          legs: [{ active: true, basisPosQ: 10_000_000_000n, assetIndex: 0 }],
+        } as any);
+      }
+
+      // Wire getConnection() so the portfolio re-fetch returns valid data.
+      function stubConnectionWithPortfolio() {
+        vi.mocked(shared.getConnection).mockReturnValue({
+          getAccountInfo: vi.fn(async () => ({ data: Buffer.alloc(9347) })),
+          getSlot: vi.fn(async () => 200),
+        } as any);
+      }
+
+      beforeEach(() => {
+        vi.mocked(core.isV17Account).mockReturnValue(true);
+        vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(9347));
+        stubV17Portfolio();
+        stubConnectionWithPortfolio();
+      });
+
+      afterEach(() => {
+        vi.mocked(core.isV17Account).mockReturnValue(false);
+      });
+
+      it('aborts (no send) when the fresh price drifts beyond MAX_LIQUIDATION_DRIFT_BPS', async () => {
+        // scanPriceE6 = 1.000000; fresh = 1.050000 → 500 bps drift > 150 bps limit.
+        vi.mocked(core.parseConfig).mockReturnValue({
+          oracleAuthority: mockZeroKey(),
+          indexFeedId: mockNonZeroKey(),
+          authorityPriceE6: 0n,
+          lastEffectivePriceE6: 1_050_000n,
+          authorityTimestamp: 0n,
+        } as any);
+
+        const sendSpy = vi.mocked(shared.sendWithRetryKeeper);
+        const before = sendSpy.mock.calls.length;
+
+        const sig = await liquidationService.liquidate(
+          makeV17Market() as any,
+          0,
+          V17_PORTFOLIO,
+          1_000_000n, // scanPriceE6
+        );
+
+        expect(sig).toBeNull();
+        expect(sendSpy.mock.calls.length).toBe(before); // no new send
+      });
+
+      it('fails safe (no send) when no fresh price is available (freshPrice===0n)', async () => {
+        vi.mocked(core.parseConfig).mockReturnValue({
+          oracleAuthority: mockZeroKey(),
+          indexFeedId: mockNonZeroKey(),
+          authorityPriceE6: 0n,
+          lastEffectivePriceE6: 0n, // never cranked → no usable price
+          authorityTimestamp: 0n,
+        } as any);
+
+        const sendSpy = vi.mocked(shared.sendWithRetryKeeper);
+        const before = sendSpy.mock.calls.length;
+
+        const sig = await liquidationService.liquidate(
+          makeV17Market() as any,
+          0,
+          V17_PORTFOLIO,
+          1_000_000n,
+        );
+
+        expect(sig).toBeNull();
+        expect(sendSpy.mock.calls.length).toBe(before);
+      });
+
+      it('proceeds when the fresh price is within the drift limit and still undercollateralized', async () => {
+        // fresh = scan (no drift), leg still underwater at maintenanceMarginBps=500.
+        vi.mocked(core.parseConfig).mockReturnValue({
+          oracleAuthority: mockZeroKey(),
+          indexFeedId: mockNonZeroKey(),
+          authorityPriceE6: 0n,
+          lastEffectivePriceE6: 1_000_000n,
+          authorityTimestamp: 0n,
+        } as any);
+
+        const sig = await liquidationService.liquidate(
+          makeV17Market() as any,
+          0,
+          V17_PORTFOLIO,
+          1_000_000n,
+        );
+
+        // equity = 100 + (-50) = 50; notional = 10_000 (10e9 * 1e6 / 1e6 = 1e10
+        // base units / 1e6 = 1e4); marginRatio = 50 * 10000 / 10000 = 50 bps
+        // < 500 maintenance → liquidatable → proceeds.
+        expect(sig).not.toBeNull();
+      });
+    });
   });
 
   describe('start and stop', () => {
@@ -950,6 +1088,51 @@ describe('LiquidationService', () => {
       // Per-cycle dedup, not lifetime: the same (slab, idx) can be retargeted
       // next cycle (partial-fill retry path).
       expect(liquidateSpy).toHaveBeenCalledTimes(2);
+    });
+
+    // #247: `scanned` must count only fulfilled scans, not rejected ones.
+    it('#247: scanned counts only fulfilled scans, not rejected ones', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const okSlab = 'SlabOk44444444444444444444444444444444444444';
+      const failSlab = 'SlabFail5555555555555555555555555555555555';
+
+      // One market scans cleanly; the other throws (e.g., RPC error) so its
+      // Promise.allSettled entry is `rejected`.
+      vi.spyOn(svc, 'scanMarket').mockImplementation(async (market: any) => {
+        if (market.slabAddress.toBase58() === failSlab) {
+          throw new Error('simulated scan RPC failure');
+        }
+        return [] as any;
+      });
+
+      const markets = new Map([
+        [okSlab, { market: makeMarketAt(okSlab) as any }],
+        [failSlab, { market: makeMarketAt(failSlab) as any }],
+      ]);
+
+      const result = await svc.scanAndLiquidateAll(markets);
+
+      // Two markets attempted, but only the fulfilled one counts as "scanned".
+      expect(result.scanned).toBe(1);
+      expect(result.candidates).toBe(0);
+      expect(result.liquidated).toBe(0);
+    });
+
+    it('#247: scanned equals number of fulfilled scans when all succeed', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const slabs = [
+        'SlabAll00000000000000000000000000000000000',
+        'SlabAll11111111111111111111111111111111111',
+        'SlabAll22222222222222222222222222222222222',
+      ];
+      vi.spyOn(svc, 'scanMarket').mockResolvedValue([] as any);
+
+      const markets = new Map(
+        slabs.map((s) => [s, { market: makeMarketAt(s) as any }]),
+      );
+
+      const result = await svc.scanAndLiquidateAll(markets);
+      expect(result.scanned).toBe(3);
     });
   });
 });


### PR DESCRIPTION
**#244** — `registerMarket` now provisions the v17 keeper portfolio before cranking (mirrors the discovery path #254 made consistent). **#245** — the v17 `liquidate` path fetches a fresh price + fail-safe + `MAX_LIQUIDATION_DRIFT_BPS` guard (was using stale scan-time price). **#246** — shadow-harness market index `keys[0]`→`keys[1]`. **#247** — `scanned` counter only counts fulfilled scans.

Verified: `tsc --noEmit` clean; my new test files (crank / liquidation / shadow-market) all pass (59 tests). NOTE: 3 `sdk-smoke.test.ts` failures are **pre-existing** (reproduce on origin/main) — the keeper pins SDK `#5b140ae`, which predates the v17 throwing behavior the test expects; a separate SDK-pin bump, not this PR. Closes #244, #245, #246, #247.

⚠️ DRAFT — verified locally but NOT for merge until human-gated (fund-critical program / cutover). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)