### PR TITLE
test: cover v17 keeper portfolio retry on rediscovery

### DIFF
--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -313,6 +313,85 @@ describe('CrankService', () => {
       await crankService.discover();
       expect(crankService.getMarkets().size).toBe(0);
     }, 20000);
+
+    it('retries v17 keeper portfolio provisioning on normal rediscovery when keeperPortfolio is null', async () => {
+      const prevLaserStream = process.env.KEEPER_USE_LASERSTREAM;
+      delete process.env.KEEPER_USE_LASERSTREAM;
+
+      try {
+        const slabAddress = new PublicKey('11111111111111111111111111111111');
+
+        const service = new CrankService(mockOracleService);
+
+        const mockMarket = {
+          slabAddress,
+          programId: new PublicKey('11111111111111111111111111111111'),
+          config: {
+            collateralMint: new PublicKey('11111111111111111111111111111111'),
+            oracleAuthority: PublicKey.default,
+            indexFeedId: { toBytes: () => new Uint8Array(32) },
+          },
+          params: { maintenanceMarginBps: 500n },
+          header: { admin: PublicKey.default, version: 16, kind: 1 },
+          _rawV17Config: {},
+        };
+
+        // Simulate a v17 market that was already discovered, but its keeper
+        // portfolio provisioning failed transiently, leaving keeperPortfolio null.
+        (service as any).markets.set(slabAddress.toBase58(), {
+          market: mockMarket,
+          lastCrankTime: 0,
+          successCount: 0,
+          failureCount: 0,
+          consecutiveFailures: 0,
+          isActive: true,
+          missingDiscoveryCount: 0,
+          keeperPortfolio: null,
+        });
+
+        // Force discover() to take the normal full rediscovery path.
+        (service as any)._lastFullRediscoverTime = 0;
+
+        const discoveredMarkets = [mockMarket];
+        vi.mocked(core.discoverMarkets)
+          .mockResolvedValueOnce(discoveredMarkets as any)
+          .mockResolvedValue([]);
+
+        const getProgramAccounts = vi.fn().mockResolvedValue([]);
+        const getMinimumBalanceForRentExemption = vi.fn().mockResolvedValue(1);
+
+        vi.mocked(shared.getConnection).mockClear();
+        vi.mocked(shared.getConnection).mockReturnValueOnce({
+          getAccountInfo: vi.fn(),
+          getSlot: vi.fn().mockResolvedValue(200),
+          getProgramAccounts,
+          getMinimumBalanceForRentExemption,
+        } as any);
+
+        await service.discover();
+
+        // Normal rediscovery should retry the v17 portfolio provisioning path
+        // for an existing market whose keeperPortfolio is still null.
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(core.discoverMarkets).toHaveBeenCalled();
+        expect(shared.getConnection).toHaveBeenCalledTimes(1);
+        expect(getProgramAccounts).toHaveBeenCalledTimes(1);
+        expect(getProgramAccounts.mock.calls[0]?.[0]).toBe(mockMarket.programId);
+        expect(getProgramAccounts.mock.calls[0]?.[1]?.filters).toContainEqual({ dataSize: 9347 });
+
+        service.stop();
+      } finally {
+        if (prevLaserStream === undefined) {
+          delete process.env.KEEPER_USE_LASERSTREAM;
+        } else {
+          process.env.KEEPER_USE_LASERSTREAM = prevLaserStream;
+        }
+      }
+    });
+
   });
 
   describe('crankMarket', () => {


### PR DESCRIPTION
## Summary

Fixes #251.

This PR adds regression coverage for the v17 keeper portfolio retry-on-rediscovery path.

It verifies that when a v17 market is already discovered but its `keeperPortfolio` is still `null`, a normal full rediscovery retries the v17 keeper portfolio provisioning lookup instead of leaving the market discovered but unprovisioned.

## Why

v17 markets need a keeper-owned portfolio before `PermissionlessCrank` can run.

The production logic already retries `ensureKeeperPortfolio()` during normal rediscovery when an existing v17 market still has `keeperPortfolio: null`. This PR adds regression coverage so that behavior does not regress in future changes.

This is separate from the LaserStream fast-path coverage. The test added here explicitly forces the normal full rediscovery path by disabling `KEEPER_USE_LASERSTREAM` and setting `_lastFullRediscoverTime = 0`.

## Changes

* Added a regression test for normal rediscovery when an existing v17 market has `keeperPortfolio: null`.
* Mocked `core.discoverMarkets` across multiple program scans so the test covers the full `config.allProgramIds` rediscovery loop.
* Asserted the v17 keeper portfolio lookup path directly via `getProgramAccounts`.
* Verified the lookup uses the expected v17 portfolio account size filter.
* Kept the change limited to `tests/services/crank.test.ts`.
* No source logic changed.

## How to test

1. Run the targeted regression test:

```bash
pnpm exec vitest run tests/services/crank.test.ts -t "retries v17 keeper portfolio provisioning on normal rediscovery"
```

2. Run the full crank service test file:

```bash
pnpm exec vitest run tests/services/crank.test.ts
```

3. Run the full test suite:

```bash
pnpm test
```

## Checklist

* [x] Linked issue included: Fixes #251
* [x] Regression test added
* [x] Targeted regression test passes
* [x] `tests/services/crank.test.ts` passes
* [x] Full test suite passes
* [x] No source logic changed
* [x] No unrelated files changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for CrankService rediscovery process, validating that keeper portfolio provisioning correctly retries for markets during normal rediscovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->