### PR TITLE
fix(keeper): require KEEPER_REDIS_URL/TOKEN when HA_ENABLED=true

### DIFF
--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -175,6 +175,31 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
         `HA_ENABLED=true: NETWORK must resolve to 'mainnet' or 'devnet' (got '${raw.slice(0, 20)}').`,
       );
     }
+
+    // C-1 (CRITICAL): index.ts only builds a LeaderLock when getRedisClient()
+    // returns non-null. If KEEPER_REDIS_URL is unset, it silently falls back
+    // to standalone-leader mode (every replica believes it is the sole
+    // leader) with just a logger.warn — split-brain on any multi-replica
+    // deployment. Fail boot instead of degrading silently.
+    const redisUrl = env.KEEPER_REDIS_URL?.trim();
+    if (!redisUrl) {
+      throw new Error(
+        "HA_ENABLED=true requires KEEPER_REDIS_URL to be set. Running HA " +
+          "mode without Redis silently falls back to standalone-leader on " +
+          "every replica, risking duplicate liquidations/cranks " +
+          "(split-brain). Set KEEPER_REDIS_URL (and KEEPER_REDIS_TOKEN) to " +
+          "your Upstash REST endpoint, or set HA_ENABLED=false for a " +
+          "single-replica deployment.",
+      );
+    }
+    const redisToken = env.KEEPER_REDIS_TOKEN?.trim();
+    if (!redisToken) {
+      throw new Error(
+        "HA_ENABLED=true and KEEPER_REDIS_URL is set, but KEEPER_REDIS_TOKEN " +
+          "is missing or empty. Set KEEPER_REDIS_TOKEN to the Upstash REST " +
+          "token (no empty-string fallback is permitted).",
+      );
+    }
   }
 
   if (!allowInsecure) {

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -165,12 +165,19 @@ describe("validateKeeperEnvGuards", () => {
         SOLANA_RPC_WS_URL: "wss://api.mainnet-beta.solana.com",
         FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
         RPC_URL: "https://api.mainnet-beta.solana.com",
+        KEEPER_REDIS_URL: "https://fake-host.upstash.io",
+        KEEPER_REDIS_TOKEN: "fake-token",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
 
     it("accepts HA_ENABLED=true + NETWORK=devnet", () => {
-      const env = { HA_ENABLED: "true", NETWORK: "devnet" } as NodeJS.ProcessEnv;
+      const env = {
+        HA_ENABLED: "true",
+        NETWORK: "devnet",
+        KEEPER_REDIS_URL: "https://fake-host.upstash.io",
+        KEEPER_REDIS_TOKEN: "fake-token",
+      } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
 
@@ -184,6 +191,99 @@ describe("validateKeeperEnvGuards", () => {
     });
 
     it("accepts HA_ENABLED=false (not 'true') regardless of NETWORK state", () => {
+      const env = { HA_ENABLED: "false" } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
+  });
+
+  // C-1 (CRITICAL): HA_ENABLED=true with KEEPER_REDIS_URL unset silently fell
+  // back to standalone-leader mode in index.ts (only a logger.warn, no
+  // throw), so every replica in a multi-replica deployment believed it was
+  // the sole leader simultaneously — duplicate liquidations/cranks
+  // (split-brain) with no boot-time signal.
+  describe("C-1: HA_ENABLED requires KEEPER_REDIS_URL + KEEPER_REDIS_TOKEN", () => {
+    it("throws when HA_ENABLED=true and KEEPER_REDIS_URL is unset", () => {
+      const env = { HA_ENABLED: "true", NETWORK: "devnet" } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /HA_ENABLED.*requires.*KEEPER_REDIS_URL/i,
+      );
+    });
+
+    it("throws when HA_ENABLED=true and KEEPER_REDIS_URL is empty string", () => {
+      const env = {
+        HA_ENABLED: "true",
+        NETWORK: "devnet",
+        KEEPER_REDIS_URL: "",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /HA_ENABLED.*requires.*KEEPER_REDIS_URL/i,
+      );
+    });
+
+    it("throws when HA_ENABLED=true and KEEPER_REDIS_URL is whitespace-only", () => {
+      const env = {
+        HA_ENABLED: "true",
+        NETWORK: "devnet",
+        KEEPER_REDIS_URL: "   ",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /HA_ENABLED.*requires.*KEEPER_REDIS_URL/i,
+      );
+    });
+
+    it("throws when HA_ENABLED=true, KEEPER_REDIS_URL is set, but KEEPER_REDIS_TOKEN is unset", () => {
+      const env = {
+        HA_ENABLED: "true",
+        NETWORK: "devnet",
+        KEEPER_REDIS_URL: "https://fake-host.upstash.io",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /HA_ENABLED.*KEEPER_REDIS_URL.*KEEPER_REDIS_TOKEN/i,
+      );
+    });
+
+    it("throws when HA_ENABLED=true, KEEPER_REDIS_URL is set, but KEEPER_REDIS_TOKEN is empty string", () => {
+      const env = {
+        HA_ENABLED: "true",
+        NETWORK: "devnet",
+        KEEPER_REDIS_URL: "https://fake-host.upstash.io",
+        KEEPER_REDIS_TOKEN: "",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /HA_ENABLED.*KEEPER_REDIS_URL.*KEEPER_REDIS_TOKEN/i,
+      );
+    });
+
+    it("throws when HA_ENABLED=true and KEEPER_REDIS_TOKEN is whitespace-only", () => {
+      const env = {
+        HA_ENABLED: "true",
+        NETWORK: "devnet",
+        KEEPER_REDIS_URL: "https://fake-host.upstash.io",
+        KEEPER_REDIS_TOKEN: "   ",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /HA_ENABLED.*KEEPER_REDIS_URL.*KEEPER_REDIS_TOKEN/i,
+      );
+    });
+
+    it("accepts HA_ENABLED=true with both KEEPER_REDIS_URL and KEEPER_REDIS_TOKEN set", () => {
+      const env = {
+        HA_ENABLED: "true",
+        NETWORK: "devnet",
+        KEEPER_REDIS_URL: "https://fake-host.upstash.io",
+        KEEPER_REDIS_TOKEN: "fake-token",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
+
+    it("does NOT require KEEPER_REDIS_URL/KEEPER_REDIS_TOKEN when HA_ENABLED is unset", () => {
+      expect(() => validateKeeperEnvGuards({} as NodeJS.ProcessEnv)).not.toThrow();
+      expect(() =>
+        validateKeeperEnvGuards({ NETWORK: "testnet" } as NodeJS.ProcessEnv),
+      ).not.toThrow();
+    });
+
+    it("does NOT require KEEPER_REDIS_URL/KEEPER_REDIS_TOKEN when HA_ENABLED=false", () => {
       const env = { HA_ENABLED: "false" } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });


### PR DESCRIPTION
## Bug

`HA_ENABLED=true` with `KEEPER_REDIS_URL` unset silently falls back to standalone-leader mode instead of failing boot.

In `src/index.ts`, when `HA_ENABLED=true`, `getRedisClient()` is called to back the Redis-coordinated `LeaderLock`. If `KEEPER_REDIS_URL` is unset (a missed secret on a new replica, a typo, a partial rollout), `getRedisClient()` returns `null` (`src/lib/redis-client.ts`), `leaderLock` becomes `null`, and `setLeaderCheck(() => true)` makes the node unconditionally report itself as leader. The only signal is a `logger.warn` — no throw, no boot failure.

## Impact

On a multi-replica HA deployment, a single misconfigured replica becomes a standalone "always leader" running concurrently alongside correctly-coordinated replicas. Both sign and submit liquidations/cranks/oracle pushes independently — duplicate transactions, doubled keeper spend (the budget circuit breaker is process-local, not shared across replicas), and potential conflicting on-chain state changes. There is no alerting, since nothing in this path actually errors.

`validateKeeperEnvGuards()` already validates that `NETWORK` is set whenever `HA_ENABLED=true` (the existing A.3 guard, written for the same split-brain bug class) but has no equivalent check for `KEEPER_REDIS_URL`/`KEEPER_REDIS_TOKEN`.

## Root cause

`src/env-guards.ts`'s `HA_ENABLED=true` validation block checks `NETWORK` but never checks Redis configuration. The standalone-leader fallback in `src/index.ts` (intended for the legitimate non-HA case) is reached identically whether HA is genuinely disabled or just misconfigured — the two cases are indistinguishable at runtime, and only the latter is dangerous.

## Fix

Add the same fail-fast boot-time validation already used for the `NETWORK` check: inside the existing `if (env.HA_ENABLED === "true")` block in `validateKeeperEnvGuards()`, require `KEEPER_REDIS_URL` and `KEEPER_REDIS_TOKEN` to both be present (non-empty after trim). A misconfigured replica now fails to boot with a clear error instead of silently joining the fleet as a rogue extra leader.

This was chosen over alternatives:
- **Putting the check only in `index.ts`**: rejected — `env-guards.ts` is the established convention for HA-coherence checks (the sibling `NETWORK` check for the same `HA_ENABLED=true` condition already lives there); splitting one HA-coherence concern across two files makes it harder to audit "what does HA require" in one place.
- **Making `getRedisClient()` itself throw on a missing URL**: rejected — that function's null-return for "no `KEEPER_REDIS_URL`" is correct, load-bearing behavior for the legitimate non-HA caller path. Overloading it with an implicit `HA_ENABLED` dependency it doesn't otherwise know about would be surprising and couple two different callers' needs.

The check only validates presence (not connectivity) — actual Redis reachability failures surface later at first `LeaderLock` operation, unchanged from today.

## Test results

New tests added to `tests/env-guards.test.ts` (written first, confirmed failing against the unfixed code, then confirmed passing after the fix):

```
 Test Files  1 passed (1)
      Tests  66 passed (66)
```

Full suite, post-fix:

```
 Test Files  80 passed | 2 skipped (82)
      Tests  830 passed | 33 skipped (863)
```

`pnpm build` passes cleanly.

Two pre-existing tests (`"accepts HA_ENABLED=true + NETWORK=mainnet"` / `"... + NETWORK=devnet"`) were updated to include `KEEPER_REDIS_URL`/`KEEPER_REDIS_TOKEN` in their fixtures, since they were previously asserting the exact gap this PR closes.

## Compatibility note

A deployment currently running `HA_ENABLED=true` without `KEEPER_REDIS_URL` set will now fail to boot (previously it ran degraded/split-brain-prone). To fix: set `KEEPER_REDIS_URL`/`KEEPER_REDIS_TOKEN`, or set `HA_ENABLED=false` for a single-replica deployment. No CI workflows, `docker-compose` configs, or `railway.toml` in this repo set `HA_ENABLED=true` without Redis vars today, so nothing in-repo breaks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * High Availability mode now enforces stricter validation: when enabled, Redis URL and token configuration must be properly set and non-empty. Validation will fail if either is missing or contains only whitespace, ensuring HA mode is correctly configured before operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->