### PR TITLE
fix(keeper): close liquidation dedup race across cycle boundary

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -383,6 +383,18 @@ export class LiquidationService {
   private _cycleSeenPositions = new Set<string>();
   private _cycleOwnerCounts = new Map<string, number>();
   private static readonly MAX_LIQ_PER_OWNER_PER_CYCLE = 3;
+  // H-1: positions with a liquidate() call currently in flight (added before
+  // awaiting liquidate(), removed in a finally once it settles). Intentionally
+  // separate from _cycleSeenPositions above: that Set is cleared at the start
+  // of every polling cycle (scanAndLiquidateAll) to bound the per-cycle dedup
+  // window, but clearing it must never erase the fact that a liquidate() call
+  // for a position is still physically executing -- otherwise a poll cycle
+  // that starts while an event-driven liquidate() is mid-flight (multiple
+  // sequential RPC round trips, easily outlasting one cycle) can re-target
+  // and double-submit the same on-chain account before the first tx confirms.
+  // gatedLiquidate is the sole entry point for both the polling path and the
+  // LaserStream event path, so guarding here covers both unconditionally.
+  private readonly _inFlightPositions = new Set<string>();
   // B5: collapse per-liquidation Discord alerts into a single summary alert per
   // market within a 5 s window — prevents cascade-driven channel flooding.
   private readonly _liquidationAlertAggregator = new AlertAggregator(
@@ -608,6 +620,17 @@ export class LiquidationService {
     const positionKey = candidate.v17PortfolioPubkey
       ? `${candidate.slabAddress}:v17:${candidate.v17PortfolioPubkey.toBase58()}`
       : `${candidate.slabAddress}:v12:${candidate.accountIdx}`;
+    // H-1: an in-flight liquidate() for this exact position (started by
+    // either the polling path or the event-driven path) takes priority over
+    // the per-cycle dedup set, which can be cleared out from under us by a
+    // concurrent scanAndLiquidateAll() while we're still awaiting RPCs below.
+    if (this._inFlightPositions.has(positionKey)) {
+      logger.debug("Skipping position with an in-flight liquidate() call", {
+        positionKey,
+        owner: candidate.owner.slice(0, 8),
+      });
+      return null;
+    }
     if (this._cycleSeenPositions.has(positionKey)) {
       logger.debug("Skipping position already targeted this cycle", {
         positionKey,
@@ -625,12 +648,19 @@ export class LiquidationService {
     }
     this._cycleSeenPositions.add(positionKey);
     this._cycleOwnerCounts.set(candidate.owner, ownerCount + 1);
-    return (await this.liquidate(
-      market,
-      candidate.accountIdx,
-      candidate.v17PortfolioPubkey,
-      candidate.scanPriceE6,
-    )) ?? null;
+    this._inFlightPositions.add(positionKey);
+    try {
+      return (await this.liquidate(
+        market,
+        candidate.accountIdx,
+        candidate.v17PortfolioPubkey,
+        candidate.scanPriceE6,
+      )) ?? null;
+    } finally {
+      // Always release, regardless of success, a returned null (race-
+      // condition abort inside liquidate()), or an unexpected thrown error.
+      this._inFlightPositions.delete(positionKey);
+    }
   }
 
   /**

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -952,4 +952,152 @@ describe('LiquidationService', () => {
       expect(liquidateSpy).toHaveBeenCalledTimes(2);
     });
   });
+
+  // H-1: scanAndLiquidateAll's per-cycle clear() wiped _cycleSeenPositions
+  // even while a liquidate() call from a PREVIOUS cycle (or the LaserStream
+  // event path) was still awaiting RPCs/tx confirmation, letting the next
+  // cycle re-liquidate the same position before the first attempt landed.
+  describe('H-1: in-flight liquidation guard survives cycle-boundary clear()', () => {
+    function makeMarketAt(slabAddr: string) {
+      return {
+        slabAddress: { toBase58: () => slabAddr, equals: () => false },
+        programId: { toBase58: () => 'ProgramId1111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'Mint111111111111111111111111111111111111' },
+          oracleAuthority: mockZeroKey(),
+          indexFeedId: mockNonZeroKey('feed'),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+      };
+    }
+
+    function makeCandidate(slabAddress: string, accountIdx: number, owner: string) {
+      return {
+        slabAddress,
+        accountIdx,
+        owner,
+        positionSize: 1_000n,
+        capital: 100n,
+        pnl: -50n,
+        marginRatio: 4.0,
+        maintenanceMarginBps: 500n,
+      };
+    }
+
+    it('does not start a second liquidate() for a position whose prior liquidate() is still in flight when the next cycle clears _cycleSeenPositions', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const owner = 'OwnerInFlight11111111111111111111111111111';
+      const slab = 'SlabInFlight111111111111111111111111111111';
+
+      vi.spyOn(svc, 'scanMarket').mockImplementation(
+        async (market: any) =>
+          [makeCandidate(market.slabAddress.toBase58(), 9, owner)] as any,
+      );
+
+      // liquidate() never resolves until released -- simulates the
+      // multi-second RPC round trips (fresh slab/portfolio fetch, oracle
+      // resolve, send+confirm) that happen between adding to the dedup set
+      // and the tx actually landing on-chain.
+      let release!: (sig: string | null) => void;
+      const pending = new Promise<string | null>((resolve) => { release = resolve; });
+      const liquidateSpy = vi.spyOn(svc, 'liquidate').mockReturnValue(pending);
+
+      const markets = new Map([[slab, { market: makeMarketAt(slab) as any }]]);
+
+      // Cycle 1 kicks off gatedLiquidate -> liquidate(), which hangs.
+      const cycle1 = svc.scanAndLiquidateAll(markets);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Cycle 2 starts WHILE cycle 1's liquidate() is still in flight. Its
+      // unconditional clear() of _cycleSeenPositions/_cycleOwnerCounts must
+      // not let a second liquidate() start for the same position.
+      const cycle2 = await svc.scanAndLiquidateAll(markets);
+
+      expect(liquidateSpy).toHaveBeenCalledTimes(1);
+      expect(cycle2.liquidated).toBe(0);
+
+      release('sig-1');
+      const cycle1Result = await cycle1;
+      expect(cycle1Result.liquidated).toBe(1);
+      expect(liquidateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows retry once the in-flight liquidate() has fully settled', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const owner = 'OwnerRetry111111111111111111111111111111111';
+      const slab = 'SlabRetry11111111111111111111111111111111111';
+
+      vi.spyOn(svc, 'scanMarket').mockImplementation(
+        async (market: any) =>
+          [makeCandidate(market.slabAddress.toBase58(), 3, owner)] as any,
+      );
+      const liquidateSpy = vi.spyOn(svc, 'liquidate').mockResolvedValue('mock-liq-sig');
+
+      const markets = new Map([[slab, { market: makeMarketAt(slab) as any }]]);
+
+      await svc.scanAndLiquidateAll(markets);
+      const second = await svc.scanAndLiquidateAll(markets);
+
+      // Once the first liquidate() resolved, the in-flight guard released
+      // the key -- the next cycle's legitimate partial-fill retry must work.
+      expect(liquidateSpy).toHaveBeenCalledTimes(2);
+      expect(second.liquidated).toBe(1);
+    });
+
+    it('releases the in-flight guard when liquidate() resolves to null (pre-submit recheck abort)', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const owner = 'OwnerAbort1111111111111111111111111111111';
+      const slab = 'SlabAbort11111111111111111111111111111111';
+      const market = makeMarketAt(slab);
+      const candidate = makeCandidate(slab, 2, owner);
+
+      const liquidateSpy = vi
+        .spyOn(svc, 'liquidate')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('sig-retry');
+
+      const first = await (svc as any).gatedLiquidate(market, candidate);
+      expect(first).toBeNull();
+
+      // Simulate the next polling cycle's boundary (scanAndLiquidateAll
+      // clears the per-cycle dedup state -- that part is unrelated to this
+      // test, which targets _inFlightPositions specifically).
+      (svc as any)._cycleSeenPositions.clear();
+      (svc as any)._cycleOwnerCounts.clear();
+
+      // A null (aborted) resolution must release the in-flight guard too,
+      // not just a successful signature -- otherwise every legitimate
+      // recheck-abort would permanently wedge the position.
+      const second = await (svc as any).gatedLiquidate(market, candidate);
+      expect(second).toBe('sig-retry');
+      expect(liquidateSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('blocks a concurrent gatedLiquidate call for the same position regardless of which path invoked it', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const owner = 'OwnerCrossPath111111111111111111111111111';
+      const slab = 'SlabCrossPath111111111111111111111111111111';
+      const market = makeMarketAt(slab);
+      const candidate = makeCandidate(slab, 5, owner);
+
+      let release!: (sig: string | null) => void;
+      const pending = new Promise<string | null>((resolve) => { release = resolve; });
+      const liquidateSpy = vi.spyOn(svc, 'liquidate').mockReturnValue(pending);
+
+      // First call (e.g. the LaserStream event path) starts a liquidation.
+      const firstCall = (svc as any).gatedLiquidate(market, candidate);
+      await Promise.resolve();
+
+      // Second call (e.g. the polling path re-discovering the same account)
+      // must be blocked while the first is still outstanding.
+      const secondResult = await (svc as any).gatedLiquidate(market, candidate);
+      expect(secondResult).toBeNull();
+      expect(liquidateSpy).toHaveBeenCalledTimes(1);
+
+      release('sig-first');
+      expect(await firstCall).toBe('sig-first');
+    });
+  });
 });

--- a/tests/v17-liquidation-dedup.poc.test.ts
+++ b/tests/v17-liquidation-dedup.poc.test.ts
@@ -20,12 +20,16 @@ function makeHarness(): {
     ) => Promise<string | null>;
     _cycleSeenPositions: Set<string>;
     _cycleOwnerCounts: Map<string, number>;
+    _inFlightPositions: Set<string>;
     liquidate: ReturnType<typeof vi.fn>;
   };
 } {
   const service = Object.create(LiquidationService.prototype);
   service._cycleSeenPositions = new Set<string>();
   service._cycleOwnerCounts = new Map<string, number>();
+  // H-1: bypassing the constructor via Object.create skips class field
+  // initializers, so this must be seeded explicitly too.
+  service._inFlightPositions = new Set<string>();
   service.liquidate = vi.fn(async () => `sig-${service.liquidate.mock.calls.length}`);
   return { service };
 }


### PR DESCRIPTION
## Bug

`LiquidationService` can submit two liquidation transactions for the same account if one is still in flight when a polling cycle boundary is crossed.

`gatedLiquidate()` shares one per-cycle dedup `Set`/`Map` (`_cycleSeenPositions`, `_cycleOwnerCounts`) between two independent callers: the polling loop (`scanAndLiquidateAll`) and the LaserStream event-driven path (`onAccount` → debounced `scanMarket` → `gatedLiquidate`). `scanAndLiquidateAll` unconditionally `.clear()`s both at the start of every cycle.

`gatedLiquidate` adds the position's key to the dedup set *before* awaiting the actual `liquidate()` call, which does several sequential RPC round trips (fresh slab/portfolio re-fetch with retries, oracle/clock read, tx send via the shared queue, confirmation poll) — easily several seconds to tens of seconds under RPC latency, routinely longer than one polling interval.

## Impact

If a poll cycle's `clear()` fires while an event-driven `liquidate()` call for the same position is still outstanding, the dedup entry is wiped. The poll cycle's own scan then finds the same account (still showing as undercollateralized, since the first liquidation tx hasn't landed/confirmed yet) and submits a second `liquidate()` for it — before the first has even confirmed. Best case: a wasted duplicate transaction and fee. The existing pre-submit on-chain recheck inside `liquidate()` does not catch this, since it only re-verifies against the *current* on-chain state, which is unchanged until the first transaction actually lands.

## Root cause

`_cycleSeenPositions` conflates two distinct questions: "was this position already targeted this cycle" (intentionally cycle-scoped, cleared every cycle to allow legitimate cross-cycle retry of partially-filled liquidations) and "is a `liquidate()` call for this position currently executing" (must not be cycle-scoped, since a call can outlive the cycle boundary and is shared across both the polling and event-driven callers).

## Fix

Adds a separate `_inFlightPositions: Set<string>` guard in `LiquidationService`, intentionally decoupled from the per-cycle bookkeeping:
- Checked first in `gatedLiquidate`, before the existing `_cycleSeenPositions` check.
- Added immediately before the `await this.liquidate(...)` call (no intervening `await`, so no caller can observe an inconsistent state).
- Removed in a `finally`, so it releases on success, a returned `null` (e.g. a pre-submit recheck abort), or an unexpected thrown error.
- **Never cleared by `scanAndLiquidateAll`** — the per-cycle clear() continues to work exactly as before for `_cycleSeenPositions`/`_cycleOwnerCounts`.

Since `gatedLiquidate` is the sole entry point for both the polling path and the event-driven path, this closes the race uniformly for both, without changing the per-owner cap (`MAX_LIQ_PER_OWNER_PER_CYCLE`) or the legitimate cross-cycle partial-fill retry behavior.

## Test results

New tests added to `tests/services/liquidation.test.ts` (written first, confirmed failing against the unfixed code — 2 of 4 failed, including a timeout-based repro of the actual race — then confirmed passing after the fix):

```
 Test Files  1 passed (1)
      Tests  24 passed (24)
```

`tests/v17-liquidation-dedup.poc.test.ts` uses `Object.create(LiquidationService.prototype)` to unit-test `gatedLiquidate` in isolation, which bypasses class field initializers — updated its harness to also seed `_inFlightPositions = new Set()`.

Full suite, post-fix:

```
 Test Files  80 passed | 2 skipped (82)
      Tests  834 passed | 33 skipped (867)
```

`pnpm build` passes cleanly.