### PR TITLE
fix(keeper): skip sends that simulation proves will fail on-chain

### DIFF
--- a/src/lib/cu-estimator.ts
+++ b/src/lib/cu-estimator.ts
@@ -13,6 +13,36 @@ const logger = createLogger("keeper:cu-estimator");
 const DEFAULT_MARGIN = 1.1;
 const DEFAULT_FALLBACK_CU = 1_400_000;
 
+export interface CuEstimateResult {
+  cu: number;
+  /**
+   * H-3: true iff simulation ran to completion and the program itself
+   * rejected the instructions (an `InstructionError`) -- a deterministic
+   * failure that a real send of the same instructions against the same
+   * on-chain state would revert identically, wasting a real fee.
+   *
+   * Deliberately narrow: `unitsConsumed` is commonly positive even when the
+   * simulated tx fails (CU is metered up to the point of failure), so it is
+   * NOT used as a success signal. But not every non-null `err` proves a real
+   * send would also fail -- transaction-level errors like "BlockhashNotFound"
+   * or "AccountInUse" can be artifacts of how THIS estimator simulates (a
+   * throwaway blockhash relying on replaceRecentBlockhash, or a transient
+   * write-lock collision with another in-flight tx) rather than evidence the
+   * instructions themselves are doomed. Only the InstructionError shape --
+   * the program actually ran and rejected the request -- is treated as proof.
+   */
+  provenToFail: boolean;
+  simError?: unknown;
+}
+
+function isProvenToFail(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "InstructionError" in (err as Record<string, unknown>)
+  );
+}
+
 export class CuEstimator {
   private readonly _margin: number;
   private readonly _fallback: number;
@@ -30,7 +60,7 @@ export class CuEstimator {
     connection: Connection,
     instructions: TransactionInstruction[],
     signers: Keypair[],
-  ): Promise<number> {
+  ): Promise<CuEstimateResult> {
     try {
       const feePayer = signers[0]?.publicKey ?? PublicKey.default;
       // Use a throwaway blockhash — replaceRecentBlockhash=true will overwrite it.
@@ -52,15 +82,27 @@ export class CuEstimator {
           err: sim.value.err,
           logs: sim.value.logs?.slice(0, 3),
         });
-        return this._fallback;
+        return { cu: this._fallback, provenToFail: false };
       }
 
-      return Math.ceil(consumed * this._margin);
+      // H-3: unitsConsumed > 0 does not mean the tx would succeed -- the
+      // simulator meters CU up to the point of failure, so a reverting
+      // simulation routinely reports a normal-looking positive value too.
+      if (isProvenToFail(sim.value.err)) {
+        logger.warn("Simulation proved the transaction will fail — flagging for caller to skip", {
+          err: sim.value.err,
+          unitsConsumed: consumed,
+          logs: sim.value.logs?.slice(0, 5),
+        });
+        return { cu: Math.ceil(consumed * this._margin), provenToFail: true, simError: sim.value.err };
+      }
+
+      return { cu: Math.ceil(consumed * this._margin), provenToFail: false };
     } catch (err) {
       logger.warn("CU simulation failed — using fallback CU limit", {
         error: err instanceof Error ? err.message : String(err),
       });
-      return this._fallback;
+      return { cu: this._fallback, provenToFail: false };
     }
   }
 }

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -112,6 +112,9 @@ function isMainnetSender(): boolean {
 interface EstimateCostResult {
   estimatedCost: number;
   simulatedCu: number;
+  /** H-3: true iff simulation proved this exact tx would fail on-chain. */
+  provenToFail: boolean;
+  simError?: unknown;
 }
 
 /**
@@ -129,7 +132,7 @@ async function estimateCost(
     .flatMap((ix) => ix.keys.map((k) => k.pubkey.toBase58()))
     .filter((v, i, a) => a.indexOf(v) === i);
 
-  const [microLamports, simulatedCu] = await Promise.all([
+  const [microLamports, cuResult] = await Promise.all([
     getPriorityFeeEstimator().estimate(accountKeys, TIER_MAP[txType]),
     getCuEstimator().estimate(connection, instructions, signers),
   ]);
@@ -138,7 +141,12 @@ async function estimateCost(
     ? parseInt(process.env.JITO_TIP_LAMPORTS ?? "200000", 10)
     : 0;
 
-  return { estimatedCost: estimateLamportCost(microLamports, simulatedCu, jitoTip), simulatedCu };
+  return {
+    estimatedCost: estimateLamportCost(microLamports, cuResult.cu, jitoTip),
+    simulatedCu: cuResult.cu,
+    provenToFail: cuResult.provenToFail,
+    simError: cuResult.simError,
+  };
 }
 
 export interface KeeperSendResult {
@@ -206,7 +214,27 @@ export async function keeperSend(
     ...instructions,
   ];
 
-  const { estimatedCost, simulatedCu } = await estimateCost(connection, instructions, signers, txType);
+  const { estimatedCost, simulatedCu, provenToFail, simError } = await estimateCost(
+    connection,
+    instructions,
+    signers,
+    txType,
+  );
+
+  // H-3: simulateTransaction can report a positive unitsConsumed even when
+  // the tx fails (CU is metered up to the point of failure), so CuEstimator
+  // separately proves failure via the program's own InstructionError. Abort
+  // before the budget gate -- no reservation is taken, so this is a pure
+  // skip, same "don't treat as failure" contract as the leader-check and
+  // budget-gate paths below.
+  if (provenToFail) {
+    logger.warn("keeperSend: simulation proved tx will fail — skipping send", {
+      txType,
+      simulatedCu,
+      err: simError,
+    });
+    return null;
+  }
 
   if (!budget.canSpend(estimatedCost, txType)) {
     logger.warn("Budget gate: refusing send — budget exhausted or halted", {

--- a/tests/lib/budget-cycle-reset.test.ts
+++ b/tests/lib/budget-cycle-reset.test.ts
@@ -27,7 +27,7 @@ vi.mock("../../src/lib/priority-fee.js", () => {
   return { HeliusPriorityFeeEstimator };
 });
 vi.mock("../../src/lib/cu-estimator.js", () => {
-  class CuEstimator { estimate = vi.fn(async () => 200_000); }
+  class CuEstimator { estimate = vi.fn(async () => ({ cu: 200_000, provenToFail: false })); }
   return { CuEstimator };
 });
 

--- a/tests/lib/budget-success-rate-isolation.test.ts
+++ b/tests/lib/budget-success-rate-isolation.test.ts
@@ -30,7 +30,7 @@ vi.mock("../../src/lib/priority-fee.js", () => {
   return { HeliusPriorityFeeEstimator };
 });
 vi.mock("../../src/lib/cu-estimator.js", () => {
-  class CuEstimator { estimate = vi.fn(async () => 200_000); }
+  class CuEstimator { estimate = vi.fn(async () => ({ cu: 200_000, provenToFail: false })); }
   return { CuEstimator };
 });
 

--- a/tests/lib/cu-estimator.test.ts
+++ b/tests/lib/cu-estimator.test.ts
@@ -21,7 +21,7 @@ function makeDummyIx(): TransactionInstruction {
   });
 }
 
-function makeConnection(unitsConsumed: number | undefined, err: string | null = null) {
+function makeConnection(unitsConsumed: number | undefined, err: unknown = null) {
   return {
     simulateTransaction: vi.fn(async () => ({
       value: {
@@ -40,7 +40,8 @@ describe("CuEstimator", () => {
 
     const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
 
-    expect(result).toBe(Math.ceil(100_000 * 1.1));
+    expect(result.cu).toBe(Math.ceil(100_000 * 1.1));
+    expect(result.provenToFail).toBe(false);
   });
 
   it("returns fallback when unitsConsumed is 0", async () => {
@@ -49,7 +50,8 @@ describe("CuEstimator", () => {
 
     const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
 
-    expect(result).toBe(1_400_000);
+    expect(result.cu).toBe(1_400_000);
+    expect(result.provenToFail).toBe(false);
   });
 
   it("returns fallback when unitsConsumed is undefined", async () => {
@@ -58,7 +60,8 @@ describe("CuEstimator", () => {
 
     const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
 
-    expect(result).toBe(500_000);
+    expect(result.cu).toBe(500_000);
+    expect(result.provenToFail).toBe(false);
   });
 
   it("returns fallback when simulateTransaction throws", async () => {
@@ -71,7 +74,8 @@ describe("CuEstimator", () => {
 
     const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
 
-    expect(result).toBe(1_400_000);
+    expect(result.cu).toBe(1_400_000);
+    expect(result.provenToFail).toBe(false);
   });
 
   it("reads KEEPER_CU_SIMULATE_MARGIN and KEEPER_CU_FALLBACK_LIMIT from env", async () => {
@@ -83,7 +87,7 @@ describe("CuEstimator", () => {
       const conn = makeConnection(200_000);
       const estimator = new CuEstimator();
       const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
-      expect(result).toBe(Math.ceil(200_000 * 1.25));
+      expect(result.cu).toBe(Math.ceil(200_000 * 1.25));
     } finally {
       if (origMargin === undefined) delete process.env.KEEPER_CU_SIMULATE_MARGIN;
       else process.env.KEEPER_CU_SIMULATE_MARGIN = origMargin;
@@ -101,7 +105,7 @@ describe("CuEstimator", () => {
       } as any;
       const estimator = new CuEstimator();
       const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
-      expect(result).toBe(750_000);
+      expect(result.cu).toBe(750_000);
     } finally {
       if (origFallback === undefined) delete process.env.KEEPER_CU_FALLBACK_LIMIT;
       else process.env.KEEPER_CU_FALLBACK_LIMIT = origFallback;
@@ -123,6 +127,73 @@ describe("CuEstimator", () => {
     );
   });
 
+  // H-3: simulateTransaction can report a positive unitsConsumed even when
+  // the simulated tx fails -- CU is metered up to the point of failure, not
+  // just on success. provenToFail must be gated on the program's own
+  // InstructionError, not on unitsConsumed, and must NOT fire for
+  // transaction-level errors that can be artifacts of how THIS estimator
+  // simulates (a throwaway blockhash, a transient write-lock collision) --
+  // those would otherwise cause a legitimate send to be wrongly skipped.
+  describe("H-3: provenToFail classification", () => {
+    it("provenToFail=true when err is an InstructionError, even with unitsConsumed > 0", async () => {
+      const conn = makeConnection(50_000, { InstructionError: [0, { Custom: 6001 }] });
+      const estimator = new CuEstimator({ margin: 1.1, fallback: 1_400_000 });
+
+      const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+
+      expect(result.provenToFail).toBe(true);
+      expect(result.simError).toEqual({ InstructionError: [0, { Custom: 6001 }] });
+      // cu is still populated from the (positive) consumed value so a caller
+      // has a usable number even if it decides to log/inspect rather than skip.
+      expect(result.cu).toBe(Math.ceil(50_000 * 1.1));
+    });
+
+    it("provenToFail=false when err is null (success path unaffected)", async () => {
+      const conn = makeConnection(50_000, null);
+      const estimator = new CuEstimator({ margin: 1.1, fallback: 1_400_000 });
+
+      const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+
+      expect(result.provenToFail).toBe(false);
+      expect(result.cu).toBe(Math.ceil(50_000 * 1.1));
+    });
+
+    it("provenToFail=false for BlockhashNotFound (simulation artifact, not a real revert)", async () => {
+      // This estimator deliberately simulates with a throwaway blockhash and
+      // relies on replaceRecentBlockhash:true to swap it server-side -- a
+      // stale-snapshot BlockhashNotFound here is an artifact of that, not
+      // proof the real send (with a fresh blockhash) would fail too.
+      const conn = makeConnection(0, "BlockhashNotFound");
+      const estimator = new CuEstimator({ margin: 1.1, fallback: 1_400_000 });
+
+      const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+
+      expect(result.provenToFail).toBe(false);
+      expect(result.cu).toBe(1_400_000);
+    });
+
+    it("provenToFail=false for AccountInUse (transient write-lock contention)", async () => {
+      const conn = makeConnection(12_000, "AccountInUse");
+      const estimator = new CuEstimator({ margin: 1.1, fallback: 1_400_000 });
+
+      const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+
+      expect(result.provenToFail).toBe(false);
+    });
+
+    it("provenToFail=false when simulateTransaction throws (existing fallback path unchanged)", async () => {
+      const conn = {
+        simulateTransaction: vi.fn(async () => { throw new Error("RPC error"); }),
+      } as any;
+      const estimator = new CuEstimator({ margin: 1.1, fallback: 1_400_000 });
+
+      const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
+
+      expect(result.provenToFail).toBe(false);
+      expect(result.cu).toBe(1_400_000);
+    });
+  });
+
   // A.12: properties protect the CU-margin math. If the estimator ever returns
   // a value below `consumed`, the CU limit on-chain would be too tight and
   // the tx would land with InsufficientComputeUnits.
@@ -136,7 +207,7 @@ describe("CuEstimator", () => {
             const conn = makeConnection(consumed);
             const estimator = new CuEstimator({ margin, fallback: 1_400_000 });
             const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
-            return result >= consumed;
+            return result.cu >= consumed;
           },
         ),
         { numRuns: 200 },
@@ -152,7 +223,7 @@ describe("CuEstimator", () => {
             const conn = makeConnection(0);
             const estimator = new CuEstimator({ margin, fallback });
             const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
-            return result === fallback;
+            return result.cu === fallback;
           },
         ),
         { numRuns: 200 },
@@ -167,7 +238,7 @@ describe("CuEstimator", () => {
             const conn = makeConnection(consumed);
             const estimator = new CuEstimator({ margin: 1.1, fallback: 1_400_000 });
             const result = await estimator.estimate(conn, [makeDummyIx()], [Keypair.generate()]);
-            return result >= 1;
+            return result.cu >= 1;
           },
         ),
         { numRuns: 200 },

--- a/tests/lib/keeper-send-leader-gate.test.ts
+++ b/tests/lib/keeper-send-leader-gate.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../src/lib/priority-fee.js", () => {
   return { HeliusPriorityFeeEstimator };
 });
 vi.mock("../../src/lib/cu-estimator.js", () => {
-  class CuEstimator { estimate = vi.fn(async () => 200_000); }
+  class CuEstimator { estimate = vi.fn(async () => ({ cu: 200_000, provenToFail: false })); }
   return { CuEstimator };
 });
 

--- a/tests/lib/keeper-send.m12-poc.test.ts
+++ b/tests/lib/keeper-send.m12-poc.test.ts
@@ -38,7 +38,7 @@ vi.mock("../../src/lib/priority-fee.js", () => {
 vi.mock("../../src/lib/cu-estimator.js", () => {
   class CuEstimator {
     // Simulator says 200k. Reality (below) will be 600k.
-    estimate = vi.fn(async () => 200_000);
+    estimate = vi.fn(async () => ({ cu: 200_000, provenToFail: false }));
   }
   return { CuEstimator };
 });

--- a/tests/lib/keeper-send.m13-poc.test.ts
+++ b/tests/lib/keeper-send.m13-poc.test.ts
@@ -41,7 +41,7 @@ vi.mock("../../src/lib/cu-estimator.js", () => {
   class CuEstimator {
     estimate = vi.fn(async () => {
       await new Promise((r) => setTimeout(r, 50));
-      return 200_000;
+      return { cu: 200_000, provenToFail: false };
     });
   }
   return { CuEstimator };

--- a/tests/lib/keeper-send.test.ts
+++ b/tests/lib/keeper-send.test.ts
@@ -17,9 +17,10 @@ vi.mock("../../src/lib/priority-fee.js", () => {
   return { HeliusPriorityFeeEstimator };
 });
 
+const mockCuEstimate = vi.fn(async () => ({ cu: 200_000, provenToFail: false }));
 vi.mock("../../src/lib/cu-estimator.js", () => {
   class CuEstimator {
-    estimate = vi.fn(async () => 200_000);
+    estimate = mockCuEstimate;
   }
   return { CuEstimator };
 });
@@ -81,6 +82,47 @@ describe("keeperSend", () => {
 
     expect(result).toBeNull();
     expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+  });
+
+  // H-3: CuEstimator can prove (via the program's own InstructionError) that
+  // a transaction will fail on-chain. keeperSend must skip the send entirely
+  // -- sending it anyway (often with skipPreflight:true) would pay a real
+  // fee on a guaranteed revert.
+  describe("H-3: aborts when simulation proves the tx will fail", () => {
+    it("returns null and never calls sendWithRetryKeeper", async () => {
+      mockCuEstimate.mockResolvedValueOnce({
+        cu: 50_000,
+        provenToFail: true,
+        simError: { InstructionError: [0, { Custom: 6001 }] },
+      });
+
+      const result = await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+
+      expect(result).toBeNull();
+      expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+    });
+
+    it("does not reserve or record any budget spend", async () => {
+      mockCuEstimate.mockResolvedValueOnce({
+        cu: 50_000,
+        provenToFail: true,
+        simError: "InsufficientFundsForRent",
+      });
+
+      const before = budget.getStats();
+      await keeperSend(connection, [makeDummyIx()], [keypair], "liquidation", budget);
+      const after = budget.getStats();
+
+      expect(after.cycleTxCount).toBe(before.cycleTxCount);
+      expect(after.cycleSpend).toBe(before.cycleSpend);
+    });
+
+    it("still sends normally when provenToFail is false (happy path unaffected)", async () => {
+      const result = await keeperSend(connection, [makeDummyIx()], [keypair], "crank", budget);
+
+      expect(result).not.toBeNull();
+      expect(shared.sendWithRetryKeeper).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("records success in budget on successful send", async () => {


### PR DESCRIPTION
## Bug

`CuEstimator.estimate()` (`src/lib/cu-estimator.ts`) only checks `sim.value.unitsConsumed` to decide whether a simulation is usable — it never inspects `sim.value.err`. If `unitsConsumed` is positive, it returns a normal margined CU estimate regardless of whether the simulation actually succeeded.

## Impact

Solana's simulator commonly reports a positive `unitsConsumed` even when the simulated transaction fails — CU is metered up to the point of failure, not just on success. So a transaction the program itself rejects (a custom program error, a failed account constraint, etc.) still gets a normal-looking CU estimate from `CuEstimator`, and nothing else catches it before broadcast — `keeperSend()` sends it for real, often with `skipPreflight: true`, paying a real fee for a transaction that was already provably doomed.

## Root cause

The estimator's only gate (`typeof consumed !== "number" || consumed <= 0`) conflates "did the simulator give us a usable CU number" with "would this transaction actually succeed" — two different questions. `sim.value.err` is the simulator's authoritative verdict on the latter; `unitsConsumed` says nothing about it.

## Fix

`CuEstimator.estimate()` now returns `{ cu, provenToFail, simError? }` instead of a bare number. `provenToFail` is set when simulation reports the program's own `InstructionError` — a deterministic failure: a real send of the same instructions against the same on-chain state will revert identically.

The classification is deliberately narrow. It does **not** treat every non-null `err` as proof of failure, because this estimator simulates against a throwaway blockhash relying on `replaceRecentBlockhash: true`, and transaction-level errors like `BlockhashNotFound` or `AccountInUse` can be artifacts of that simulation setup (a stale bank snapshot, a transient write-lock collision with another in-flight tx) rather than evidence the real send — with a fresh blockhash, moments later — would also fail. Treating those as fatal would trade one bug (paying a fee on a proven revert) for a worse one (silently dropping legitimate liquidations/cranks on a benign simulation artifact). Only the `InstructionError` shape is unambiguous enough to abort on.

`keeperSend()` checks `provenToFail` immediately after `estimateCost()` resolves, before the budget gate, and returns `null` — the same "skip, don't treat as failure" contract already documented and used for the leader-check and budget-exhausted paths, so no caller-side changes are needed anywhere in `crank.ts`/`liquidation.ts`.

## Test results

New tests added to `tests/lib/cu-estimator.test.ts` and `tests/lib/keeper-send.test.ts` (written first, confirmed failing against the unfixed code, then confirmed passing after the fix — stashing just the two source files reproduced 24 of 40 failures across both test files):

```
 Test Files  2 passed (2)
      Tests  39 passed | 1 skipped (40)
```

Four other test files independently mock `CuEstimator` and needed their mocks updated to the new return shape (`tests/lib/budget-cycle-reset.test.ts`, `tests/lib/budget-success-rate-isolation.test.ts`, `tests/lib/keeper-send-leader-gate.test.ts`, `tests/lib/keeper-send.m12-poc.test.ts`, `tests/lib/keeper-send.m13-poc.test.ts`) — mechanical updates only, no behavioral changes to those tests.

Full suite, post-fix:

```
 Test Files  80 passed | 2 skipped (82)
      Tests  833 passed | 33 skipped (866)
```

`pnpm build` passes cleanly.