### PR TITLE
fix(keeper): roll cycle and event-source the hour/day spend in adjustForRealizedCost

### DIFF
--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -375,13 +375,41 @@ export class KeeperBudget {
     this._realizedCostDriftLamports += delta;
     this._realizedCostSamples++;
 
+    // H-4: this runs ~5s after the original send (see keeper-send.ts's
+    // scheduleRealizedCostReconciliation), which can straddle a cycle-window
+    // boundary (default 30s). Roll first, same as canSpend/recordTx/getStats,
+    // so the cycle adjustment always lands in whichever cycle is current
+    // right now rather than a stale pre-roll snapshot that's about to be
+    // wiped by the next roll.
+    const nowMs = this._now();
+    this._rollCycleIfElapsed(nowMs);
+
     // Adjust running totals. Clamp at 0 so a large negative reconciliation
     // (e.g., we estimated 50k but only spent 5k) doesn't drive counters
     // negative — that would falsely make the budget look "underused" and
     // allow more spend than the operator intended in this cycle.
     this._cycleSpend = Math.max(0, this._cycleSpend + delta);
-    this._hourSpendSum = Math.max(0, this._hourSpendSum + delta);
-    this._daySpendSum = Math.max(0, this._daySpendSum + delta);
+
+    // Route the hour/day adjustment through the same SpendEvent + _pruneOld
+    // mechanism recordTx() uses, instead of mutating the scalars directly —
+    // _pruneOld only knows how to decrement these sums by shifting entries
+    // off _hourEvents/_dayEvents, so a bare scalar mutation here would never
+    // be backed by a prunable event and would permanently desync the sum
+    // from the event log. Store the amount ACTUALLY applied to the scalar
+    // (post zero-floor clamp), not the raw delta — otherwise pruning this
+    // event later would subtract more (or less) than was ever really added,
+    // desyncing the scalar in the opposite direction once it ages out.
+    const hourApplied = Math.max(0, this._hourSpendSum + delta) - this._hourSpendSum;
+    if (hourApplied !== 0) {
+      this._hourSpendSum += hourApplied;
+      this._hourEvents.push({ ts: nowMs, lamports: hourApplied });
+    }
+    const dayApplied = Math.max(0, this._daySpendSum + delta) - this._daySpendSum;
+    if (dayApplied !== 0) {
+      this._daySpendSum += dayApplied;
+      this._dayEvents.push({ ts: nowMs, lamports: dayApplied });
+    }
+    this._pruneOld(nowMs);
 
     if (process.env.KEEPER_BUDGET_DEBUG === "true") {
       logger.debug("adjustForRealizedCost", {

--- a/tests/lib/budget.test.ts
+++ b/tests/lib/budget.test.ts
@@ -631,4 +631,89 @@ describe("KeeperBudget — M12 adjustForRealizedCost", () => {
     b.adjustForRealizedCost(150, 170, "crank"); // now cycleSpend = 170
     expect(b.canSpend(40, "crank")).toBe(false); // 170 + 40 = 210 > 200
   });
+
+  // H-4: adjustForRealizedCost never rolled the cycle window before touching
+  // _cycleSpend, so a reconciliation arriving after a cycle boundary (the
+  // 5s keeper-send.ts delay vs. a 30s default cycleWindowMs) blended its
+  // delta into whatever unrelated transactions had already landed in the
+  // NEW cycle. It also mutated _hourSpendSum/_daySpendSum directly with no
+  // backing SpendEvent, permanently desyncing them from what _pruneOld
+  // expects to decrement as entries age out.
+  describe("H-4: cycle-roll safety + hour/day event sync", () => {
+    it("rolls the cycle before applying a reconciliation that lands after the cycle window elapsed", () => {
+      const clock = makeClock();
+      const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000 }, { now: clock.now });
+
+      b.recordTx(100, "crank", "success"); // cycle A: cycleSpend = 100
+      expect(b.getStats().cycleSpend).toBe(100);
+
+      clock.advance(30_000); // cycle window elapses before reconciliation fires
+      b.recordTx(40, "crank", "success"); // unrelated tx lands in the NEW cycle B
+      expect(b.getStats().cycleSpend).toBe(40); // cycle A's 100 already rolled away
+
+      // Late reconciliation for the ORIGINAL (cycle A) tx: realized cost was
+      // 60 lamports higher than estimated.
+      b.adjustForRealizedCost(100, 160, "crank");
+
+      // The +60 must land in the cycle that's current NOW (cycle B), not get
+      // silently lost against a stale pre-roll snapshot of cycle A.
+      expect(b.getStats().cycleSpend).toBe(100); // 40 + 60
+    });
+
+    it("does not disturb the cycle counter when reconciliation arrives within the same (unrolled) cycle", () => {
+      const clock = makeClock();
+      const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000 }, { now: clock.now });
+      b.recordTx(100, "crank", "success");
+      clock.advance(5_000); // typical reconciliation delay, well under the 30s window
+      b.adjustForRealizedCost(100, 160, "crank");
+      expect(b.getStats().cycleSpend).toBe(160); // unchanged from pre-fix behavior
+    });
+
+    it("hourSpend/daySpend decay back to zero once both the original event and the delta event age out", () => {
+      const clock = makeClock();
+      const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+
+      b.recordTx(100, "crank", "success");
+      b.adjustForRealizedCost(100, 150, "crank"); // delta +50
+      expect(b.getStats().hourSpend).toBe(150);
+
+      // Pre-fix: the +50 was never backed by a SpendEvent, so hourSpend would
+      // stay at 150 forever, never pruned. Post-fix: it was pushed as its own
+      // event and prunes out along with the original 100 once the hour window
+      // elapses.
+      clock.advance(3_600_001);
+      const s = b.getStats();
+      expect(s.hourSpend).toBe(0);
+      expect(s.daySpend).toBe(150); // day window (24h) hasn't elapsed yet
+    });
+
+    it("a clamped negative delta event does not desync the scalar once it ages out (stores the applied amount, not the raw delta)", () => {
+      const clock = makeClock();
+      const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+
+      b.recordTx(50, "crank", "success"); // hourSpend = 50
+      // Raw delta = -200, but only 50 is available — clamps to 0. If the
+      // RAW -200 were stored as the event (instead of the -50 actually
+      // applied), pruning it later would subtract -200 (i.e. ADD 200) from
+      // a sum that only ever lost 50, desyncing it positive.
+      b.adjustForRealizedCost(250, 50, "crank");
+      expect(b.getStats().hourSpend).toBe(0);
+
+      clock.advance(3_600_001); // expire both events
+      const s = b.getStats();
+      expect(s.hourSpend).toBe(0); // must settle at exactly 0, never positive or negative
+      expect(s.daySpend).toBeGreaterThanOrEqual(0);
+    });
+
+    it("realizedCostDriftLamports always reflects the full unclamped delta, independent of cycle roll or hour/day clamping", () => {
+      const clock = makeClock();
+      const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000 }, { now: clock.now });
+      b.recordTx(100, "crank", "success");
+      clock.advance(30_000);
+      b.adjustForRealizedCost(100, 175, "crank");
+      const s = b.getStats();
+      expect(s.realizedCostDriftLamports).toBe(75);
+      expect(s.realizedCostSamples).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
## Bug

`keeperSend` schedules a budget reconciliation ~5 seconds after every transaction confirms (`scheduleRealizedCostReconciliation` in `src/lib/keeper-send.ts`), adjusting `KeeperBudget`'s running spend counters by the delta between the estimated and realized on-chain cost. `KeeperBudget.adjustForRealizedCost` (`src/lib/budget.ts`) had two bugs:

1. **Cross-cycle misattribution.** It never called `_rollCycleIfElapsed` before touching `_cycleSpend`, unlike every other mutator (`canSpend`, `recordTx`, `getStats`). The per-cycle window defaults to 30 seconds. If that window rolls over between the original send and the 5-second-delayed reconciliation — easily possible under any RPC latency or load — the delta gets applied to whatever `_cycleSpend` currently holds, which by then reflects entirely unrelated transactions that landed in the new cycle.

2. **Permanent hour/day desync.** It mutated `_hourSpendSum`/`_daySpendSum` directly instead of pushing a `SpendEvent`. `_pruneOld` only knows how to decay those sums by shifting entries off `_hourEvents`/`_dayEvents` as they age out of the window. Since no event ever backed the reconciliation adjustment, the scalar permanently desyncs from the event log the moment the *original* send's event ages out.

## Impact

Bug 1 can falsely trip a spend-cap halt on a cycle that didn't actually overspend (DoS), or mask real overspend by absorbing a negative adjustment into an unrelated cycle. Bug 2 is worse and doesn't self-heal: I confirmed it concretely in a test — record a 50-lamport spend, reconcile it down with a clamped negative delta (so the scalar floors at 0), then advance the clock past the 1-hour window. The original spend's event ages out and `_pruneOld` subtracts its 50 lamports from a scalar that was already at 0 — landing at **-50**, a negative spend total, because the reconciliation's effect was never backed by a prunable event in the first place.

## Fix

- Call `_rollCycleIfElapsed` at the top of `adjustForRealizedCost`, matching every other mutator, so the cycle adjustment always lands in whichever cycle is current rather than a stale pre-roll snapshot.
- Route the hour/day adjustment through the same `SpendEvent` + `_pruneOld` mechanism `recordTx` already uses. Critically, the pushed event stores the amount **actually applied** to the scalar (i.e. `Math.max(0, sum + delta) - sum`, after the existing zero-floor clamp), not the raw `delta` — otherwise a clamped adjustment's event would later get over-subtracted on prune, desyncing the scalar in the *opposite* direction once it ages out.
- `_realizedCostDriftLamports`/`_realizedCostSamples` telemetry is unchanged — it still always reflects the full unclamped signed delta, regardless of cycle roll or hour/day clamping, matching the existing documented contract.

I deliberately did not add the more elaborate "skip the cycle adjustment entirely if the cycle has rolled since the original send" refinement some analysis suggested — that requires reliably knowing which specific cycle the original tx belonged to, which in turn requires threading a captured cycle epoch through `keeperSend` → `scheduleRealizedCostReconciliation` → `adjustForRealizedCost`. Given the per-cycle window is an approximate burst limiter (not an authoritative historical ledger — once a cycle rolls, nothing else ever reads its totals again) and reconciliation deltas are small relative to typical cycle caps (priority-fee estimation error, not the base fee or Jito tip, which aren't estimated at all), the added complexity isn't proportionate. The hour/day windows — where real money-protection caps live and where sustained drift actually matters — get the fully correct, event-sourced fix.

## Test results

New tests added to `tests/lib/budget.test.ts` (written first, confirmed failing against the unfixed code, then confirmed passing after the fix — one of the two failures showed the unfixed code producing a **negative** `hourSpend`, exactly the desync described above):

```
 Test Files  1 passed (1)
      Tests  55 passed (55)
```

Full suite, post-fix:

```
 Test Files  80 passed | 2 skipped (82)
      Tests  834 passed | 33 skipped (867)
```

`pnpm build` passes cleanly.