### PR TITLE
fix(keeper): #247 — scanned counter only counts fulfilled scans (credit @v1ktorrr0x)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -1075,12 +1075,14 @@ export class LiquidationService {
       );
 
       for (let j = 0; j < batchResults.length; j++) {
-        scanned++;
         const result = batchResults[j]!;
         if (result.status === "rejected") {
+          // #247: a rejected scan was NOT successfully scanned — don't inflate
+          // the counter. Only fulfilled scans count toward `scanned`.
           logger.error("Market scan rejected", { error: result.reason });
           continue;
         }
+        scanned++;
         const candidates = result.value;
         candidateCount += candidates.length;
 


### PR DESCRIPTION
Moves `scanned++` past the rejected-scan `continue` so failed scans no longer inflate the metric. Metrics-only. This was the one issue from the closed bundle PR #272 that no contributor PR covered. Credit @v1ktorrr0x (#247). Closes #247.