### PR TITLE
fix(keeper): close stop()/connect() race in AccountLoader

### DIFF
--- a/src/lib/account-loader.ts
+++ b/src/lib/account-loader.ts
@@ -261,6 +261,11 @@ export class AccountLoader {
       // cache.set() calls and overwrite newer slot data with older RPC data.
       await this._snapshotKnownAccounts();
 
+      // H-5: stop() may have run while the snapshot RPC above was in flight.
+      // Don't bother starting a stream subscription for a loader that's
+      // already been told to stop.
+      if (!this.running) return;
+
       await this.adapter.start(
         this.opts,
         (update) => this.enqueue(update),
@@ -270,6 +275,18 @@ export class AccountLoader {
         },
         (err) => this.onStreamError(err),
       );
+
+      // H-5: stop() may instead have run while adapter.start() itself was in
+      // flight. At that point stop()'s call to adapter.stop() found no handle
+      // yet assigned (e.g. LaserStreamAdapter.handle is set only once
+      // subscribe() resolves) and was a no-op -- the subscription that just
+      // came up here is live and otherwise uncancelled. Tear it down now
+      // instead of marking the loader connected.
+      if (!this.running) {
+        this.adapter.stop();
+        return;
+      }
+
       this.connected = true;
       this.backoff.reset();
       logger.info("AccountLoader: stream connected", {
@@ -366,6 +383,11 @@ export class AccountLoader {
   }
 
   private enqueue(update: AccountUpdate): void {
+    // H-5: defense-in-depth, matching onStreamError()'s existing convention --
+    // discard any update delivered after stop() ran, in case the underlying
+    // transport delivers an already-in-flight callback before its
+    // cancellation fully takes effect.
+    if (!this.running) return;
     this.eventsReceived++;
     this.cache.set(update.pubkey, update.data, update.owner, update.slot);
 

--- a/tests/lib/account-loader.test.ts
+++ b/tests/lib/account-loader.test.ts
@@ -108,6 +108,43 @@ class FailingAdapter implements StreamAdapter {
   stop(): void {}
 }
 
+/**
+ * H-5: a FakeAdapter whose start() does not resolve until the test calls
+ * releaseStart() -- lets tests put connect() in a "mid-await" state to
+ * exercise stop() racing it.
+ */
+class DeferredStartAdapter implements StreamAdapter {
+  startCallCount = 0;
+  stopCallCount = 0;
+  private onAccount: ((u: AccountUpdate) => void) | null = null;
+  private resolveStart: (() => void) | null = null;
+
+  start(
+    _opts: AccountLoaderOptions,
+    onAccountUpdate: (u: AccountUpdate) => void,
+  ): Promise<void> {
+    this.startCallCount++;
+    this.onAccount = onAccountUpdate;
+    return new Promise<void>((resolve) => {
+      this.resolveStart = resolve;
+    });
+  }
+
+  /** Let the pending start() call resolve, simulating the handle becoming live. */
+  releaseStart(): void {
+    this.resolveStart?.();
+    this.resolveStart = null;
+  }
+
+  stop(): void {
+    this.stopCallCount++;
+  }
+
+  pushAccount(update: AccountUpdate): void {
+    this.onAccount?.(update);
+  }
+}
+
 function makeUpdate(pubkey: string, slot: number): AccountUpdate {
   return { pubkey, data: new Uint8Array([1, 2, 3]), owner: "owner", slot };
 }
@@ -526,4 +563,75 @@ describe("AccountLoader stress test", () => {
       await loader.stop();
     },
   );
+});
+
+// H-5: connect() awaits _snapshotKnownAccounts() then adapter.start(). If
+// stop() ran during either await, it found nothing to cancel yet (the
+// adapter's handle didn't exist) and was a no-op. connect()'s continuation
+// then unconditionally set connected=true with no check of `running`,
+// leaving a live, otherwise-uncancelled subscription after the loader was
+// told to stop.
+describe("AccountLoader — H-5: connect()/stop() race", () => {
+  it("does not report connected=true if stop() ran while adapter.start() was pending", async () => {
+    const deferred = new DeferredStartAdapter();
+    const l = new AccountLoader(BASE_OPTS, deferred);
+
+    const startPromise = l.start(); // connect() begins, awaits adapter.start() (held open)
+    await Promise.resolve(); // let connect() reach the adapter.start() await
+
+    await l.stop(); // running=false while adapter.start() is still pending
+    expect(deferred.stopCallCount).toBe(1); // the no-op call from stop() itself
+
+    deferred.releaseStart(); // simulate subscribe() finally resolving, handle now "live"
+    await startPromise;
+    await Promise.resolve();
+
+    // Core of H-5: must not report connected after stop() raced the await.
+    expect(l.getStats().connected).toBe(false);
+    // The now-live handle must be torn down -- adapter.stop() called a
+    // second time, after adapter.start() resolved, proving the post-resolve
+    // subscription was actually cancelled rather than left orphaned.
+    expect(deferred.stopCallCount).toBe(2);
+  });
+
+  it("does not deliver account updates pushed after stop() raced a pending connect()", async () => {
+    const deferred = new DeferredStartAdapter();
+    const l = new AccountLoader(BASE_OPTS, deferred);
+    const received: AccountUpdate[] = [];
+    l.onAccount((u) => received.push(u));
+
+    const startPromise = l.start();
+    await Promise.resolve();
+    await l.stop();
+
+    deferred.releaseStart();
+    await startPromise;
+    await Promise.resolve();
+
+    // Even though the adapter's internal handle resolved and is "live"
+    // until adapter.stop() cancels it, any update delivered in that window
+    // must be dropped by enqueue()'s running guard.
+    deferred.pushAccount(makeUpdate("pk-late", 999));
+    await Promise.resolve();
+
+    expect(received).toHaveLength(0);
+    expect(l.getStats().eventsReceived).toBe(0);
+  });
+
+  it("does not schedule a reconnect when stop() races a pending connect()", async () => {
+    vi.useFakeTimers();
+    const deferred = new DeferredStartAdapter();
+    const l = new AccountLoader(BASE_OPTS, deferred);
+
+    const startPromise = l.start();
+    await Promise.resolve();
+    await l.stop();
+
+    deferred.releaseStart();
+    await startPromise;
+    await vi.advanceTimersByTimeAsync(5_000);
+    vi.useRealTimers();
+
+    expect(l.getStats().reconnectCount).toBe(0);
+  });
 });


### PR DESCRIPTION
## Bug

`AccountLoader.connect()` (`src/lib/account-loader.ts`) awaits `_snapshotKnownAccounts()` then `adapter.start(...)`. If `stop()` is called while either await is in flight, `stop()` sets `running=false` and calls `adapter.stop()` — but at that point the adapter's internal handle hasn't been assigned yet (`LaserStreamAdapter.handle` is set only once `subscribe()` resolves), so the call is a no-op. When `connect()`'s await later resolves, it unconditionally sets `connected = true` with no check of `running`, leaving a live, otherwise-uncancelled subscription running after the loader was told to stop. `enqueue()` also has no `running` guard at all, unlike `onStreamError()` which does.

## Impact

This is no longer a latent path — `index.ts`'s `stopAllServices()` (called on HA demotion) awaits `accountLoader.stop()`, while `startAllServices()` elsewhere may still have `accountLoader.start()` in flight (e.g. a leader-lock flap that promotes then immediately demotes a node). When that races, the loader reports `connected: true` after being told to stop, the underlying stream subscription is never cancelled, and it keeps mutating the shared `AccountCache` and firing registered listeners indefinitely — risking stale-looking-fresh cache reads by `CrankService`/`LiquidationService` even though the node believes its account stream was torn down.

## Fix

`connect()` re-checks `this.running` immediately after each await, before committing to connected state:
- After `_snapshotKnownAccounts()` resolves: bail out before even starting the stream subscription if `stop()` already ran.
- After `adapter.start()` resolves: if `stop()` raced in, call `adapter.stop()` again — this time against a real, live handle — and return without setting `connected = true`.

`enqueue()` gets a `running` guard matching the existing convention in `onStreamError()`, as defense-in-depth against any update delivered in the brief window between cancellation being requested and the underlying transport actually tearing down.

## Test results

New tests added to `tests/lib/account-loader.test.ts` (a `DeferredStartAdapter` test double whose `start()` doesn't resolve until the test releases it, to put `connect()` in a controllable mid-await state; written first, confirmed failing against the unfixed code, then confirmed passing after the fix):

```
 Test Files  1 passed (1)
      Tests  27 passed | 1 skipped (28)
```

Full suite, post-fix:

```
 Test Files  83 passed | 2 skipped (85)
      Tests  868 passed | 33 skipped (901)
```

`pnpm build` passes cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved race conditions in account loading operations that could occur with simultaneous stop and connect actions.
  * Ensured account updates are properly discarded after the loader stops, preventing stale data processing.
  * Improved shutdown sequence reliability with additional safeguards to prevent reconnection after being stopped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->