### PR TITLE
fix(keeper): require DISCORD_ALERT_WEBHOOK on mainnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,15 @@ CRANK_KEYPAIR=
 SUPABASE_URL=
 SUPABASE_KEY=
 
-# Sentry (optional)
+# Discord alert webhook — REQUIRED when NETWORK=mainnet (H-7). Without it,
+# sendCriticalAlert/sendWarningAlert/sendInfoAlert (conservation-invariant
+# violations, oracle outages, budget circuit-breaker halts) silently no-op.
+# Optional on devnet/local dev.
+DISCORD_ALERT_WEBHOOK=
+
+# Sentry (optional) — crash-path reporting only (uncaught exceptions /
+# unhandled rejections). Does NOT cover the operational alerts above, which
+# require DISCORD_ALERT_WEBHOOK.
 SENTRY_DSN=
 
 # Health check port

--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -260,5 +260,24 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
           "liquidation retry on devnet, discovering zero mainnet markets.",
       );
     }
+
+    // H-7 (HIGH): @percolatorct/shared's sendAlert() reads DISCORD_ALERT_WEBHOOK
+    // directly and, when unset, does logger.debug(...) + return -- no throw, no
+    // fallback channel. Every sendCriticalAlert/sendWarningAlert/sendInfoAlert
+    // call in the keeper (conservation-invariant violations, crank-cycle hangs,
+    // oracle dual-source outages, budget circuit-breaker trips) would silently
+    // no-op on mainnet, leaving only a logger.error/logger.warn line as the sole
+    // survivor for incidents that are supposed to page someone. Require it
+    // explicitly on mainnet; unset is still fine off mainnet for local/devnet dev.
+    if (!env.DISCORD_ALERT_WEBHOOK?.trim()) {
+      throw new Error(
+        "DISCORD_ALERT_WEBHOOK must be set when NETWORK=mainnet. It is unset, " +
+          "and @percolatorct/shared's sendAlert() silently no-ops (logger.debug, " +
+          "no throw, no fallback channel) when the webhook is missing -- every " +
+          "sendCriticalAlert/sendWarningAlert/sendInfoAlert call (conservation " +
+          "invariant violations, crank hangs, oracle outages, budget halts) " +
+          "would fire and vanish with no operator-visible signal.",
+      );
+    }
   }
 }

--- a/src/lib/account-loader.ts
+++ b/src/lib/account-loader.ts
@@ -261,6 +261,11 @@ export class AccountLoader {
       // cache.set() calls and overwrite newer slot data with older RPC data.
       await this._snapshotKnownAccounts();
 
+      // H-5: stop() may have run while the snapshot RPC above was in flight.
+      // Don't bother starting a stream subscription for a loader that's
+      // already been told to stop.
+      if (!this.running) return;
+
       await this.adapter.start(
         this.opts,
         (update) => this.enqueue(update),
@@ -270,6 +275,18 @@ export class AccountLoader {
         },
         (err) => this.onStreamError(err),
       );
+
+      // H-5: stop() may instead have run while adapter.start() itself was in
+      // flight. At that point stop()'s call to adapter.stop() found no handle
+      // yet assigned (e.g. LaserStreamAdapter.handle is set only once
+      // subscribe() resolves) and was a no-op -- the subscription that just
+      // came up here is live and otherwise uncancelled. Tear it down now
+      // instead of marking the loader connected.
+      if (!this.running) {
+        this.adapter.stop();
+        return;
+      }
+
       this.connected = true;
       this.backoff.reset();
       logger.info("AccountLoader: stream connected", {
@@ -366,6 +383,11 @@ export class AccountLoader {
   }
 
   private enqueue(update: AccountUpdate): void {
+    // H-5: defense-in-depth, matching onStreamError()'s existing convention --
+    // discard any update delivered after stop() ran, in case the underlying
+    // transport delivers an already-in-flight callback before its
+    // cancellation fully takes effect.
+    if (!this.running) return;
     this.eventsReceived++;
     this.cache.set(update.pubkey, update.data, update.owner, update.slot);
 

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -167,6 +167,7 @@ describe("validateKeeperEnvGuards", () => {
         RPC_URL: "https://api.mainnet-beta.solana.com",
         KEEPER_REDIS_URL: "https://fake-host.upstash.io",
         KEEPER_REDIS_TOKEN: "fake-token",
+        DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -355,6 +356,7 @@ describe("validateKeeperEnvGuards", () => {
         SOLANA_RPC_WS_URL: "wss://mainnet.helius-rpc.com/?api-key=xxx",
         FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
         RPC_URL: "https://mainnet.helius-rpc.com/?api-key=xxx",
+        DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -511,6 +513,7 @@ describe("validateKeeperEnvGuards", () => {
         SOLANA_RPC_WS_URL: "wss://mainnet.helius-rpc.com/?api-key=test",
         FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
         RPC_URL: MAINNET,
+        DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -523,6 +526,7 @@ describe("validateKeeperEnvGuards", () => {
         SOLANA_RPC_URL: "https://my-devnet-migration.example.com",
         RPC_URL: "https://my-devnet-migration.example.com",
         FALLBACK_RPC_URL: "https://my-devnet-migration.example.com",
+        DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -552,6 +556,72 @@ describe("validateKeeperEnvGuards", () => {
         FALLBACK_RPC_URL: "https://api.devnet.solana.com",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
+  });
+
+  // H-7 (HIGH): @percolatorct/shared's sendAlert() silently no-ops (logger.debug,
+  // no throw, no fallback channel) when DISCORD_ALERT_WEBHOOK is unset. Every
+  // sendCriticalAlert/sendWarningAlert/sendInfoAlert call in the keeper --
+  // including conservation-invariant violations and budget circuit-breaker trips
+  // -- would fire and vanish with zero operator-visible signal on mainnet.
+  describe("H-7: DISCORD_ALERT_WEBHOOK required on mainnet", () => {
+    const MAINNET = "https://mainnet.helius-rpc.com/?api-key=test";
+
+    it("throws when DISCORD_ALERT_WEBHOOK is unset on mainnet", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: MAINNET,
+        RPC_URL: MAINNET,
+        FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /DISCORD_ALERT_WEBHOOK must be set.*NETWORK=mainnet/i,
+      );
+    });
+
+    it("throws when DISCORD_ALERT_WEBHOOK is empty string on mainnet", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: MAINNET,
+        RPC_URL: MAINNET,
+        FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
+        DISCORD_ALERT_WEBHOOK: "",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /DISCORD_ALERT_WEBHOOK must be set/i,
+      );
+    });
+
+    it("throws when DISCORD_ALERT_WEBHOOK is whitespace-only on mainnet", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: MAINNET,
+        RPC_URL: MAINNET,
+        FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
+        DISCORD_ALERT_WEBHOOK: "   ",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /DISCORD_ALERT_WEBHOOK must be set/i,
+      );
+    });
+
+    it("accepts a complete mainnet env with DISCORD_ALERT_WEBHOOK set", () => {
+      const env = {
+        NETWORK: "mainnet",
+        SOLANA_RPC_URL: MAINNET,
+        SOLANA_RPC_WS_URL: "wss://mainnet.helius-rpc.com/?api-key=test",
+        RPC_URL: MAINNET,
+        FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
+        DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+      } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
+
+    it("does NOT require DISCORD_ALERT_WEBHOOK off mainnet (devnet/unset)", () => {
+      expect(() =>
+        validateKeeperEnvGuards({ NETWORK: "devnet" } as NodeJS.ProcessEnv),
+      ).not.toThrow();
+      expect(() => validateKeeperEnvGuards({} as NodeJS.ProcessEnv)).not.toThrow();
     });
   });
 

--- a/tests/lib/account-loader.test.ts
+++ b/tests/lib/account-loader.test.ts
@@ -108,6 +108,43 @@ class FailingAdapter implements StreamAdapter {
   stop(): void {}
 }
 
+/**
+ * H-5: a FakeAdapter whose start() does not resolve until the test calls
+ * releaseStart() -- lets tests put connect() in a "mid-await" state to
+ * exercise stop() racing it.
+ */
+class DeferredStartAdapter implements StreamAdapter {
+  startCallCount = 0;
+  stopCallCount = 0;
+  private onAccount: ((u: AccountUpdate) => void) | null = null;
+  private resolveStart: (() => void) | null = null;
+
+  start(
+    _opts: AccountLoaderOptions,
+    onAccountUpdate: (u: AccountUpdate) => void,
+  ): Promise<void> {
+    this.startCallCount++;
+    this.onAccount = onAccountUpdate;
+    return new Promise<void>((resolve) => {
+      this.resolveStart = resolve;
+    });
+  }
+
+  /** Let the pending start() call resolve, simulating the handle becoming live. */
+  releaseStart(): void {
+    this.resolveStart?.();
+    this.resolveStart = null;
+  }
+
+  stop(): void {
+    this.stopCallCount++;
+  }
+
+  pushAccount(update: AccountUpdate): void {
+    this.onAccount?.(update);
+  }
+}
+
 function makeUpdate(pubkey: string, slot: number): AccountUpdate {
   return { pubkey, data: new Uint8Array([1, 2, 3]), owner: "owner", slot };
 }
@@ -526,4 +563,75 @@ describe("AccountLoader stress test", () => {
       await loader.stop();
     },
   );
+});
+
+// H-5: connect() awaits _snapshotKnownAccounts() then adapter.start(). If
+// stop() ran during either await, it found nothing to cancel yet (the
+// adapter's handle didn't exist) and was a no-op. connect()'s continuation
+// then unconditionally set connected=true with no check of `running`,
+// leaving a live, otherwise-uncancelled subscription after the loader was
+// told to stop.
+describe("AccountLoader — H-5: connect()/stop() race", () => {
+  it("does not report connected=true if stop() ran while adapter.start() was pending", async () => {
+    const deferred = new DeferredStartAdapter();
+    const l = new AccountLoader(BASE_OPTS, deferred);
+
+    const startPromise = l.start(); // connect() begins, awaits adapter.start() (held open)
+    await Promise.resolve(); // let connect() reach the adapter.start() await
+
+    await l.stop(); // running=false while adapter.start() is still pending
+    expect(deferred.stopCallCount).toBe(1); // the no-op call from stop() itself
+
+    deferred.releaseStart(); // simulate subscribe() finally resolving, handle now "live"
+    await startPromise;
+    await Promise.resolve();
+
+    // Core of H-5: must not report connected after stop() raced the await.
+    expect(l.getStats().connected).toBe(false);
+    // The now-live handle must be torn down -- adapter.stop() called a
+    // second time, after adapter.start() resolved, proving the post-resolve
+    // subscription was actually cancelled rather than left orphaned.
+    expect(deferred.stopCallCount).toBe(2);
+  });
+
+  it("does not deliver account updates pushed after stop() raced a pending connect()", async () => {
+    const deferred = new DeferredStartAdapter();
+    const l = new AccountLoader(BASE_OPTS, deferred);
+    const received: AccountUpdate[] = [];
+    l.onAccount((u) => received.push(u));
+
+    const startPromise = l.start();
+    await Promise.resolve();
+    await l.stop();
+
+    deferred.releaseStart();
+    await startPromise;
+    await Promise.resolve();
+
+    // Even though the adapter's internal handle resolved and is "live"
+    // until adapter.stop() cancels it, any update delivered in that window
+    // must be dropped by enqueue()'s running guard.
+    deferred.pushAccount(makeUpdate("pk-late", 999));
+    await Promise.resolve();
+
+    expect(received).toHaveLength(0);
+    expect(l.getStats().eventsReceived).toBe(0);
+  });
+
+  it("does not schedule a reconnect when stop() races a pending connect()", async () => {
+    vi.useFakeTimers();
+    const deferred = new DeferredStartAdapter();
+    const l = new AccountLoader(BASE_OPTS, deferred);
+
+    const startPromise = l.start();
+    await Promise.resolve();
+    await l.stop();
+
+    deferred.releaseStart();
+    await startPromise;
+    await vi.advanceTimersByTimeAsync(5_000);
+    vi.useRealTimers();
+
+    expect(l.getStats().reconnectCount).toBe(0);
+  });
 });


### PR DESCRIPTION
## Bug

`@percolatorct/shared`'s `sendAlert()` reads `DISCORD_ALERT_WEBHOOK` directly from `process.env` and, when unset, does `logger.debug(...)` + `return` — no throw, no fallback channel. `validateKeeperEnvGuards()` never checked for it.

## Impact

Every `sendCriticalAlert`/`sendWarningAlert`/`sendInfoAlert` call in the keeper — conservation-invariant/fund-leak detection, budget circuit-breaker halts, oracle dual-source outages, crank-cycle hangs, liquidation-scanner stalls — silently no-ops if the webhook is missing or revoked. An operator who forgets to set it on a mainnet deploy (or whose webhook gets revoked later) gets a keeper that runs and cranks normally while every safety alert vanishes into a debug log line nobody is watching.

Sentry is wired separately in this repo (`index.ts`'s `uncaughtException`/`unhandledRejection` handlers) but only covers the crash path — it never sees these conditions, since none of them throw. There is no other fallback channel.

## Fix

Adds a boot-time check inside the existing `if (isMainnetEnv(env))` block in `validateKeeperEnvGuards()` (`src/env-guards.ts`), requiring `DISCORD_ALERT_WEBHOOK` to be set whenever `NETWORK=mainnet`, following the same "fail fast at boot, don't discover broken config mid-incident" philosophy already applied to `CRANK_KEYPAIR`, RPC URL schemes/hosts, and the HA Redis vars in this same file.

Scoped to mainnet only — matching the existing `FALLBACK_RPC_URL` precedent in the same block — since devnet/local development legitimately runs without Discord alerting configured today (it isn't even documented in `.env.example`), and CI never sets `NETWORK=mainnet` in its test/build jobs, so it's unaffected by this change.

Also documents `DISCORD_ALERT_WEBHOOK` in `.env.example` (it was previously undocumented despite being referenced implicitly elsewhere in that file), with a note clarifying Sentry's narrower crash-only scope.

## Test results

New tests added to `tests/env-guards.test.ts` (written first, confirmed failing against the unfixed code, then confirmed passing after the fix). Four pre-existing tests that build a complete mainnet env and assert `.not.toThrow()` needed `DISCORD_ALERT_WEBHOOK` added to their fixtures, since they were previously asserting the gap this PR closes:

```
 Test Files  1 passed (1)
      Tests  71 passed (71)
```

Full suite, post-fix:

```
 Test Files  83 passed | 2 skipped (85)
      Tests  873 passed | 33 skipped (906)
```

`pnpm build` passes cleanly.

## Compatibility note

A deployment currently running `NETWORK=mainnet` without `DISCORD_ALERT_WEBHOOK` set will now fail to boot. This is the intended effect — converting a silent alerting blind spot into a loud boot failure — but it is a breaking change for any such deployment; set the webhook before deploying this change to a mainnet environment.