### PR TITLE
fix(keeper): validate maintenanceMarginBps, alert on corruption

### DIFF
--- a/src/lib/v17-risk.ts
+++ b/src/lib/v17-risk.ts
@@ -31,6 +31,33 @@ function readU128LE(data: Uint8Array, offset: number): bigint {
   return lo | (hi << 64n);
 }
 
+/**
+ * H-8: maintenanceMarginBps gates the only line that decides whether a v17
+ * position is liquidatable (`marginRatioBps < maintenanceMarginBps` in
+ * liquidation.ts). computeMarginRatioBps() clamps marginRatioBps to exactly
+ * 0n whenever notional===0n or equity<=0n, so if maintenanceMarginBps is
+ * itself 0n -- an uninitialized account, a future on-chain layout change
+ * shifting this field's byte offset without a matching keeper update, or
+ * corrupted/zeroed bytes -- `0n < 0n` is always false: no position in that
+ * market, however underwater, is ever flagged liquidatable, silently. A
+ * value >= 10_000 bps (>=100% margin requirement) is equally not a coherent
+ * on-chain config and would cause the opposite failure: every position with
+ * any notional would immediately appear liquidatable. Neither is a real
+ * market configuration -- treat both as corrupted data and refuse to parse.
+ */
+export class V17RiskParamsCorruptedError extends Error {
+  constructor(
+    public readonly field: string,
+    public readonly value: bigint,
+  ) {
+    super(
+      `parseV17RiskParams: ${field}=${value} is out of the valid (0, 10000) bps range ` +
+        `(suspected corrupted/misaligned read)`,
+    );
+    this.name = "V17RiskParamsCorruptedError";
+  }
+}
+
 export function parseV17RiskParams(data: Uint8Array): {
   warmupPeriodSlots: bigint;
   maintenanceMarginBps: bigint;
@@ -48,12 +75,17 @@ export function parseV17RiskParams(data: Uint8Array): {
     );
   }
 
+  const maintenanceMarginBps = readU64LE(
+    data,
+    V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_MAINTENANCE_MARGIN_BPS_OFF,
+  );
+  if (maintenanceMarginBps <= 0n || maintenanceMarginBps >= 10_000n) {
+    throw new V17RiskParamsCorruptedError("maintenanceMarginBps", maintenanceMarginBps);
+  }
+
   return {
     warmupPeriodSlots: 0n,
-    maintenanceMarginBps: readU64LE(
-      data,
-      V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_MAINTENANCE_MARGIN_BPS_OFF,
-    ),
+    maintenanceMarginBps,
     hMin: readU64LE(data, V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_H_MIN_OFF),
     hMax: readU64LE(data, V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_H_MAX_OFF),
     openInterestCap: 0n,

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -16,7 +16,7 @@ import {
   parsePortfolioV17,
   type DiscoveredMarket,
 } from "@percolatorct/sdk";
-import { config, getConnection, loadKeypair, sendWithRetry, pollSignatureStatus, getRecentPriorityFees, checkTransactionSize, eventBus, createLogger, sendWarningAlert, acquireToken, getFallbackConnection, backoffMs, getErrorMessage } from "@percolatorct/shared";
+import { config, getConnection, loadKeypair, sendWithRetry, pollSignatureStatus, getRecentPriorityFees, checkTransactionSize, eventBus, createLogger, sendWarningAlert, sendCriticalAlert, acquireToken, getFallbackConnection, backoffMs, getErrorMessage } from "@percolatorct/shared";
 import { OracleService } from "./oracle.js";
 import { resolveExternalOracleAccount } from "../lib/oracle-account.js";
 import { recordAttempt, recordLanded, recordFailed } from "../lib/sender-metrics.js";
@@ -30,7 +30,7 @@ import type { AccountLoader } from "../lib/account-loader.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
 import { AlertAggregator } from "../lib/alert-aggregator.js";
-import { parseV17RiskParams } from "../lib/v17-risk.js";
+import { parseV17RiskParams, V17RiskParamsCorruptedError } from "../lib/v17-risk.js";
 import { resolveV17OracleTail } from "../lib/v17-oracle-tail.js";
 
 const logger = createLogger("keeper:liquidation");
@@ -182,7 +182,11 @@ async function scanV17Portfolios(
         const feeDebt = pf.feeCredits < 0n ? -pf.feeCredits : 0n;
         const equity = pf.capital + pf.pnl - feeDebt;
         const marginRatioBps = computeMarginRatioBps(equity, notional);
-        if (marginRatioBps < maintenanceMarginBps) {
+        // H-8 defense-in-depth: a position with equity<=0n is unambiguously
+        // bankrupt and liquidatable regardless of maintenanceMarginBps -- even
+        // if that value were somehow corrupted/zero despite parseV17RiskParams'
+        // own validation. Don't let a bad threshold mask the unconditional case.
+        if (equity <= 0n || marginRatioBps < maintenanceMarginBps) {
           candidates.push({
             portfolioPubkey: pubkey,
             owner: pf.owner.toBase58(),
@@ -378,6 +382,13 @@ export class LiquidationService {
   // PERC-484: Track markets that permanently fail with InvalidSlabLen (0x4).
   // These are test/corrupt markets with wrong slab size — skip them indefinitely.
   private readonly permanentlySkipped = new Set<string>();
+  // H-8: per-market cooldown latch for the "corrupted risk params" alert. A
+  // corrupted/zero maintenanceMarginBps is a sustained, unchanging condition
+  // re-evaluated every scan cycle (default 60s) -- not a burst of distinct
+  // events -- so this is a plain per-market timestamp map, not AlertAggregator
+  // (which collapses bursts within a few seconds, not a level held for hours).
+  private readonly _corruptedRiskParamsAlertedAt = new Map<string, number>();
+  private static readonly RISK_PARAMS_ALERT_COOLDOWN_MS = 15 * 60_000; // 15 min
   // Cache keypair at construction — avoids re-parsing from env on every liquidate() call
   private readonly _keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
   /** LaserStream account loader — injected for event-driven portfolio scanning. */
@@ -435,6 +446,31 @@ export class LiquidationService {
   }
 
   /**
+   * H-8: fire a CRITICAL alert at most once per RISK_PARAMS_ALERT_COOLDOWN_MS
+   * per market. A market stuck with a corrupted maintenanceMarginBps means bad
+   * debt can accumulate completely undetected -- no position in that market
+   * will ever be flagged liquidatable by the threshold comparison alone (the
+   * equity<=0n defense-in-depth still catches outright-bankrupt positions, but
+   * a near-bankrupt one with positive equity would not be) -- so this must be
+   * operator-visible, not a buried log line.
+   */
+  private _alertCorruptedRiskParams(slabAddress: string, err: Error): void {
+    logger.error("Corrupted risk params — liquidation may be degraded for this market", {
+      slabAddress,
+      error: err.message,
+    });
+    const now = Date.now();
+    const lastAlert = this._corruptedRiskParamsAlertedAt.get(slabAddress) ?? 0;
+    if (now - lastAlert > LiquidationService.RISK_PARAMS_ALERT_COOLDOWN_MS) {
+      this._corruptedRiskParamsAlertedAt.set(slabAddress, now);
+      sendCriticalAlert("Market risk params corrupted — liquidation may be degraded", [
+        { name: "Market", value: slabAddress.slice(0, 16), inline: true },
+        { name: "Error", value: err.message.slice(0, 200), inline: false },
+      ]).catch(() => {});
+    }
+  }
+
+  /**
    * Scan a single market for undercollateralized accounts.
    *
    * DESYNC-3/4 FIX: v17 market accounts have different magic bytes (PERCV16\0)
@@ -452,7 +488,17 @@ export class LiquidationService {
       if (isV17Account(data)) {
         // Resolve price from the v17 config (markEwmaE6 acts as lastEffectivePriceE6)
         const price = market.config.lastEffectivePriceE6 ?? market.config.authorityPriceE6 ?? 0n;
-        const v17Params = parseV17RiskParams(data);
+        let v17Params: ReturnType<typeof parseV17RiskParams>;
+        try {
+          v17Params = parseV17RiskParams(data);
+        } catch (err) {
+          if (err instanceof V17RiskParamsCorruptedError) {
+            this._alertCorruptedRiskParams(slabAddress, err);
+            return []; // fail closed for this scan; the alert is the signal to investigate
+          }
+          throw err;
+        }
+        this._corruptedRiskParamsAlertedAt.delete(slabAddress); // recovered — re-arm the latch
         const maintenanceMarginBps = v17Params.maintenanceMarginBps;
         const connection = getConnection();
         const v17Candidates = await scanV17Portfolios(
@@ -489,6 +535,20 @@ export class LiquidationService {
 
       const candidates: LiquidationCandidate[] = [];
       const maintenanceMarginBps = params.maintenanceMarginBps;
+      // H-8: parseParams() (SDK, vendored — cannot be edited here) reads this
+      // field with the same unvalidated raw-u64 pattern parseV17RiskParams used
+      // to have, and it gates the identical `marginRatioBps < maintenanceMarginBps`
+      // decision below — a 0n (or >=100%) here is exactly as dangerous on the
+      // v12.x path. The guard lives at this call site since the parser itself
+      // is out of scope.
+      if (maintenanceMarginBps <= 0n || maintenanceMarginBps >= BPS_MULTIPLIER) {
+        this._alertCorruptedRiskParams(
+          slabAddress,
+          new Error(`v12.x maintenanceMarginBps=${maintenanceMarginBps} is out of the valid (0, 10000) bps range`),
+        );
+        return [];
+      }
+      this._corruptedRiskParamsAlertedAt.delete(slabAddress);
 
       // H3: Use cluster clock for admin-oracle staleness to avoid false positives
       // from keeper host clock drift.
@@ -563,7 +623,9 @@ export class LiquidationService {
           // The equity<=0n short-circuit lives inside computeMarginRatioBps;
           // a candidate with marginRatioBps == 0n is collected here just like
           // any other below-threshold ratio.
-          if (marginRatioBps < maintenanceMarginBps) {
+          // H-8 defense-in-depth: equity<=0n is unconditionally liquidatable,
+          // independent of maintenanceMarginBps (see the validation above).
+          if (equity <= 0n || marginRatioBps < maintenanceMarginBps) {
             candidates.push({
               slabAddress,
               accountIdx: i,
@@ -801,7 +863,24 @@ export class LiquidationService {
           // equity as the scanner (#230). scanPriceE6 is the scan-time price; if it's
           // unavailable (0) we keep the leg-active check + rely on the on-chain program.
           const freshMarketData = await fetchSlabWithRetry(slabAddress);
-          const reMmBps = parseV17RiskParams(freshMarketData).maintenanceMarginBps;
+          // H-8: isolate this call from the outer "proceed cautiously" catch --
+          // that catch's fail-open posture is meant for transient RPC failures
+          // preventing re-verification entirely, not for "we got data back but
+          // it's corrupted." A corrupted reMmBps must not skip the recheck below
+          // (which would fall through to submitting the liquidation
+          // unconditionally) -- degrade to relying on the equity<=0n signal
+          // alone instead.
+          let reMmBps: bigint | null = null;
+          try {
+            reMmBps = parseV17RiskParams(freshMarketData).maintenanceMarginBps;
+            this._corruptedRiskParamsAlertedAt.delete(slabAddress.toBase58());
+          } catch (err) {
+            if (err instanceof V17RiskParamsCorruptedError) {
+              this._alertCorruptedRiskParams(slabAddress.toBase58(), err);
+            } else {
+              throw err;
+            }
+          }
           const freshNowSec = await fetchClusterUnixTimeSec(connection);
           const freshPrice = resolveV17WrapperPrice(parseWrapperConfigV17(freshMarketData), freshNowSec);
           if (freshPrice === 0n) {
@@ -828,7 +907,13 @@ export class LiquidationService {
               return null;
             }
           }
-          if (reMmBps > 0n) {
+          // H-8: always run the recheck, even when reMmBps could not be
+          // obtained (corrupted/null) -- equity<=0n is checked unconditionally
+          // so an outright-bankrupt position is never masked by an untrusted
+          // threshold. If reMmBps is null AND equity>0n for every leg, we have
+          // no reliable signal either way -- stillLiquidatable stays false and
+          // the function safely aborts (fails closed) rather than guessing.
+          {
             const feeDebt = pf.feeCredits < 0n ? -pf.feeCredits : 0n;
             const equity = pf.capital + pf.pnl - feeDebt;
             let stillLiquidatable = false;
@@ -837,7 +922,7 @@ export class LiquidationService {
               const absPos = leg.basisPosQ < 0n ? -leg.basisPosQ : leg.basisPosQ;
               const notional = absPos * freshPrice / PRICE_E6_DIVISOR;
               if (notional === 0n) continue;
-              if (computeMarginRatioBps(equity, notional) < reMmBps) {
+              if (equity <= 0n || (reMmBps !== null && computeMarginRatioBps(equity, notional) < reMmBps)) {
                 stillLiquidatable = true;
                 break;
               }

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -69,6 +69,7 @@ vi.mock('@percolatorct/shared', () => ({
     debug: vi.fn(),
   })),
   sendWarningAlert: vi.fn(),
+  sendCriticalAlert: vi.fn(async () => undefined),
   getConnection: vi.fn(() => ({
     getAccountInfo: vi.fn(),
     getLatestBlockhash: vi.fn(async () => ({
@@ -129,19 +130,25 @@ vi.mock('../../src/lib/keeper-send.js', async () => {
   };
 });
 
-vi.mock('../../src/lib/v17-risk.js', () => ({
-  parseV17RiskParams: vi.fn(() => ({
-    warmupPeriodSlots: 0n,
-    maintenanceMarginBps: 500n,
-    hMin: 0n,
-    hMax: 0n,
-    openInterestCap: 0n,
-    maintenanceFeePerSlot: 0n,
-    liquidationFeeShareBps: 0n,
-    adlFillCapBps: 0n,
-    minPositionSize: 0n,
-  })),
-}));
+vi.mock('../../src/lib/v17-risk.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/lib/v17-risk.js')>('../../src/lib/v17-risk.js');
+  return {
+    // Real class so `instanceof V17RiskParamsCorruptedError` checks in
+    // liquidation.ts still work against errors thrown by this mock.
+    V17RiskParamsCorruptedError: actual.V17RiskParamsCorruptedError,
+    parseV17RiskParams: vi.fn(() => ({
+      warmupPeriodSlots: 0n,
+      maintenanceMarginBps: 500n,
+      hMin: 0n,
+      hMax: 0n,
+      openInterestCap: 0n,
+      maintenanceFeePerSlot: 0n,
+      liquidationFeeShareBps: 0n,
+      adlFillCapBps: 0n,
+      minPositionSize: 0n,
+    })),
+  };
+});
 
 import { PublicKey, ComputeBudgetProgram } from '@solana/web3.js';
 import { LiquidationService } from '../../src/services/liquidation.js';
@@ -408,6 +415,103 @@ describe('LiquidationService', () => {
       const candidates = await liquidationService.scanMarket(mockMarket as any);
 
       expect(candidates).toHaveLength(0); // Skipped due to stale price and no fallback
+    });
+
+    // H-8: maintenanceMarginBps===0n (or out of range) makes the liquidation
+    // candidacy comparison unsatisfiable for every position, silently. The
+    // fix bails out loudly (alert + no candidates) instead.
+    describe('H-8: corrupted maintenanceMarginBps', () => {
+      const mockMarket = {
+        slabAddress: { toBase58: () => 'MarketCorrupt111111111111111111111111' },
+        programId: { toBase58: () => 'Program11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+          oracleAuthority: { toBase58: () => 'Oracle11111111111111111111111111111111' },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+          authorityPriceE6: 1_000_000n,
+          authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+      };
+
+      it('v12.x path: returns no candidates and fires sendCriticalAlert when maintenanceMarginBps is 0n', async () => {
+        vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+        vi.mocked(core.parseEngine).mockReturnValue({ totalOpenInterest: 100_000_000n } as any);
+        vi.mocked(core.parseParams).mockReturnValue({ maintenanceMarginBps: 0n } as any);
+        vi.mocked(core.parseConfig).mockReturnValue({
+          oracleAuthority: mockNonZeroKey(),
+          indexFeedId: mockZeroKey(),
+          authorityPriceE6: 1_000_000n,
+          lastEffectivePriceE6: 1_000_000n,
+          authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
+        } as any);
+        vi.mocked(core.detectLayout).mockReturnValue({ accountsOffset: 0 } as any);
+
+        const candidates = await liquidationService.scanMarket(mockMarket as any);
+
+        expect(candidates).toEqual([]);
+        expect(shared.sendCriticalAlert).toHaveBeenCalledWith(
+          expect.stringContaining('risk params corrupted'),
+          expect.anything(),
+        );
+      });
+
+      it('v12.x path: alerts only once per market within the cooldown across repeated scans', async () => {
+        vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+        vi.mocked(core.parseEngine).mockReturnValue({ totalOpenInterest: 100_000_000n } as any);
+        vi.mocked(core.parseParams).mockReturnValue({ maintenanceMarginBps: 0n } as any);
+        vi.mocked(core.parseConfig).mockReturnValue({
+          oracleAuthority: mockNonZeroKey(),
+          indexFeedId: mockZeroKey(),
+          authorityPriceE6: 1_000_000n,
+          lastEffectivePriceE6: 1_000_000n,
+          authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
+        } as any);
+        vi.mocked(core.detectLayout).mockReturnValue({ accountsOffset: 0 } as any);
+
+        await liquidationService.scanMarket(mockMarket as any);
+        await liquidationService.scanMarket(mockMarket as any);
+        await liquidationService.scanMarket(mockMarket as any);
+
+        expect(shared.sendCriticalAlert).toHaveBeenCalledTimes(1);
+      });
+
+      it('v17 path: returns no candidates and fires sendCriticalAlert when parseV17RiskParams throws V17RiskParamsCorruptedError', async () => {
+        vi.mocked(core.isV17Account).mockReturnValueOnce(true);
+        vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(9_347));
+        const v17Risk = await import('../../src/lib/v17-risk.js');
+        vi.mocked(v17Risk.parseV17RiskParams).mockImplementationOnce(() => {
+          throw new v17Risk.V17RiskParamsCorruptedError('maintenanceMarginBps', 0n);
+        });
+
+        const candidates = await liquidationService.scanMarket(mockMarket as any);
+
+        expect(candidates).toEqual([]);
+        expect(shared.sendCriticalAlert).toHaveBeenCalledWith(
+          expect.stringContaining('risk params corrupted'),
+          expect.anything(),
+        );
+      });
+
+      it('does NOT alert for a legitimate non-zero maintenanceMarginBps (no false positives)', async () => {
+        vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(1024));
+        vi.mocked(core.parseEngine).mockReturnValue({ totalOpenInterest: 100_000_000n } as any);
+        vi.mocked(core.parseParams).mockReturnValue({ maintenanceMarginBps: 500n } as any);
+        vi.mocked(core.parseConfig).mockReturnValue({
+          oracleAuthority: mockNonZeroKey(),
+          indexFeedId: mockZeroKey(),
+          authorityPriceE6: 1_000_000n,
+          lastEffectivePriceE6: 1_000_000n,
+          authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
+        } as any);
+        vi.mocked(core.detectLayout).mockReturnValue({ accountsOffset: 0 } as any);
+        vi.mocked(core.parseUsedIndices).mockReturnValue([]);
+
+        await liquidationService.scanMarket(mockMarket as any);
+
+        expect(shared.sendCriticalAlert).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/tests/v17-risk-params.poc.test.ts
+++ b/tests/v17-risk-params.poc.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseV17RiskParams, V17_RISK_PARAMS_MIN_DATA_LEN } from "../src/lib/v17-risk.js";
+import {
+  parseV17RiskParams,
+  V17_RISK_PARAMS_MIN_DATA_LEN,
+  V17RiskParamsCorruptedError,
+} from "../src/lib/v17-risk.js";
 
 const V17_HEADER_LEN = 16;
 const V17_WRAPPER_CONFIG_LEN = 432;
@@ -41,5 +45,42 @@ describe("PoC: v17 risk params are parsed from the market-group header", () => {
     expect(params.hMax).toBe(86_400n);
     expect(params.maintenanceFeePerSlot).toBe(7n);
     expect(params.liquidationFeeShareBps).toBe(75n);
+  });
+
+  // H-8: a zero (or implausibly large) maintenanceMarginBps makes the
+  // liquidation-candidacy comparison `marginRatioBps < maintenanceMarginBps`
+  // unsatisfiable (0n<0n is always false) or trivially satisfied for every
+  // position (>=10000n), silently. Neither is a real on-chain config --
+  // reject both at parse time.
+  describe("H-8: maintenanceMarginBps sanity validation", () => {
+    function buildData(maintenanceMarginBps: bigint): Uint8Array {
+      const data = new Uint8Array(V17_RISK_PARAMS_MIN_DATA_LEN);
+      writeU128LE(data, V17_HEADER_LEN + 96, 7n);
+      writeU64LE(data, V17_ENGINE_CONFIG_OFF + 38, 100n);
+      writeU64LE(data, V17_ENGINE_CONFIG_OFF + 46, 86_400n);
+      writeU64LE(data, V17_ENGINE_CONFIG_OFF + 54, maintenanceMarginBps);
+      writeU64LE(data, V17_ENGINE_CONFIG_OFF + 78, 75n);
+      return data;
+    }
+
+    it("throws V17RiskParamsCorruptedError when maintenanceMarginBps decodes to 0", () => {
+      expect(() => parseV17RiskParams(buildData(0n))).toThrow(V17RiskParamsCorruptedError);
+      expect(() => parseV17RiskParams(buildData(0n))).toThrow(/maintenanceMarginBps=0/);
+    });
+
+    it("throws when maintenanceMarginBps decodes to >= 10_000 (>= 100% margin)", () => {
+      expect(() => parseV17RiskParams(buildData(10_000n))).toThrow(V17RiskParamsCorruptedError);
+    });
+
+    it("throws when maintenanceMarginBps decodes to an implausibly huge corrupted value", () => {
+      expect(() => parseV17RiskParams(buildData(18_446_744_073_709_551_615n))).toThrow(
+        V17RiskParamsCorruptedError,
+      );
+    });
+
+    it("accepts the boundary values 1 and 9999 bps", () => {
+      expect(parseV17RiskParams(buildData(1n)).maintenanceMarginBps).toBe(1n);
+      expect(parseV17RiskParams(buildData(9_999n)).maintenanceMarginBps).toBe(9_999n);
+    });
   });
 });


### PR DESCRIPTION
## Bug

`computeMarginRatioBps()` (`src/services/liquidation.ts`) clamps to exactly `0n` whenever `notional===0n` or `equity<=0n` (B3: underwater = liquidatable). The liquidation-candidacy checks compare this against `maintenanceMarginBps` via `marginRatioBps < maintenanceMarginBps`. If `maintenanceMarginBps` is itself `0n` — an uninitialized account, a future on-chain layout change shifting this field's byte offset without a matching keeper update, or corrupted/zeroed bytes — `0n < 0n` is always `false`: no position in that market, however underwater, is ever flagged liquidatable, silently, with no error or metric anywhere.

A value `>= 10_000` bps (>=100% margin) is equally not a coherent on-chain config and causes the mirror-image failure: every position with any notional would immediately appear liquidatable the moment such a corrupted value is read.

## Fix

1. **`parseV17RiskParams()`** (`src/lib/v17-risk.ts`) now throws a new `V17RiskParamsCorruptedError` if `maintenanceMarginBps` decodes outside `(0, 10000)` bps. This is the single chokepoint every v17 caller goes through (`crank.ts` discovery, `liquidation.ts` scan and pre-submit recheck), so validating once at the source protects all of them.

2. **The v12.x path** uses the SDK's own `parseParams()`, which has the identical unvalidated-read pattern but lives in a vendored dependency that can't be edited here — the same range check is added at the `liquidation.ts` call site instead.

3. **Decision-site defense in depth**: `equity <= 0n ||` is added to the v17 and v12.x scan comparisons and the v17 pre-submit recheck, so an outright-bankrupt position is caught unconditionally even if a threshold were somehow corrupted despite the validation above. The pre-submit recheck needed isolating from its existing fail-open `catch { /* proceed cautiously */ }` (which is appropriate for transient RPC failures preventing re-verification, but not for "we got data back and it's corrupted") — a thrown `V17RiskParamsCorruptedError` there now degrades to relying on the `equity<=0n` signal alone instead of skipping the recheck entirely and falling through to submit the liquidation unconditionally.

4. **Alerting**: detecting corrupted risk params now fires a `sendCriticalAlert` (cooldown-latched per market at 15 minutes, not `AlertAggregator` — which is built for collapsing bursts of distinct events within seconds, not a sustained per-market condition re-evaluated every 60s scan cycle) instead of failing silently. The original bug had zero error or metric anywhere; a market stuck with corrupted risk params now pages an operator instead of quietly never liquidating anyone.

## Test results

New tests added to `tests/v17-risk-params.poc.test.ts` and `tests/services/liquidation.test.ts` (written first, confirmed failing against the unfixed code — 6 of 35 failed — then confirmed passing after the fix):

```
 Test Files  2 passed (2)
      Tests  35 passed (35)
```

Full suite, post-fix:

```
 Test Files  83 passed | 2 skipped (85)
      Tests  873 passed | 33 skipped (906)
```

`pnpm build` passes cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of risk parameters during liquidation candidate scanning to detect and alert on corrupted or out-of-range values.
  * Enhanced liquidation logic to handle edge cases where portfolio equity falls below critical thresholds, ensuring more reliable liquidation decisions.
  * Added rate-limited alerting for corrupted risk parameters to prevent alert fatigue while maintaining system observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->