### PR TITLE
fix(keeper): apply recoverable-state transitions on the LaserStream fast path

### DIFF
--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -881,6 +881,62 @@ export class CrankService {
     return ms + Math.floor(Math.random() * ms * 0.25);
   }
 
+  /**
+   * M-1: the three recoverable-state transitions below only require the
+   * market's own existing state (no fresh RPC discovery data), so they apply
+   * equally whether a market was just refreshed via the LaserStream fast
+   * path or via a full getProgramAccounts/MARKETS_FILTER rediscovery. They
+   * were previously inlined only in the full-rediscover branch, so a market
+   * stuck with elevated consecutiveFailures, foreignOracleSkipped=true, or in
+   * permanentlySkipped cooldown would not self-heal via the fast path for up
+   * to KEEPER_FULL_REDISCOVER_INTERVAL_MS (default 30 min) once LaserStream
+   * is enabled. Dead-market eviction (missingDiscoveryCount) is deliberately
+   * NOT included here -- it requires the full set of markets actually found
+   * by this cycle's RPC discovery to know what's missing, which the fast
+   * path (by design) never computes.
+   */
+  private _resetRecoverableMarketState(key: string, state: MarketCrankState): void {
+    // P1 FIX: Reset consecutiveFailures so markets can recover.
+    if (state.consecutiveFailures > 0) {
+      logger.debug("Resetting consecutive failures on rediscovery", {
+        slabAddress: key,
+        previousFailures: state.consecutiveFailures,
+      });
+      state.consecutiveFailures = 0;
+      state.isActive = true;
+    }
+    // GH#1508: Reset foreignOracleSkipped — oracle authority may have changed.
+    // crankMarket() will re-check and re-set it if the keeper is still not the authority.
+    if (state.foreignOracleSkipped) {
+      state.foreignOracleSkipped = false;
+      logger.debug("Re-checking foreign oracle skip on rediscovery", { slabAddress: key });
+    }
+    // PERC-381: Only re-enable permanently skipped (0x4) markets after a long cooldown
+    // to avoid crank→skip→rediscover→re-enable→crank thrash loop on stale slabs.
+    // Cooldown increases exponentially with skip count (1h, 2h, 4h, ... capped at 24h).
+    if (state.permanentlySkipped && state.permanentlySkippedAt) {
+      const skipCount = state.skipCount ?? 1;
+      const cooldownMs = Math.min(skipCount * 3_600_000, 24 * 3_600_000); // 1h per skip, max 24h
+      const elapsed = Date.now() - state.permanentlySkippedAt;
+      if (elapsed >= cooldownMs) {
+        state.permanentlySkipped = false;
+        state.consecutiveFailures = 0;
+        logger.info("Re-enabling permanently skipped market after cooldown", {
+          slabAddress: key,
+          cooldownMs,
+          skipCount,
+          elapsedMs: elapsed,
+        });
+      } else {
+        logger.debug("Permanently skipped market still in cooldown", {
+          slabAddress: key,
+          remainingMs: cooldownMs - elapsed,
+          skipCount,
+        });
+      }
+    }
+  }
+
   async discover(): Promise<DiscoveredMarket[]> {
     // When the LaserStream loader is active and the feature flag is set,
     // use the cache for the fast path. The slow-path full re-discover still
@@ -905,6 +961,10 @@ export class CrankService {
         let cacheHits = 0;
         for (const [, state] of this.markets) {
           const key = state.market.slabAddress.toBase58();
+          // M-1: run the same recoverable-state transitions the full-rediscover
+          // branch applies to "already known" markets, every fast-path tick --
+          // not just once every KEEPER_FULL_REDISCOVER_INTERVAL_MS.
+          this._resetRecoverableMarketState(key, state);
           const entry = cache.getOwnerVerified(key, currentSlot, expectedOwner);
           if (entry) {
             // Re-parse the slab from cached bytes so the market state reflects
@@ -1182,47 +1242,9 @@ export class CrankService {
           state.mainnetCA = dbMeta.mainnetCA;
         }
         state.missingDiscoveryCount = 0;
-        // P1 FIX: Reset consecutiveFailures on rediscovery so markets can recover.
-        // Previously, a market that hit MAX_CONSECUTIVE_FAILURES was dead until keeper restart.
-        // Now it gets a fresh chance every discovery cycle (default 5min).
-        if (state.consecutiveFailures > 0) {
-          logger.debug("Resetting consecutive failures on rediscovery", {
-            slabAddress: key,
-            previousFailures: state.consecutiveFailures,
-          });
-          state.consecutiveFailures = 0;
-          state.isActive = true;
-        }
-        // GH#1508: Reset foreignOracleSkipped on re-discovery — oracle authority may have changed.
-        // crankMarket() will re-check and re-set it if the keeper is still not the authority.
-        if (state.foreignOracleSkipped) {
-          state.foreignOracleSkipped = false;
-          logger.debug("Re-checking foreign oracle skip on rediscovery", { slabAddress: key });
-        }
-        // PERC-381: Only re-enable permanently skipped (0x4) markets after a long cooldown
-        // to avoid crank→skip→rediscover→re-enable→crank thrash loop on stale slabs.
-        // Cooldown increases exponentially with skip count (1h, 2h, 4h, ... capped at 24h).
-        if (state.permanentlySkipped && state.permanentlySkippedAt) {
-          const skipCount = state.skipCount ?? 1;
-          const cooldownMs = Math.min(skipCount * 3_600_000, 24 * 3_600_000); // 1h per skip, max 24h
-          const elapsed = Date.now() - state.permanentlySkippedAt;
-          if (elapsed >= cooldownMs) {
-            state.permanentlySkipped = false;
-            state.consecutiveFailures = 0;
-            logger.info("Re-enabling permanently skipped market after cooldown", {
-              slabAddress: key,
-              cooldownMs,
-              skipCount,
-              elapsedMs: elapsed,
-            });
-          } else {
-            logger.debug("Permanently skipped market still in cooldown", {
-              slabAddress: key,
-              remainingMs: cooldownMs - elapsed,
-              skipCount,
-            });
-          }
-        }
+        // M-1: P1 FIX / GH#1508 / PERC-381 transitions extracted into the
+        // shared helper so the LaserStream fast path applies them too.
+        this._resetRecoverableMarketState(key, state);
       }
     }
 

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -1730,4 +1730,136 @@ describe('CrankService', () => {
       service.stop();
     });
   });
+
+  // M-1: consecutiveFailures reset, foreignOracleSkipped reset, and the
+  // permanentlySkipped cooldown re-enable previously only ran in the
+  // full-rediscover branch -- a market recovering via the LaserStream fast
+  // path stayed stuck until the next full rediscover (default 30 min).
+  describe('M-1: LaserStream fast-path applies recoverable-state transitions', () => {
+    const EXPECTED_PROGRAM_ID = 'ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv';
+    const SLAB = 'RecoverSlab111111111111111111111111111111111';
+
+    let restoreEnv: () => void;
+
+    beforeEach(() => {
+      const prev = process.env.KEEPER_USE_LASERSTREAM;
+      process.env.KEEPER_USE_LASERSTREAM = 'true';
+      restoreEnv = () => {
+        if (prev === undefined) delete process.env.KEEPER_USE_LASERSTREAM;
+        else process.env.KEEPER_USE_LASERSTREAM = prev;
+      };
+    });
+
+    afterEach(() => {
+      restoreEnv();
+    });
+
+    function makeFakeLoader() {
+      return {
+        getCache: () => ({ getOwnerVerified: () => null }),
+        getProgramId: () => EXPECTED_PROGRAM_ID,
+        getStats: () => ({
+          connected: true,
+          lastSlot: 110,
+          eventsReceived: 0,
+          eventsDropped: 0,
+          reconnectCount: 0,
+        }),
+      } as any;
+    }
+
+    function makeMarket() {
+      return {
+        slabAddress: { toBase58: () => SLAB, equals: () => false },
+        programId: { toBase58: () => EXPECTED_PROGRAM_ID },
+        config: {
+          collateralMint: { toBase58: () => 'Mint1111111111111111111111111111111111111' },
+          oracleAuthority: { toBase58: () => 'Auth1111111111111111111111111111111111111', equals: () => false },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+      };
+    }
+
+    it('resets consecutiveFailures on a fast-path tick, not just on full rediscovery', async () => {
+      const service = new CrankService(mockOracleService, undefined, makeFakeLoader());
+      const internal: any = service;
+      internal.markets.set(SLAB, {
+        market: makeMarket(),
+        missingDiscoveryCount: 0,
+        consecutiveFailures: 7,
+        isActive: false,
+      });
+      internal._lastFullRediscoverTime = Date.now(); // stay in the fast-path window
+
+      await service.discover();
+
+      const state = internal.markets.get(SLAB);
+      expect(state.consecutiveFailures).toBe(0);
+      expect(state.isActive).toBe(true);
+
+      service.stop();
+    });
+
+    it('resets foreignOracleSkipped on a fast-path tick', async () => {
+      const service = new CrankService(mockOracleService, undefined, makeFakeLoader());
+      const internal: any = service;
+      internal.markets.set(SLAB, {
+        market: makeMarket(),
+        missingDiscoveryCount: 0,
+        consecutiveFailures: 0,
+        foreignOracleSkipped: true,
+      });
+      internal._lastFullRediscoverTime = Date.now();
+
+      await service.discover();
+
+      expect(internal.markets.get(SLAB).foreignOracleSkipped).toBe(false);
+
+      service.stop();
+    });
+
+    it('re-enables a permanentlySkipped market on a fast-path tick once its cooldown has elapsed', async () => {
+      const service = new CrankService(mockOracleService, undefined, makeFakeLoader());
+      const internal: any = service;
+      internal.markets.set(SLAB, {
+        market: makeMarket(),
+        missingDiscoveryCount: 0,
+        consecutiveFailures: 0,
+        permanentlySkipped: true,
+        permanentlySkippedAt: Date.now() - 3_600_001, // 1h cooldown (skipCount=1) elapsed
+        skipCount: 1,
+      });
+      internal._lastFullRediscoverTime = Date.now();
+
+      await service.discover();
+
+      const state = internal.markets.get(SLAB);
+      expect(state.permanentlySkipped).toBe(false);
+      expect(state.consecutiveFailures).toBe(0);
+
+      service.stop();
+    });
+
+    it('does NOT re-enable a permanentlySkipped market on a fast-path tick while still in cooldown', async () => {
+      const service = new CrankService(mockOracleService, undefined, makeFakeLoader());
+      const internal: any = service;
+      internal.markets.set(SLAB, {
+        market: makeMarket(),
+        missingDiscoveryCount: 0,
+        consecutiveFailures: 0,
+        permanentlySkipped: true,
+        permanentlySkippedAt: Date.now(), // just skipped, cooldown not elapsed
+        skipCount: 1,
+      });
+      internal._lastFullRediscoverTime = Date.now();
+
+      await service.discover();
+
+      expect(internal.markets.get(SLAB).permanentlySkipped).toBe(true);
+
+      service.stop();
+    });
+  });
 });


### PR DESCRIPTION
## Bug

`CrankService.discover()`'s LaserStream fast path (`KEEPER_USE_LASERSTREAM=true` with an active `AccountLoader`) refreshes cached account bytes for known markets and returns early, without running three lifecycle transitions that only lived in the full-rediscover branch: `consecutiveFailures` reset (P1 FIX), `foreignOracleSkipped` reset (GH#1508), and the `permanentlySkipped` cooldown re-enable (PERC-381).

## Impact

A market stuck with elevated `consecutiveFailures`, `foreignOracleSkipped=true`, or in `permanentlySkipped` cooldown would not self-heal via the fast path — it stays stuck until the next full rediscover, which only runs every `KEEPER_FULL_REDISCOVER_INTERVAL_MS` (default 30 minutes).

This was dormant when originally found — `AccountLoader` wasn't constructed anywhere in `index.ts` yet — but PR #262 wired up the LaserStream entrypoint, so this is now a live path in any `KEEPER_USE_LASERSTREAM=true` deployment.

## Fix

Extracts the three transitions (verbatim, no behavior change to the full-rediscover path) into a shared `_resetRecoverableMarketState()` helper, called from both the fast path's per-market loop and the full-rediscover branch's "already known market" case.

Dead-market eviction (`missingDiscoveryCount`) is deliberately **not** included — it requires the full set of markets actually found by that cycle's RPC discovery to know what's missing, which the fast path (by design, to avoid RPC load) never computes.

## Test results

New tests added to `tests/services/crank.test.ts` (written first, confirmed failing against the unfixed code — 3 of 4 failed — then confirmed passing after the fix):

```
 Test Files  1 passed (1)
      Tests  37 passed | 8 skipped (45)
```

Full suite, post-fix:

```
 Test Files  83 passed | 2 skipped (85)
      Tests  877 passed | 33 skipped (910)
```

`pnpm build` passes cleanly.