### PR TITLE
fix(keeper): treat zero tracked markets as healthy in /health, restore Railway healthcheck

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,13 @@ builder = "dockerfile"
 dockerfilePath = "Dockerfile"
 
 [deploy]
+# M-2: re-added after the root cause (src/lib/health-status.ts:
+# marketsTracked===0 used to fall through to "down" after the startup grace
+# period, even on a healthy fresh-mainnet deploy with no markets yet) was
+# fixed, rather than worked around by removing platform-level health gating
+# entirely (see commit e6b5d2a).
+healthcheckPath = "/health"
+healthcheckTimeout = 120
 startCommand = "node dist/index.js"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { getRedisClient } from "./lib/redis-client.js";
 import { LeaderLock, makeIdentity } from "./lib/leader.js";
 import { captureAndExit } from "./lib/exit-handlers.js";
 import { StartupTracker } from "./lib/startup-tracker.js";
+import { computeHealthStatus } from "./lib/health-status.js";
 import { sharedTxQueue, DRAIN_TIMEOUT_MS } from "./lib/tx-queue.js";
 import { sharedBudget, setLeaderCheck } from "./lib/keeper-send.js";
 import { initSharedShadowHarness, sharedShadowHarness } from "./lib/shadow-harness.js";
@@ -561,31 +562,20 @@ res.writeHead(401, secureJsonHeaders);
     const now = Date.now();
     const timeSinceLastCrank = mostRecentCrank > 0 ? now - mostRecentCrank : Infinity;
     const timeSinceLastOracle = mostRecentOracle > 0 ? now - mostRecentOracle : Infinity;
-    
-    // Determine health status
-    // Grace period: allow 5 minutes after startup before marking as "down"
-    const uptimeMs = now - startupTime;
-    let status: "ok" | "degraded" | "down" | "starting";
-    if (uptimeMs < 300_000 && mostRecentCrank === 0) {
-      status = "starting"; // Still warming up, no cranks yet
-    } else if (timeSinceLastCrank < 60_000) {
-      status = "ok";
-    } else if (timeSinceLastCrank < 300_000) {
-      status = "degraded";
-    } else {
-      status = "down";
-    }
 
-    // GH#2025: Also degrade/down if liquidation scanner has stalled
+    // Determine health status (M-2: extracted to a pure, testable helper —
+    // see src/lib/health-status.ts for why marketsTracked===0 short-circuits
+    // to "ok" rather than falling through to "down").
+    const uptimeMs = now - startupTime;
     const liqScanStatus = liquidationService.getStatus();
-    if (uptimeMs >= 300_000 && liqScanStatus.running) {
-      const timeSinceLiqScan = liqScanStatus.lastScanTime > 0 ? now - liqScanStatus.lastScanTime : Infinity;
-      if (timeSinceLiqScan > 300_000 && status !== "down") {
-        status = "down"; // Liquidation scan stalled >5 min
-      } else if (timeSinceLiqScan > 120_000 && status === "ok") {
-        status = "degraded"; // Liquidation scan stalled >2 min
-      }
-    }
+    const status = computeHealthStatus({
+      uptimeMs,
+      mostRecentCrank,
+      marketsTracked,
+      timeSinceLastCrank,
+      liqScanRunning: liqScanStatus.running,
+      timeSinceLiqScan: liqScanStatus.lastScanTime > 0 ? now - liqScanStatus.lastScanTime : Infinity,
+    });
     
     // ADL removed in v17 — always disabled.
     const adlStats: Record<string, unknown> = { enabled: false };

--- a/src/lib/health-status.ts
+++ b/src/lib/health-status.ts
@@ -1,0 +1,65 @@
+export interface HealthStatusInput {
+  /** Milliseconds since the process started. */
+  uptimeMs: number;
+  /** Timestamp (ms) of the most recent crank across all tracked markets, or 0 if never. */
+  mostRecentCrank: number;
+  /** Number of markets currently tracked by CrankService. */
+  marketsTracked: number;
+  /** Milliseconds since mostRecentCrank, or Infinity if mostRecentCrank===0. */
+  timeSinceLastCrank: number;
+  /** Whether the liquidation scanner's polling loop is currently running. */
+  liqScanRunning: boolean;
+  /** Milliseconds since the liquidation scanner's last scan, or Infinity if it has never scanned. */
+  timeSinceLiqScan: number;
+}
+
+/**
+ * M-2: pure status-computation helper, extracted from index.ts's /health
+ * handler so it can be unit tested without booting the whole module (which
+ * has top-level side effects on import).
+ *
+ * Originally, a deployment with zero tracked markets (a fresh mainnet
+ * deploy before any market is registered, or MARKETS_FILTER scoped to none
+ * yet -- both explicitly supported, intentional states) would have
+ * mostRecentCrank stuck at 0 forever, since there is nothing to crank.
+ * Once past the startup grace period this fell through to "down"
+ * permanently, even though the keeper was working exactly as designed
+ * (idling, retrying discovery each cycle). Railway's platform-level
+ * healthcheck was removed entirely as a workaround (commit e6b5d2a)
+ * instead of fixing this root cause -- this restores the healthcheck-worthy
+ * behavior by special-casing zero tracked markets as healthy.
+ */
+export function computeHealthStatus(
+  input: HealthStatusInput,
+): "ok" | "degraded" | "down" | "starting" {
+  const { uptimeMs, mostRecentCrank, marketsTracked, timeSinceLastCrank, liqScanRunning, timeSinceLiqScan } = input;
+
+  // Grace period: allow 5 minutes after startup before marking as "down".
+  if (uptimeMs < 300_000 && mostRecentCrank === 0) {
+    return "starting";
+  }
+
+  if (marketsTracked === 0) {
+    return "ok";
+  }
+
+  let status: "ok" | "degraded" | "down";
+  if (timeSinceLastCrank < 60_000) {
+    status = "ok";
+  } else if (timeSinceLastCrank < 300_000) {
+    status = "degraded";
+  } else {
+    status = "down";
+  }
+
+  // GH#2025: also degrade/down if the liquidation scanner has stalled.
+  if (uptimeMs >= 300_000 && liqScanRunning) {
+    if (timeSinceLiqScan > 300_000 && status !== "down") {
+      status = "down"; // Liquidation scan stalled >5 min
+    } else if (timeSinceLiqScan > 120_000 && status === "ok") {
+      status = "degraded"; // Liquidation scan stalled >2 min
+    }
+  }
+
+  return status;
+}

--- a/tests/lib/health-status.test.ts
+++ b/tests/lib/health-status.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { computeHealthStatus } from "../../src/lib/health-status.js";
+
+function base() {
+  return {
+    uptimeMs: 600_000, // past the 5-minute startup grace period
+    mostRecentCrank: Date.now() - 10_000,
+    marketsTracked: 1,
+    timeSinceLastCrank: 10_000,
+    liqScanRunning: true,
+    timeSinceLiqScan: 10_000,
+  };
+}
+
+describe("computeHealthStatus", () => {
+  it("returns 'starting' within the grace period when no crank has happened yet", () => {
+    const status = computeHealthStatus({
+      ...base(),
+      uptimeMs: 100_000,
+      mostRecentCrank: 0,
+      timeSinceLastCrank: Infinity,
+    });
+    expect(status).toBe("starting");
+  });
+
+  // M-2: a deployment with zero tracked markets has nothing to crank by
+  // design (fresh mainnet deploy before any market is registered, or
+  // MARKETS_FILTER scoped to none yet) -- mostRecentCrank can never advance,
+  // so without this case status would permanently fall through to "down"
+  // after the startup grace period.
+  it("returns 'ok' when marketsTracked===0, even well past the startup grace period", () => {
+    const status = computeHealthStatus({
+      uptimeMs: 24 * 3_600_000, // a full day of uptime
+      mostRecentCrank: 0,
+      marketsTracked: 0,
+      timeSinceLastCrank: Infinity,
+      liqScanRunning: true,
+      timeSinceLiqScan: 10_000,
+    });
+    expect(status).toBe("ok");
+  });
+
+  it("returns 'ok' for a recently-cranked market", () => {
+    expect(computeHealthStatus(base())).toBe("ok");
+  });
+
+  it("returns 'degraded' when the most recent crank is between 1 and 5 minutes old", () => {
+    const status = computeHealthStatus({ ...base(), timeSinceLastCrank: 120_000 });
+    expect(status).toBe("degraded");
+  });
+
+  it("returns 'down' when the most recent crank is more than 5 minutes old", () => {
+    const status = computeHealthStatus({ ...base(), timeSinceLastCrank: 400_000 });
+    expect(status).toBe("down");
+  });
+
+  it("downgrades 'ok' to 'degraded' when the liquidation scanner has stalled 2-5 minutes", () => {
+    const status = computeHealthStatus({ ...base(), timeSinceLiqScan: 150_000 });
+    expect(status).toBe("degraded");
+  });
+
+  it("downgrades to 'down' when the liquidation scanner has stalled more than 5 minutes", () => {
+    const status = computeHealthStatus({ ...base(), timeSinceLiqScan: 400_000 });
+    expect(status).toBe("down");
+  });
+
+  it("does not apply the liquidation-scan stall check before the startup grace period elapses", () => {
+    const status = computeHealthStatus({
+      ...base(),
+      uptimeMs: 100_000,
+      timeSinceLiqScan: 400_000,
+    });
+    expect(status).toBe("ok");
+  });
+
+  it("does not apply the liquidation-scan stall check when the scanner isn't running", () => {
+    const status = computeHealthStatus({
+      ...base(),
+      liqScanRunning: false,
+      timeSinceLiqScan: 400_000,
+    });
+    expect(status).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Bug

`/health`'s status computation in `src/index.ts` derives status purely from elapsed time since the most recent crank. If `mostRecentCrank` never advances — a fresh mainnet deploy with no markets registered yet, or `MARKETS_FILTER` scoped to none — status permanently falls through to `"down"` once the 5-minute startup grace period elapses, even though the keeper is working exactly as designed (idling, retrying discovery each cycle — explicitly noted as normal elsewhere in this same file).

## Impact

Railway's platform-level healthcheck was removed entirely as a workaround (commit `e6b5d2a`, "fix: remove healthcheck from railway.toml — no markets on fresh mainnet") instead of fixing this root cause. That disables deploy-promotion gating and auto-restart-on-unhealthy for **every** deploy on this service, not just the zero-market case — a keeper that's alive-but-wedged (e.g. stuck in an RPC retry loop) no longer gets caught by Railway's own health monitoring.

## Fix

- Extracts the status computation into a pure, testable `src/lib/health-status.ts` (`index.ts` has top-level side effects on import and isn't otherwise unit tested — this follows the same pattern already used for `computeMarginRatioBps` in `liquidation.ts`).
- Adds the `marketsTracked === 0` special case: an idle, zero-market keeper now reports `"ok"` instead of falling through to `"down"`.
- Restores `healthcheckPath = "/health"` / `healthcheckTimeout = 120` in `railway.toml` now that the underlying bug is fixed, regaining Railway's deploy-promotion gating and auto-restart-on-unhealthy.

## Test results

New tests added in `tests/lib/health-status.test.ts` covering the startup grace period, the zero-markets case, normal ok/degraded/down transitions, and the liquidation-scan-stall interaction:

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Full suite, post-fix:

```
 Test Files  84 passed | 2 skipped (86)
      Tests  878 passed | 33 skipped (911)
```

`pnpm build` passes cleanly.