### PR TITLE
fix(keeper): bound priority-fee cache size to prevent unbounded growth

### DIFF
--- a/src/lib/priority-fee.ts
+++ b/src/lib/priority-fee.ts
@@ -8,6 +8,7 @@ export type PriorityFeeTier = "crank" | "liquidation" | "oracle" | "adl";
 
 const FALLBACK_MICROLAMPORTS = 1_000;
 const DEFAULT_CACHE_MS = 5_000;
+const DEFAULT_CACHE_MAX_ENTRIES = 1_000;
 
 /** Default percentiles per tier (overridable via env). ADL is liquidation-priority. */
 const DEFAULT_PERCENTILES: Record<PriorityFeeTier, number> = {
@@ -80,9 +81,10 @@ function percentileToLevel(p: number): string {
 export class HeliusPriorityFeeEstimator implements PriorityFeeEstimator {
   private readonly _rpcUrl: string;
   private readonly _cacheMs: number;
+  private readonly _cacheMaxEntries: number;
   private readonly _cache = new Map<string, { value: number; expiresAt: number }>();
 
-  constructor(rpcUrl?: string, opts?: { cacheMs?: number }) {
+  constructor(rpcUrl?: string, opts?: { cacheMs?: number; cacheMaxEntries?: number }) {
     this._rpcUrl =
       rpcUrl ??
       process.env.HELIUS_RPC_URL ??
@@ -92,6 +94,34 @@ export class HeliusPriorityFeeEstimator implements PriorityFeeEstimator {
     this._cacheMs =
       opts?.cacheMs ??
       parseInt(process.env.KEEPER_PRIORITY_FEE_CACHE_MS ?? String(DEFAULT_CACHE_MS), 10);
+    this._cacheMaxEntries =
+      opts?.cacheMaxEntries ??
+      parseInt(
+        process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES ?? String(DEFAULT_CACHE_MAX_ENTRIES),
+        10,
+      );
+  }
+
+  /**
+   * The cache key is derived from the full account-key set, which varies
+   * per market/instruction shape and grows without bound over the life of
+   * a long-running keeper as markets are added/removed and discovery
+   * cycles touch new account combinations. Without this, entries for
+   * stale/never-repeated key sets would accumulate in `_cache` forever
+   * (Map.set never overwrites a *different* key, and nothing else ever
+   * deletes from it).
+   */
+  private _evictStaleEntries(now: number): void {
+    for (const [key, entry] of this._cache) {
+      if (now >= entry.expiresAt) {
+        this._cache.delete(key);
+      }
+    }
+    while (this._cache.size >= this._cacheMaxEntries) {
+      const oldestKey = this._cache.keys().next().value;
+      if (oldestKey === undefined) break;
+      this._cache.delete(oldestKey);
+    }
   }
 
   async estimate(accountKeys: string[], tier: PriorityFeeTier): Promise<number> {
@@ -144,7 +174,9 @@ export class HeliusPriorityFeeEstimator implements PriorityFeeEstimator {
       }
 
       const value = Math.round(fee);
-      this._cache.set(cacheKey, { value, expiresAt: Date.now() + this._cacheMs });
+      const now = Date.now();
+      this._evictStaleEntries(now);
+      this._cache.set(cacheKey, { value, expiresAt: now + this._cacheMs });
       // Only emit the gauge for non-trivial fees to avoid label noise from zero-fee routes.
       if (value > 0) {
         priorityFeeMicrolamports.set({ accountSet_hash: accountSetHash(accountKeys), tier }, value);

--- a/tests/lib/priority-fee.test.ts
+++ b/tests/lib/priority-fee.test.ts
@@ -192,4 +192,83 @@ describe("HeliusPriorityFeeEstimator", () => {
       else process.env.KEEPER_PRIORITY_FEE_PERCENTILE_CRANK = origEnv;
     }
   });
+
+  describe("M-4: bounded cache size", () => {
+    function cacheSize(estimator: HeliusPriorityFeeEstimator): number {
+      return (estimator as unknown as { _cache: Map<string, unknown> })._cache.size;
+    }
+
+    it("never exceeds cacheMaxEntries even with many distinct never-repeated account-key sets", async () => {
+      global.fetch = mockFetch(HELIUS_SUCCESS_RESPONSE);
+      const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", {
+        cacheMs: 60_000,
+        cacheMaxEntries: 5,
+      });
+
+      for (let i = 0; i < 20; i++) {
+        await estimator.estimate([`acc${i}`], "crank");
+      }
+
+      expect(cacheSize(estimator)).toBeLessThanOrEqual(5);
+    });
+
+    it("evicts the oldest entry once cacheMaxEntries is reached, forcing a re-fetch for it", async () => {
+      const fetchFn = mockFetch(HELIUS_SUCCESS_RESPONSE);
+      global.fetch = fetchFn;
+      const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", {
+        cacheMs: 60_000,
+        cacheMaxEntries: 2,
+      });
+
+      await estimator.estimate(["acc1"], "crank");
+      await estimator.estimate(["acc2"], "crank");
+      await estimator.estimate(["acc3"], "crank"); // pushes acc1 out
+
+      expect(fetchFn).toHaveBeenCalledTimes(3);
+
+      await estimator.estimate(["acc1"], "crank"); // evicted -- must re-fetch
+
+      expect(fetchFn).toHaveBeenCalledTimes(4);
+    });
+
+    it("sweeps expired entries on write instead of letting them accumulate until re-queried", async () => {
+      vi.useFakeTimers();
+      global.fetch = mockFetch(HELIUS_SUCCESS_RESPONSE);
+      const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", {
+        cacheMs: 1_000,
+        cacheMaxEntries: 1_000,
+      });
+
+      await estimator.estimate(["acc1"], "crank");
+      expect(cacheSize(estimator)).toBe(1);
+
+      vi.advanceTimersByTime(1_001); // acc1's entry is now expired but never re-queried
+      await estimator.estimate(["acc2"], "crank");
+
+      // Without sweeping, both the expired acc1 entry and the new acc2 entry
+      // would sit in the map (size 2), even though acc1 is dead weight.
+      expect(cacheSize(estimator)).toBe(1);
+    });
+
+    it("reads cacheMaxEntries from KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES when no explicit option is given", async () => {
+      const origEnv = process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES;
+      process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES = "3";
+      try {
+        const fetchFn = mockFetch(HELIUS_SUCCESS_RESPONSE);
+        global.fetch = fetchFn;
+        const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", {
+          cacheMs: 60_000,
+        });
+
+        for (let i = 0; i < 10; i++) {
+          await estimator.estimate([`acc${i}`], "crank");
+        }
+
+        expect(cacheSize(estimator)).toBeLessThanOrEqual(3);
+      } finally {
+        if (origEnv === undefined) delete process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES;
+        else process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES = origEnv;
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Bug

`HeliusPriorityFeeEstimator._cache` (`src/lib/priority-fee.ts`) is a `Map<string, { value, expiresAt }>` keyed by `tier:hash(accountKeys)`. Entries are only ever inserted (`_cache.set(...)`) — nothing ever calls `_cache.delete(...)`. There is no TTL sweep, no LRU, and no max-size cap.

`accountKeys` varies per market and per instruction shape, so over the life of a long-running keeper process (markets added/removed, discovery cycles touching different account-key combinations), the cache accumulates one entry per distinct key set ever seen — including entries whose TTL expired long ago and that are never queried again. This is an unbounded memory leak proportional to total distinct account-key sets observed over the process lifetime, not to the working set actually in use.

## Fix

Added `_evictStaleEntries(now)`, called on the write path right before every `_cache.set(...)`:
1. Drop any entry already past its `expiresAt` (the cheap, common case — most growth is dead TTL'd entries that were never re-queried).
2. If the cache is still at/over a configurable size cap after the sweep, evict oldest-inserted entries (`Map` preserves insertion order) until back under the cap — a backstop for bursts of many distinct never-repeating key sets within a single TTL window.

Cap defaults to 1000 entries, overridable via `KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES` or the `cacheMaxEntries` constructor option (mirrors the existing `cacheMs`/`KEEPER_PRIORITY_FEE_CACHE_MS` pattern).

## Test plan

New `describe("M-4: bounded cache size", ...)` block in `tests/lib/priority-fee.test.ts` (4 tests):
- Cache size never exceeds `cacheMaxEntries` across 20 distinct never-repeated account-key sets.
- Reaching the cap evicts the oldest entry, forcing a re-fetch when it's queried again.
- Expired entries are swept on the next write rather than sitting until directly re-queried.
- `KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES` env var is respected when no explicit option is passed.

Confirmed all 4 fail against the pre-fix code (`git stash` the source change, re-run) — each asserts a bound the old code has no mechanism to enforce.

- `pnpm build` — clean.
- `pnpm test` — full suite green, no regressions (869 passed / 33 skipped).