### PR TITLE
fix(keeper): pass expectedOwner to fetchSlab to enforce on-chain owner check

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -54,6 +54,7 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
  */
 async function fetchSlabWithRetry(
   slabPubkey: PublicKey,
+  expectedOwner: PublicKey,
   maxRetries = 3,
 ): Promise<Uint8Array> {
   let lastErr: unknown;
@@ -62,7 +63,7 @@ async function fetchSlabWithRetry(
     try {
       await acquireToken();
       return await withTimeout(
-        fetchSlab(conn, slabPubkey),
+        fetchSlab(conn, slabPubkey, expectedOwner),
         RPC_TIMEOUT_MS,
         `fetchSlab(${slabPubkey.toBase58()})`,
       );
@@ -446,7 +447,7 @@ export class LiquidationService {
     const slabAddress = market.slabAddress.toBase58();
 
     try {
-      const data = await fetchSlabWithRetry(market.slabAddress);
+      const data = await fetchSlabWithRetry(market.slabAddress, market.programId);
 
       // DESYNC-3 FIX: Route v17 accounts through the portfolio-based scanner.
       if (isV17Account(data)) {
@@ -800,7 +801,7 @@ export class LiquidationService {
           // (wasted fee). Mirrors the v12.x recheck below and uses the same fee-debt-aware
           // equity as the scanner (#230). scanPriceE6 is the scan-time price; if it's
           // unavailable (0) we keep the leg-active check + rely on the on-chain program.
-          const freshMarketData = await fetchSlabWithRetry(slabAddress);
+          const freshMarketData = await fetchSlabWithRetry(slabAddress, programId);
           const reMmBps = parseV17RiskParams(freshMarketData).maintenanceMarginBps;
           const freshNowSec = await fetchClusterUnixTimeSec(connection);
           const freshPrice = resolveV17WrapperPrice(parseWrapperConfigV17(freshMarketData), freshNowSec);
@@ -856,7 +857,7 @@ export class LiquidationService {
       } else {
       // Bug 3: Re-read slab data and verify account before submitting (v12.x path)
       {
-        const freshData = await fetchSlabWithRetry(slabAddress);
+        const freshData = await fetchSlabWithRetry(slabAddress, programId);
         const freshEngine = parseEngine(freshData);
         const freshParams = parseParams(freshData);
         const freshCfg = parseConfig(freshData);

--- a/src/services/monitor.ts
+++ b/src/services/monitor.ts
@@ -191,7 +191,7 @@ export class MonitorService {
       // ── 6.1: Conservation invariant ───────────────────────────────────────
       try {
         const data = await withTimeout(
-          fetchSlab(conn, crankState.market.slabAddress),
+          fetchSlab(conn, crankState.market.slabAddress, crankState.market.programId),
           MONITOR_RPC_TIMEOUT_MS,
           `fetchSlab(${slabAddress.slice(0, 8)})`,
         );

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -267,6 +267,15 @@ describe('LiquidationService', () => {
       expect(candidates).toHaveLength(1);
       expect(candidates[0].accountIdx).toBe(0);
       expect(candidates[0].marginRatio).toBeLessThan(5); // Below 5%
+
+      // M-6: fetchSlab must be called with the market's own programId so the
+      // SDK's owner check (fetchSlab throws if info.owner !== expectedOwner)
+      // actually runs, instead of trusting whatever account is at that pubkey.
+      expect(core.fetchSlab).toHaveBeenCalledWith(
+        expect.anything(),
+        mockMarket.slabAddress,
+        mockMarket.programId,
+      );
     });
 
     it('should find undercollateralized accounts in Pyth-pinned oracle mode', async () => {
@@ -474,6 +483,14 @@ describe('LiquidationService', () => {
 
       expect(sig).toBeNull();
       expect(keeperSendModule.keeperSend).not.toHaveBeenCalled();
+
+      // M-6: the v17 pre-submit recheck's fetchSlab call must pass the
+      // market's programId as expectedOwner, not just the slab pubkey.
+      expect(core.fetchSlab).toHaveBeenCalledWith(
+        expect.anything(),
+        slabAddress,
+        market.programId,
+      );
     });
 
     it('should execute liquidation with multi-instruction transaction', async () => {
@@ -519,6 +536,12 @@ describe('LiquidationService', () => {
         expect.any(String),
         expect.objectContaining({ accountIdx: 0 })
       );
+
+      // M-6: the pre-submit recheck's fetchSlab call (re-reading the slab right
+      // before submitting) must also pass the market's programId as expectedOwner.
+      for (const call of vi.mocked(core.fetchSlab).mock.calls) {
+        expect(call[2]).toBe(mockMarket.programId);
+      }
     });
 
     it('should increment liquidation count on success', async () => {

--- a/tests/services/monitor.test.ts
+++ b/tests/services/monitor.test.ts
@@ -70,4 +70,27 @@ describe("MonitorService", () => {
       }),
     ]);
   });
+
+  it("M-6: passes the market's programId to fetchSlab as expectedOwner", async () => {
+    const service = new MonitorService();
+    const slabAddress = "11111111111111111111111111111111";
+    const programId = new PublicKey("So11111111111111111111111111111111111111112");
+    const market = {
+      slabAddress: new PublicKey(slabAddress),
+      programId,
+    };
+    const markets = new Map([[slabAddress, { market }]]);
+
+    vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array([1, 2, 3]));
+    vi.mocked(sdk.isV17Account).mockReturnValue(true);
+
+    service.setMarketSource(() => markets as any);
+    await (service as any)._runChecks();
+
+    expect(sdk.fetchSlab).toHaveBeenCalledWith(
+      expect.anything(),
+      market.slabAddress,
+      programId,
+    );
+  });
 });


### PR DESCRIPTION
## Bug

`fetchSlab(connection, slabPubkey, expectedOwner?)` (from `@percolatorct/sdk`) only checks that the fetched account is owned by the Percolator program when `expectedOwner` is passed:

```ts
if (expectedOwner && !info.owner.equals(expectedOwner)) {
  throw new Error(`fetchSlab: account ${slabPubkey} is owned by ${info.owner} but expected ${expectedOwner}`);
}
```

Both real call sites in this repo omit it:
- `liquidation.ts`'s `fetchSlabWithRetry` (used by `scanMarket`, and both the v17 and v12.x pre-submit rechecks in `liquidate`)
- `monitor.ts`'s conservation-invariant check

Without `expectedOwner`, the only validation left is the caller's later magic-byte parsing (`parseHeader`/`isV17Account`). A magic-byte match at the right offsets is not equivalent to an owner check — a misrouted or crafted account (e.g. from a compromised/buggy RPC response, or any future code path that derives a slab pubkey from less-trusted input) with the right header layout would be silently accepted as a legitimate market/slab account, feeding liquidation decisions, margin-ratio checks, and the crank's conservation-invariant monitor from data the Percolator program never actually wrote.

## Fix

Pass the market's `programId` (already in scope as `DiscoveredMarket.programId` at every call site) through as `expectedOwner`:
- `liquidation.ts`: `fetchSlabWithRetry` now takes an `expectedOwner: PublicKey` parameter, threaded through to all 3 call sites (`scanMarket`, v17 recheck, v12.x recheck).
- `monitor.ts`: `fetchSlab(conn, crankState.market.slabAddress, crankState.market.programId)`.

Pure plumbing — no new RPC calls, no behavior change for the happy path (where the account genuinely is owned by the program).

## Test plan

- New assertions confirming `fetchSlab` is called with the market's `programId` as the third argument, at all 4 affected call sites (`tests/services/liquidation.test.ts` x3, `tests/services/monitor.test.ts` x1).
- Confirmed all 4 fail against the pre-fix code (`git stash` the source change, re-run).
- `pnpm build` — clean.
- `pnpm test` — full suite green, no regressions (866 passed / 33 skipped).