### PR TITLE
fix(keeper): derive mainnet program id from a single canonical source

### DIFF
--- a/src/lib/account-loader.ts
+++ b/src/lib/account-loader.ts
@@ -3,10 +3,10 @@ import { createLogger } from "@percolatorct/shared";
 import { AccountCache } from "./account-cache.js";
 import { ReconnectBackoff } from "./stream-reconnect.js";
 import { SlotTracker } from "./slot-tracker.js";
+import { MAINNET_PROGRAM_ID } from "./boot-assertions.js";
 
 const logger = createLogger("keeper:account-loader");
 
-const MAINNET_PROGRAM_ID = "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv";
 const DEFAULT_DROP_QUEUE_MAX = 10_000;
 // C3: getMultipleAccountsInfo RPC accepts up to 100 pubkeys per call.
 const SNAPSHOT_CHUNK_SIZE = 100;

--- a/src/lib/shadow-harness.ts
+++ b/src/lib/shadow-harness.ts
@@ -38,6 +38,7 @@ import {
   shadowMatchTotal,
   shadowDivergencePct,
 } from "./metrics.js";
+import { MAINNET_PROGRAM_ID as FALLBACK_PROGRAM_ID } from "./boot-assertions.js";
 
 const logger = createLogger("keeper:shadow-harness");
 
@@ -52,9 +53,6 @@ const DEFAULT_SILENT_CYCLES_BEFORE_ALERT = 3;   // ~15 min at 5 min/cycle
 const DEFAULT_RUNAWAY_MULTIPLIER = 3;            // shadow > 3x live
 const DEFAULT_RUNAWAY_MIN_SAMPLES = 10;          // small-sample guard
 const DEFAULT_ALERT_COOLDOWN_MS = 3_600_000;     // 1 hour between alerts
-// When the program id is not set in env, fall back to the mainnet constant.
-// This constant must match MAINNET_PROGRAM_ID in boot-assertions.ts.
-const FALLBACK_PROGRAM_ID = "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv";
 
 export interface ShadowCompareResult {
   windowMs: number;

--- a/tests/lib/account-loader.test.ts
+++ b/tests/lib/account-loader.test.ts
@@ -488,6 +488,15 @@ describe("AccountLoader", () => {
   });
 });
 
+describe("AccountLoader — M-7: canonical program id", () => {
+  it("defaults to the canonical MAINNET_PROGRAM_ID (boot-assertions.js) when no programId override is given", async () => {
+    const { MAINNET_PROGRAM_ID } = await import("../../src/lib/boot-assertions.js");
+    const l = new AccountLoader(BASE_OPTS, new FakeAdapter());
+    expect(l.getProgramId()).toBe(MAINNET_PROGRAM_ID);
+    await l.stop();
+  });
+});
+
 describe("AccountLoader stress test", () => {
   it.skipIf(!process.env.STRESS)(
     "processes 10k events/sec for 60s without counter drift",

--- a/tests/lib/shadow-harness.test.ts
+++ b/tests/lib/shadow-harness.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../src/lib/metrics.js", () => ({
 
 import * as shared from "@percolatorct/shared";
 import { ShadowHarness, computeDivergencePct } from "../../src/lib/shadow-harness.js";
+import { MAINNET_PROGRAM_ID } from "../../src/lib/boot-assertions.js";
 import type { DecisionEntry } from "../../src/lib/decision-log.js";
 import type { Connection } from "@solana/web3.js";
 import { PublicKey } from "@solana/web3.js";
@@ -358,6 +359,29 @@ describe("ShadowHarness — comparison logic", () => {
     expect(() => harness.start()).not.toThrow(); // idempotent
     expect(() => harness.stop()).not.toThrow();
     expect(() => harness.stop()).not.toThrow(); // idempotent
+  });
+
+  it("M-7: falls back to the canonical MAINNET_PROGRAM_ID (boot-assertions.js) when no programId/PROGRAM_ID is given", async () => {
+    const origEnv = process.env.PROGRAM_ID;
+    delete process.env.PROGRAM_ID;
+    try {
+      const conn = makeConnection(0);
+      const harness = new ShadowHarness({
+        connection: conn,
+        readDecisions: vi.fn(async () => []),
+        compareWindowMs: 300_000,
+      });
+      await harness.runCycle();
+      expect(conn.getSignaturesForAddress).toHaveBeenCalledWith(
+        expect.objectContaining({ toBase58: expect.any(Function) }),
+        expect.anything(),
+      );
+      const calledWith = vi.mocked(conn.getSignaturesForAddress).mock.calls[0][0] as PublicKey;
+      expect(calledWith.toBase58()).toBe(MAINNET_PROGRAM_ID);
+    } finally {
+      if (origEnv === undefined) delete process.env.PROGRAM_ID;
+      else process.env.PROGRAM_ID = origEnv;
+    }
   });
 });
 


### PR DESCRIPTION
## Bug

The mainnet Percolator program id (`ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv`) was hardcoded independently in 3 places:

- `src/lib/account-loader.ts`: `const MAINNET_PROGRAM_ID = "ESa89..."`
- `src/lib/shadow-harness.ts`: `const FALLBACK_PROGRAM_ID = "ESa89..."` — with a comment literally saying *"This constant must match MAINNET_PROGRAM_ID in boot-assertions.ts"*
- `src/lib/boot-assertions.ts`: `export const MAINNET_PROGRAM_ID = "ESa89..."` — the intentional security anchor (per its own doc comment: hardcoded and never read from env on mainnet, so a typo/stale config can't redirect signing to a different program)

Three independent copies kept in sync only by a comment is a silent-drift risk: a future program upgrade/migration that updates the canonical constant in `boot-assertions.ts` has no compiler or test signal forcing the other two copies to follow. `account-loader.ts` determines which accounts the keeper subscribes to and `shadow-harness.ts` determines which live transactions it compares against — both go directly to security-relevant boot assertions if they ever diverge from the canonical value.

## Fix

`account-loader.ts` and `shadow-harness.ts` now import `MAINNET_PROGRAM_ID` from `boot-assertions.ts` instead of maintaining their own copies. `boot-assertions.ts` has zero imports, so this introduces no circular dependency.

This is a structural fix, not a behavioral one — the three values were already identical today, so there's nothing for a test to "catch" pre-fix (reverting the source change doesn't change current behavior, since the hardcoded literal already equals the canonical one). The new tests instead pin the *wiring*: they assert the default resolves through the actual import, not a coincidentally-equal literal, so a future edit to the canonical constant is automatically picked up everywhere instead of silently diverging.

## Test plan

- New test in `tests/lib/account-loader.test.ts`: `AccountLoader` with no `programId` override resolves `getProgramId()` to the imported `MAINNET_PROGRAM_ID`.
- New test in `tests/lib/shadow-harness.test.ts`: `ShadowHarness` with no `programId`/`PROGRAM_ID` env falls back to the imported `MAINNET_PROGRAM_ID` when calling `getSignaturesForAddress`.
- `pnpm build` — clean.
- `pnpm test` — full suite green, no regressions (867 passed / 33 skipped).