### PR TITLE
fix: validate fraud detector env config

### DIFF
--- a/src/services/fraud-detector.ts
+++ b/src/services/fraud-detector.ts
@@ -59,15 +59,47 @@ export function divergenceBps(onchain: bigint | number, offchain: bigint | numbe
 }
 
 // Config
+const DEFAULT_INTERVAL_MS = 30_000;
+const DEFAULT_DIVERGENCE_THRESHOLD_BPS = 500;
+const DEFAULT_PER_MINT_COOLDOWN_MS = 1_800_000;
+
+function parseBoundedIntEnv(
+  name: string,
+  fallback: number,
+  min: number,
+  max = Number.MAX_SAFE_INTEGER,
+): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min || value > max) {
+    return fallback;
+  }
+
+  return value;
+}
+
 function getIntervalMs(): number {
-  return parseInt(process.env.FRAUD_DETECT_INTERVAL_MS ?? "30000", 10);
+  return parseBoundedIntEnv("FRAUD_DETECT_INTERVAL_MS", DEFAULT_INTERVAL_MS, 1_000);
 }
+
 function getDivergenceThresholdBps(): number {
-  return parseInt(process.env.FRAUD_DETECT_DIVERGENCE_BPS ?? "500", 10);
+  return parseBoundedIntEnv(
+    "FRAUD_DETECT_DIVERGENCE_BPS",
+    DEFAULT_DIVERGENCE_THRESHOLD_BPS,
+    0,
+  );
 }
+
 function getPerMintCooldownMs(): number {
-  return parseInt(process.env.FRAUD_DETECT_PER_MINT_COOLDOWN_MS ?? "1800000", 10);
+  return parseBoundedIntEnv(
+    "FRAUD_DETECT_PER_MINT_COOLDOWN_MS",
+    DEFAULT_PER_MINT_COOLDOWN_MS,
+    0,
+  );
 }
+
 function isEnabled(): boolean {
   return process.env.FRAUD_DETECT_ENABLED !== "false";
 }

--- a/tests/services/fraud-detector.test.ts
+++ b/tests/services/fraud-detector.test.ts
@@ -396,12 +396,68 @@ describe("FraudDetectorService", () => {
     const mainnetCA = "So11111111111111111111111111111111111111112";
     const state = makeHyperpState({ markPriceE6: 1_000_000n, mainnetCA });
     const markets = new Map([["slab1", state]]);
-    const oracle = makeMockOracle({ priceE6: 1_000_000n, source: "dexscreener", timestamp: Date.now() });
+    const oracle = makeMockOracle({
+      priceE6: 1_000_000n,
+      source: "dexscreener",
+      timestamp: Date.now(),
+    });
 
     const svc = new FraudDetectorService(oracle, () => markets);
     await svc._runCheck();
 
     // fetchPrice should be called with mainnetCA, not the collateral mint
     expect(oracle.fetchPrice).toHaveBeenCalledWith(mainnetCA, "slab1");
+  });
+
+  // ── malformed env config PoC ───────────────────────────────────────────────
+
+  it("falls back to the default divergence threshold when FRAUD_DETECT_DIVERGENCE_BPS is malformed", async () => {
+    process.env.FRAUD_DETECT_DIVERGENCE_BPS = "abc";
+    mockWarnAlertFn.mockReturnValue(Promise.resolve());
+
+    // on-chain: $1.01, off-chain: $1.00 → 100 bps.
+    // With the default 500 bps threshold, this should NOT alert.
+    const onChain = 1_010_000n;
+    const offChain = 1_000_000n;
+
+    const state = makeHyperpState({ markPriceE6: onChain });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeMockOracle({
+      priceE6: offChain,
+      source: "dexscreener",
+      timestamp: Date.now(),
+    });
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+    await svc._runCheck();
+
+    expect(mockWarnAlertFn).not.toHaveBeenCalled();
+    expect(mockFraudAlertTotal.inc).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default cooldown when FRAUD_DETECT_PER_MINT_COOLDOWN_MS is negative", async () => {
+    process.env.FRAUD_DETECT_DIVERGENCE_BPS = "500";
+    process.env.FRAUD_DETECT_PER_MINT_COOLDOWN_MS = "-1";
+    mockWarnAlertFn.mockReturnValue(Promise.resolve());
+
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const state = makeHyperpState({ markPriceE6: 2_000_000n });
+    const markets = new Map([["slab1", state]]);
+    const oracle = makeMockOracle({
+      priceE6: 1_000_000n,
+      source: "dexscreener",
+      timestamp: Date.now(),
+    });
+
+    const svc = new FraudDetectorService(oracle, () => markets);
+
+    await svc._runCheck();
+    await svc._runCheck();
+
+    expect(mockWarnAlertFn).toHaveBeenCalledTimes(1);
+    expect(mockFraudAlertTotal.inc).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

This PR validates fraud detector environment configuration values before using them at runtime.

Previously, the fraud detector parsed several env values with raw `parseInt(...)` and used the result directly. This allowed malformed or out-of-range values such as `abc`, `-1`, or `0` to become active runtime config.

Fixes #290.

## Changes

* Add bounded integer parsing for fraud detector env values.
* Fall back to safe defaults when env values are malformed or out of range.
* Prevent malformed `FRAUD_DETECT_DIVERGENCE_BPS` from becoming `NaN`.
* Prevent negative `FRAUD_DETECT_PER_MINT_COOLDOWN_MS` from bypassing cooldown suppression.
* Prevent unsafe `FRAUD_DETECT_INTERVAL_MS` values below `1000ms`.
* Add regression tests covering malformed divergence threshold and negative cooldown config.

## Why

The fraud detector uses these values to decide when to emit alerts and when to suppress repeated alerts for the same mint.

Before this change:

* `FRAUD_DETECT_DIVERGENCE_BPS=abc` produced `NaN`, which allowed small divergences to fall through into the alert path.
* `FRAUD_DETECT_PER_MINT_COOLDOWN_MS=-1` disabled effective cooldown suppression and allowed repeated alerts.
* `FRAUD_DETECT_INTERVAL_MS=0` or malformed values could create unsafe polling intervals.

This PR makes the runtime config safer while preserving existing default behavior.

## Implementation

A small helper, `parseBoundedIntEnv(...)`, was added to parse env values safely.

It returns the default fallback when:

* the env value is missing,
* the value is empty,
* the value is not an integer,
* the value is lower than the allowed minimum,
* the value is higher than the allowed maximum.

Valid configured integer values continue to be respected.

## Tests

Added regression coverage for:

* malformed `FRAUD_DETECT_DIVERGENCE_BPS` falling back to the default threshold,
* negative `FRAUD_DETECT_PER_MINT_COOLDOWN_MS` falling back to the default cooldown.

Validated with:

```bash
pnpm test -- tests/services/fraud-detector.test.ts
pnpm build
pnpm test
```

Final full test result:

```text
Test Files  80 passed | 2 skipped
Tests       823 passed | 33 skipped
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced configuration validation with bounds checking and default fallbacks

* **Tests**
  * Added test coverage for malformed environment configuration handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->