### PR TITLE
docs(keeper): document parseV17RiskParams's 4 hardcoded stub fields

### DIFF
--- a/src/lib/v17-risk.ts
+++ b/src/lib/v17-risk.ts
@@ -58,6 +58,17 @@ export class V17RiskParamsCorruptedError extends Error {
   }
 }
 
+/**
+ * M-8: four fields below are hardcoded to 0n, not parsed from on-chain bytes.
+ * Verified against percolator-prog's v16_program.rs (the v16/v17 engine
+ * config struct) and percolator-sdk — neither defines openInterestCap,
+ * adlFillCapBps, or minPositionSize anywhere; there is no on-chain byte
+ * layout for them to parse. warmupPeriodSlots is a real field, but only on
+ * pre-v12.15 slabs — v12.15+ (including every v17 market) replaced it with
+ * hMin/hMax, which ARE parsed below. A caller must not treat any of these
+ * four 0n values as a meaningful on-chain reading (e.g. "no cap"); they are
+ * placeholders kept for return-type shape compatibility only.
+ */
 export function parseV17RiskParams(data: Uint8Array): {
   warmupPeriodSlots: bigint;
   maintenanceMarginBps: bigint;
@@ -84,17 +95,17 @@ export function parseV17RiskParams(data: Uint8Array): {
   }
 
   return {
-    warmupPeriodSlots: 0n,
+    warmupPeriodSlots: 0n, // not present on v17 slabs — see function doc comment
     maintenanceMarginBps,
     hMin: readU64LE(data, V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_H_MIN_OFF),
     hMax: readU64LE(data, V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_H_MAX_OFF),
-    openInterestCap: 0n,
+    openInterestCap: 0n, // no on-chain field exists — see function doc comment
     maintenanceFeePerSlot: readU128LE(data, V17_WRAPPER_MAINTENANCE_FEE_PER_SLOT_OFF),
     liquidationFeeShareBps: readU64LE(
       data,
       V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_LIQUIDATION_FEE_BPS_OFF,
     ),
-    adlFillCapBps: 0n,
-    minPositionSize: 0n,
+    adlFillCapBps: 0n, // no on-chain field exists — see function doc comment
+    minPositionSize: 0n, // no on-chain field exists — see function doc comment
   };
 }

--- a/tests/v17-risk-params.poc.test.ts
+++ b/tests/v17-risk-params.poc.test.ts
@@ -84,3 +84,29 @@ describe("PoC: v17 risk params are parsed from the market-group header", () => {
     });
   });
 });
+
+describe("M-8: warmupPeriodSlots/openInterestCap/adlFillCapBps/minPositionSize are documented stubs, not parsed values", () => {
+  it("stay 0n regardless of surrounding non-zero data — they have no on-chain byte offset to read", () => {
+    // Fill the whole buffer with non-zero bytes, including the real parsed
+    // fields (overwritten with known values below) and everywhere else.
+    // If any of the 4 stub fields were silently reading from some byte
+    // range, this would surface it as a non-zero result.
+    const data = new Uint8Array(V17_RISK_PARAMS_MIN_DATA_LEN).fill(0xff);
+
+    writeU128LE(data, V17_HEADER_LEN + 96, 7n);
+    writeU64LE(data, V17_ENGINE_CONFIG_OFF + 38, 100n);
+    writeU64LE(data, V17_ENGINE_CONFIG_OFF + 46, 86_400n);
+    writeU64LE(data, V17_ENGINE_CONFIG_OFF + 54, 1_000n);
+    writeU64LE(data, V17_ENGINE_CONFIG_OFF + 78, 75n);
+
+    const params = parseV17RiskParams(data);
+
+    expect(params.warmupPeriodSlots).toBe(0n);
+    expect(params.openInterestCap).toBe(0n);
+    expect(params.adlFillCapBps).toBe(0n);
+    expect(params.minPositionSize).toBe(0n);
+    // Sanity check: the real fields DO pick up the non-zero fill, proving
+    // the buffer construction above isn't accidentally all-zero.
+    expect(params.maintenanceMarginBps).toBe(1_000n);
+  });
+});


### PR DESCRIPTION
## Bug

`warmupPeriodSlots`, `openInterestCap`, `adlFillCapBps`, and `minPositionSize` are hardcoded to `0n` in `parseV17RiskParams` with no explanation — indistinguishable in the return value from a genuinely-parsed on-chain zero.

Verified against the authoritative sources rather than guessing at offsets:
- **percolator-prog's `v16_program.rs`** (the v16/v17 engine config struct that `maintenanceMarginBps`/`hMin`/`hMax`/`liquidationFeeShareBps` are correctly parsed from): `openInterestCap`, `adlFillCapBps`, and `minPositionSize` don't exist anywhere in the on-chain layout. There is no byte offset to parse them from, on this or any other version of the program.
- **percolator-sdk**: `warmupPeriodSlots` *is* a real field, but only on pre-v12.15 slabs. v12.15+ (every v17 market) replaced it with `hMin`/`hMax`, which `parseV17RiskParams` already parses correctly.

So none of the 4 fields can be "really" parsed for v17 — three don't exist on-chain at all, and the fourth was superseded before v17 even shipped. This isn't a parsing bug to fix (there's nothing to parse); it's an undocumented stub that could mislead a future reader into trusting `0n` as on-chain truth (e.g. "`openInterestCap=0n` means no cap" rather than "this field doesn't exist").

## Fix

Added a doc comment on the function (citing the verification above) plus a per-field inline note on each of the 4 stub lines. No behavior change — confirmed zero current consumers of these 4 fields anywhere in `src/`.

## Test plan

New test in `tests/v17-risk-params.poc.test.ts`: fills the entire input buffer with non-zero bytes and confirms all 4 stub fields still read `0n`, while the genuinely-parsed fields (`maintenanceMarginBps`, etc.) pick up the fill — proving the stubs aren't accidentally reading from some byte range, and that the test buffer itself isn't accidentally all-zero.

- `pnpm build` — clean.
- `pnpm test` — full suite green, no regressions (906 passed / 33 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying comments explaining v17 risk parameter parsing behavior, specifically noting that certain fields are hardcoded values and not parsed from on-chain data.

* **Tests**
  * Added test suite to verify v17 parameter parsing behavior remains consistent with documented specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->