### PR TITLE
fix: validate priority fee cache env config

### DIFF
--- a/src/lib/priority-fee.ts
+++ b/src/lib/priority-fee.ts
@@ -9,6 +9,22 @@ export type PriorityFeeTier = "crank" | "liquidation" | "oracle" | "adl";
 const FALLBACK_MICROLAMPORTS = 1_000;
 const DEFAULT_CACHE_MS = 5_000;
 const DEFAULT_CACHE_MAX_ENTRIES = 1_000;
+function parseBoundedIntEnv(
+  name: string,
+  fallback: number,
+  min: number,
+  max = Number.MAX_SAFE_INTEGER,
+): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min || value > max) {
+    return fallback;
+  }
+
+  return value;
+}
 
 /** Default percentiles per tier (overridable via env). ADL is liquidation-priority. */
 const DEFAULT_PERCENTILES: Record<PriorityFeeTier, number> = {
@@ -93,12 +109,13 @@ export class HeliusPriorityFeeEstimator implements PriorityFeeEstimator {
       "";
     this._cacheMs =
       opts?.cacheMs ??
-      parseInt(process.env.KEEPER_PRIORITY_FEE_CACHE_MS ?? String(DEFAULT_CACHE_MS), 10);
+      parseBoundedIntEnv("KEEPER_PRIORITY_FEE_CACHE_MS", DEFAULT_CACHE_MS, 1);
     this._cacheMaxEntries =
       opts?.cacheMaxEntries ??
-      parseInt(
-        process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES ?? String(DEFAULT_CACHE_MAX_ENTRIES),
-        10,
+      parseBoundedIntEnv(
+        "KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES",
+        DEFAULT_CACHE_MAX_ENTRIES,
+        1,
       );
   }
 

--- a/src/lib/priority-fee.ts
+++ b/src/lib/priority-fee.ts
@@ -109,7 +109,7 @@ export class HeliusPriorityFeeEstimator implements PriorityFeeEstimator {
       "";
     this._cacheMs =
       opts?.cacheMs ??
-      parseBoundedIntEnv("KEEPER_PRIORITY_FEE_CACHE_MS", DEFAULT_CACHE_MS, 1);
+      parseBoundedIntEnv("KEEPER_PRIORITY_FEE_CACHE_MS", DEFAULT_CACHE_MS, 0);
     this._cacheMaxEntries =
       opts?.cacheMaxEntries ??
       parseBoundedIntEnv(

--- a/tests/lib/priority-fee.test.ts
+++ b/tests/lib/priority-fee.test.ts
@@ -271,7 +271,7 @@ describe("HeliusPriorityFeeEstimator", () => {
       }
     });
 
-        it("falls back to default cache duration when KEEPER_PRIORITY_FEE_CACHE_MS is malformed", async () => {
+    it("falls back to default cache duration when KEEPER_PRIORITY_FEE_CACHE_MS is malformed", async () => {
       const origEnv = process.env.KEEPER_PRIORITY_FEE_CACHE_MS;
       process.env.KEEPER_PRIORITY_FEE_CACHE_MS = "abc";
 

--- a/tests/lib/priority-fee.test.ts
+++ b/tests/lib/priority-fee.test.ts
@@ -291,6 +291,26 @@ describe("HeliusPriorityFeeEstimator", () => {
       }
     });
 
+        it("preserves zero cache duration as an explicit env override", async () => {
+      const origEnv = process.env.KEEPER_PRIORITY_FEE_CACHE_MS;
+      process.env.KEEPER_PRIORITY_FEE_CACHE_MS = "0";
+
+      try {
+        const fetchFn = mockFetch(HELIUS_SUCCESS_RESPONSE);
+        global.fetch = fetchFn;
+
+        const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com");
+
+        await estimator.estimate(["acc1"], "crank");
+        await estimator.estimate(["acc1"], "crank");
+
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      } finally {
+        if (origEnv === undefined) delete process.env.KEEPER_PRIORITY_FEE_CACHE_MS;
+        else process.env.KEEPER_PRIORITY_FEE_CACHE_MS = origEnv;
+      }
+    });
+
     it("falls back to default cache cap when KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES is malformed", async () => {
       const origEnv = process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES;
       process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES = "abc";

--- a/tests/lib/priority-fee.test.ts
+++ b/tests/lib/priority-fee.test.ts
@@ -270,5 +270,48 @@ describe("HeliusPriorityFeeEstimator", () => {
         else process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES = origEnv;
       }
     });
+
+        it("falls back to default cache duration when KEEPER_PRIORITY_FEE_CACHE_MS is malformed", async () => {
+      const origEnv = process.env.KEEPER_PRIORITY_FEE_CACHE_MS;
+      process.env.KEEPER_PRIORITY_FEE_CACHE_MS = "abc";
+
+      try {
+        const fetchFn = mockFetch(HELIUS_SUCCESS_RESPONSE);
+        global.fetch = fetchFn;
+
+        const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com");
+
+        await estimator.estimate(["acc1"], "crank");
+        await estimator.estimate(["acc1"], "crank");
+
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      } finally {
+        if (origEnv === undefined) delete process.env.KEEPER_PRIORITY_FEE_CACHE_MS;
+        else process.env.KEEPER_PRIORITY_FEE_CACHE_MS = origEnv;
+      }
+    });
+
+    it("falls back to default cache cap when KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES is malformed", async () => {
+      const origEnv = process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES;
+      process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES = "abc";
+
+      try {
+        const fetchFn = mockFetch(HELIUS_SUCCESS_RESPONSE);
+        global.fetch = fetchFn;
+
+        const estimator = new HeliusPriorityFeeEstimator("https://rpc.example.com", {
+          cacheMs: 60_000,
+        });
+
+        for (let i = 0; i < 1_005; i++) {
+          await estimator.estimate([`acc${i}`], "crank");
+        }
+
+        expect(cacheSize(estimator)).toBeLessThanOrEqual(1_000);
+      } finally {
+        if (origEnv === undefined) delete process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES;
+        else process.env.KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES = origEnv;
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

Validates priority fee estimator cache environment configuration before using it at runtime.

Previously, `KEEPER_PRIORITY_FEE_CACHE_MS` and `KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES` were parsed with raw `parseInt(...)`. If either environment value was malformed, for example `abc`, the parsed result became `NaN` and was used directly by the cache logic.

This could disable cache hits or bypass the intended cache size cap.

Fixes #293

## Related Issue

This PR fixes #293.

Issue #293 reported that malformed priority fee cache environment values could become `NaN` and affect cache behavior:

* `KEEPER_PRIORITY_FEE_CACHE_MS=abc` could disable cache hits because cache entries were stored with `expiresAt = NaN`.
* `KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES=abc` could disable cache eviction because the cache size comparison against `NaN` never passed.

## Changes

* Add bounded integer parsing for priority fee cache environment values.
* Fall back to `DEFAULT_CACHE_MS` when `KEEPER_PRIORITY_FEE_CACHE_MS` is missing, empty, malformed, non-integer, below the allowed minimum, or above the allowed maximum.
* Fall back to `DEFAULT_CACHE_MAX_ENTRIES` when `KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES` is missing, empty, malformed, non-integer, below the allowed minimum, or above the allowed maximum.
* Preserve valid explicit integer configuration values.
* Add regression tests for malformed cache duration config.
* Add regression tests for malformed cache max entries config.

## Why

The priority fee estimator uses an in-memory cache to avoid repeatedly fetching the same priority fee estimate for the same account set and tier.

Before this change, malformed cache environment values could break that behavior.

### Malformed cache duration

If the keeper was configured with:

```env
KEEPER_PRIORITY_FEE_CACHE_MS=abc
```

then `parseInt("abc", 10)` returned `NaN`.

That caused cache entries to be stored with:

```ts
expiresAt = Date.now() + NaN
```

which produced:

```ts
expiresAt = NaN
```

Later, cache hits are checked with:

```ts
Date.now() < cached.expiresAt
```

Since comparison with `NaN` is always false, the cache entry was never considered valid. As a result, repeated calls for the same account set and tier fetched again instead of using the cached estimate.

### Malformed cache max entries

If the keeper was configured with:

```env
KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES=abc
```

then `parseInt("abc", 10)` returned `NaN`.

That made the cache eviction condition ineffective:

```ts
cache.size >= cacheMaxEntries
```

Since comparison with `NaN` is always false, the eviction loop did not run. This allowed the cache to grow beyond the intended default cap.

## Implementation

This PR adds a small bounded parser:

```ts
function parseBoundedIntEnv(
  name: string,
  fallback: number,
  min: number,
  max = Number.MAX_SAFE_INTEGER,
): number
```

The parser returns the fallback value when:

* the environment value is missing,
* the environment value is empty,
* the environment value is not an integer,
* the environment value is lower than the allowed minimum,
* the environment value is higher than the allowed maximum.

The parser is then used for:

```ts
KEEPER_PRIORITY_FEE_CACHE_MS
KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES
```

This keeps valid explicit configuration working while preventing malformed values from becoming active runtime cache config.

## Tests

Added regression coverage for:

* malformed `KEEPER_PRIORITY_FEE_CACHE_MS` falling back to the default cache duration,
* malformed `KEEPER_PRIORITY_FEE_CACHE_MAX_ENTRIES` falling back to the default cache cap.

Validated with:

```bash
pnpm test -- tests/lib/priority-fee.test.ts
pnpm build
pnpm test
```

Full test result:

```text
Test Files  84 passed | 2 skipped
Tests       907 passed | 33 skipped
```
