### PR TITLE
fix(keeper): re-verify market_group_id in scanV17Portfolios

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -169,6 +169,22 @@ async function scanV17Portfolios(
       const data = new Uint8Array(account.data);
       const pf = parsePortfolioV17(data);
 
+      // M-9: getProgramAccounts' memcmp filter is enforced RPC-side, not
+      // on-chain -- a non-conforming or misbehaving RPC could return a
+      // portfolio belonging to a different market. Re-derive the same
+      // market_group_id check the filter was supposed to perform from the
+      // parsed account data itself, rather than trusting the RPC's filtering.
+      // A mismatch here would otherwise evaluate this portfolio's legs
+      // against the WRONG market's price/maintenanceMarginBps.
+      if (!pf.marketGroupId.equals(market.slabAddress)) {
+        logger.warn("scanV17Portfolios: RPC returned portfolio for a different market — skipping", {
+          expectedMarket: marketKey.slice(0, 8),
+          actualMarket: pf.marketGroupId.toBase58().slice(0, 8),
+          portfolio: pubkey.toBase58().slice(0, 8),
+        });
+        continue;
+      }
+
       // Check each active leg for undercollateralization.
       // DESYNC-4: asset_index is the leg's assetIndex field (0 for single-asset markets).
       for (const leg of pf.legs) {

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -522,6 +522,103 @@ describe('LiquidationService', () => {
         expect(shared.sendCriticalAlert).not.toHaveBeenCalled();
       });
     });
+
+    describe('M-9: scanV17Portfolios re-checks market_group_id against the RPC memcmp filter', () => {
+      const mockMarket = {
+        slabAddress: mockNonZeroKey('MarketV17Scan111111111111111111111111'),
+        programId: { toBase58: () => 'Program11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'So11111111111111111111111111111111111111112' },
+          oracleAuthority: { toBase58: () => 'Oracle11111111111111111111111111111111' },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+          authorityPriceE6: 1_000_000n,
+          lastEffectivePriceE6: 1_000_000n,
+          authorityTimestamp: BigInt(Math.floor(Date.now() / 1000)),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+      };
+
+      function makeRawPortfolio(label: string) {
+        return {
+          pubkey: { toBase58: () => `Portfolio${label}111111111111111111111111` } as any,
+          account: { data: new Uint8Array(16) },
+        };
+      }
+
+      it('skips a portfolio whose parsed marketGroupId does not match the scanned market', async () => {
+        vi.mocked(core.isV17Account).mockReturnValueOnce(true);
+        vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(9_347));
+        vi.mocked(shared.getConnection).mockReturnValue({
+          getProgramAccounts: vi.fn(async () => [makeRawPortfolio('Mismatched')]),
+        } as any);
+        vi.mocked(core.parsePortfolioV17).mockReturnValueOnce({
+          marketGroupId: mockNonZeroKey('SomeOtherMarket1111111111111111111111'),
+          owner: mockNonZeroKey('Owner11111111111111111111111111111111'),
+          capital: 1_000_000n,
+          pnl: 0n,
+          feeCredits: 0n,
+          legs: [{ active: true, basisPosQ: 100_000_000_000n, assetIndex: 0 }],
+        } as any);
+
+        const candidates = await liquidationService.scanMarket(mockMarket as any);
+
+        expect(candidates).toEqual([]);
+      });
+
+      it('keeps a portfolio whose parsed marketGroupId matches the scanned market', async () => {
+        vi.mocked(core.isV17Account).mockReturnValueOnce(true);
+        vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(9_347));
+        vi.mocked(shared.getConnection).mockReturnValue({
+          getProgramAccounts: vi.fn(async () => [makeRawPortfolio('Matching')]),
+        } as any);
+        vi.mocked(core.parsePortfolioV17).mockReturnValueOnce({
+          marketGroupId: mockMarket.slabAddress,
+          owner: mockNonZeroKey('Owner11111111111111111111111111111111'),
+          capital: 100_000_000n, // 100 USDC — undercollateralized vs the position below
+          pnl: 0n,
+          feeCredits: 0n,
+          legs: [{ active: true, basisPosQ: 10_000_000_000n, assetIndex: 0 }],
+        } as any);
+
+        const candidates = await liquidationService.scanMarket(mockMarket as any);
+
+        expect(candidates).toHaveLength(1);
+      });
+
+      it('evaluates a mixed batch correctly: drops the mismatched portfolio, keeps the matching one', async () => {
+        vi.mocked(core.isV17Account).mockReturnValueOnce(true);
+        vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(9_347));
+        vi.mocked(shared.getConnection).mockReturnValue({
+          getProgramAccounts: vi.fn(async () => [
+            makeRawPortfolio('Mismatched'),
+            makeRawPortfolio('Matching'),
+          ]),
+        } as any);
+        vi.mocked(core.parsePortfolioV17)
+          .mockReturnValueOnce({
+            marketGroupId: mockNonZeroKey('SomeOtherMarket1111111111111111111111'),
+            owner: mockNonZeroKey('OwnerMismatched111111111111111111111'),
+            capital: 1_000_000n,
+            pnl: 0n,
+            feeCredits: 0n,
+            legs: [{ active: true, basisPosQ: 100_000_000_000n, assetIndex: 0 }],
+          } as any)
+          .mockReturnValueOnce({
+            marketGroupId: mockMarket.slabAddress,
+            owner: mockNonZeroKey('OwnerMatching11111111111111111111111'),
+            capital: 100_000_000n,
+            pnl: 0n,
+            feeCredits: 0n,
+            legs: [{ active: true, basisPosQ: 10_000_000_000n, assetIndex: 0 }],
+          } as any);
+
+        const candidates = await liquidationService.scanMarket(mockMarket as any);
+
+        expect(candidates).toHaveLength(1);
+        expect(candidates[0].owner).toBe('OwnerMatching11111111111111111111111');
+      });
+    });
   });
 
   describe('liquidate', () => {


### PR DESCRIPTION
## Bug

`scanV17Portfolios` (`src/services/liquidation.ts`) enumerates portfolio accounts for a market via `getProgramAccounts` with a `memcmp` filter on `market_group_id` (offset 16). That filter is enforced **RPC-side**, not on-chain — a non-conforming or misbehaving RPC could return a portfolio belonging to a different market, and the function trusted the result completely.

`parsePortfolioV17`'s return value already exposes `marketGroupId`, parsed directly from the account's own bytes — but it was never read anywhere in this function (or anywhere else in the repo).

A mismatched portfolio would have its legs evaluated against the **wrong market's** `price` and `maintenanceMarginBps` (both passed into `scanV17Portfolios` for the market being scanned, not derived per-portfolio), producing a scan-time candidacy decision — and potentially a wasted liquidation attempt — based on a margin computation that doesn't correspond to the portfolio's actual market.

Same trust-boundary class as #289 (M-6, `fetchSlab`'s `expectedOwner` check): re-derive on-chain truth from the account's own parsed data instead of trusting an RPC-side filter result.

## Fix

Right after `parsePortfolioV17(data)`, skip (with a warning log) any portfolio whose parsed `marketGroupId` doesn't match `market.slabAddress` — before evaluating its legs for undercollateralization.

## Test plan

3 new tests in `tests/services/liquidation.test.ts`:
- A mismatched-only batch returns no candidates.
- A matching-only batch returns the candidate (confirms the check doesn't false-positive on legitimate data).
- A mixed batch drops the mismatched portfolio while keeping the matching one.

Confirmed 2 of the 3 fail against the pre-fix code (the third — the matching case — passes either way since there's nothing to filter out).

- `pnpm build` — clean.
- `pnpm test` — full suite green, no regressions (908 passed / 33 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced portfolio validation to ensure portfolios are correctly matched against their intended markets before processing liquidation analysis, preventing potential miscalculations of market-specific parameters.

* **Tests**
  * Expanded test coverage with new comprehensive scenarios validating portfolio market matching behavior, including verification of both matched and mismatched portfolio handling during liquidation scanning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->