### PR TITLE
fix(keeper): validate tx queue env integers

### DIFF
--- a/src/lib/tx-queue.ts
+++ b/src/lib/tx-queue.ts
@@ -54,19 +54,19 @@ export interface TxLaneStats {
   failed: number;
 }
 
-function parseEnvInt(name: string, fallback: number): number {
+function parseEnvInt(name: string, fallback: number, min = 1): number {
   const raw = process.env[name]?.trim();
   if (!raw) return fallback;
 
   const n = Number(raw);
-  return Number.isInteger(n) && n > 0 ? n : fallback;
+  return Number.isInteger(n) && n >= min ? n : fallback;
 }
 
 function buildLaneConfig(lane: TxLane, defaults: { concurrency: number; intervalCap: number; interval: number }) {
   return {
-    concurrency: parseEnvInt(`TX_QUEUE_${lane.toUpperCase()}_CONCURRENCY`, defaults.concurrency),
-    intervalCap: parseEnvInt(`TX_QUEUE_${lane.toUpperCase()}_INTERVAL_CAP`, defaults.intervalCap),
-    interval: parseEnvInt(`TX_QUEUE_${lane.toUpperCase()}_INTERVAL_MS`, defaults.interval),
+    concurrency: parseEnvInt(`TX_QUEUE_${lane.toUpperCase()}_CONCURRENCY`, defaults.concurrency, 1),
+    intervalCap: parseEnvInt(`TX_QUEUE_${lane.toUpperCase()}_INTERVAL_CAP`, defaults.intervalCap, 1),
+    interval: parseEnvInt(`TX_QUEUE_${lane.toUpperCase()}_INTERVAL_MS`, defaults.interval, 0),
   };
 }
 
@@ -78,19 +78,19 @@ export class TxQueue {
 
   constructor(config: TxQueueConfig = {}) {
     const liqCfg = {
-      concurrency: config.liquidation?.concurrency ?? parseEnvInt("TX_QUEUE_LIQUIDATION_CONCURRENCY", 10),
-      intervalCap: config.liquidation?.intervalCap ?? parseEnvInt("TX_QUEUE_LIQUIDATION_INTERVAL_CAP", 30),
-      interval: config.liquidation?.interval ?? parseEnvInt("TX_QUEUE_LIQUIDATION_INTERVAL_MS", 1000),
+      concurrency: config.liquidation?.concurrency ?? parseEnvInt("TX_QUEUE_LIQUIDATION_CONCURRENCY", 10, 1),
+      intervalCap: config.liquidation?.intervalCap ?? parseEnvInt("TX_QUEUE_LIQUIDATION_INTERVAL_CAP", 30, 1),
+      interval: config.liquidation?.interval ?? parseEnvInt("TX_QUEUE_LIQUIDATION_INTERVAL_MS", 1000, 0),
     };
     const oracleCfg = {
-      concurrency: config.oracle?.concurrency ?? parseEnvInt("TX_QUEUE_ORACLE_CONCURRENCY", 5),
-      intervalCap: config.oracle?.intervalCap ?? parseEnvInt("TX_QUEUE_ORACLE_INTERVAL_CAP", 15),
-      interval: config.oracle?.interval ?? parseEnvInt("TX_QUEUE_ORACLE_INTERVAL_MS", 1000),
+      concurrency: config.oracle?.concurrency ?? parseEnvInt("TX_QUEUE_ORACLE_CONCURRENCY", 5, 1),
+      intervalCap: config.oracle?.intervalCap ?? parseEnvInt("TX_QUEUE_ORACLE_INTERVAL_CAP", 15, 1),
+      interval: config.oracle?.interval ?? parseEnvInt("TX_QUEUE_ORACLE_INTERVAL_MS", 1000, 0),
     };
     const crankCfg = {
-      concurrency: config.crank?.concurrency ?? parseEnvInt("TX_QUEUE_CRANK_CONCURRENCY", 5),
-      intervalCap: config.crank?.intervalCap ?? parseEnvInt("TX_QUEUE_CRANK_INTERVAL_CAP", 10),
-      interval: config.crank?.interval ?? parseEnvInt("TX_QUEUE_CRANK_INTERVAL_MS", 1000),
+      concurrency: config.crank?.concurrency ?? parseEnvInt("TX_QUEUE_CRANK_CONCURRENCY", 5, 1),
+      intervalCap: config.crank?.intervalCap ?? parseEnvInt("TX_QUEUE_CRANK_INTERVAL_CAP", 10, 1),
+      interval: config.crank?.interval ?? parseEnvInt("TX_QUEUE_CRANK_INTERVAL_MS", 1000, 0),
     };
 
     this._lanes = {

--- a/src/lib/tx-queue.ts
+++ b/src/lib/tx-queue.ts
@@ -55,10 +55,11 @@ export interface TxLaneStats {
 }
 
 function parseEnvInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw === undefined) return fallback;
-  const n = parseInt(raw, 10);
-  return isNaN(n) ? fallback : n;
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : fallback;
 }
 
 function buildLaneConfig(lane: TxLane, defaults: { concurrency: number; intervalCap: number; interval: number }) {

--- a/tests/lib/tx-queue-env-validation.poc.test.ts
+++ b/tests/lib/tx-queue-env-validation.poc.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 vi.mock("@percolatorct/shared", () => ({
   createLogger: vi.fn(() => ({
@@ -27,7 +27,7 @@ describe("TxQueue env validation", () => {
     vi.clearAllMocks();
   });
 
-  it("falls back for non-positive env values instead of constructing an invalid queue", async () => {
+  it("falls back for invalid concurrency and cap values while allowing zero-ms intervals", async () => {
     process.env.TX_QUEUE_CRANK_CONCURRENCY = "0";
     process.env.TX_QUEUE_CRANK_INTERVAL_CAP = "-1";
     process.env.TX_QUEUE_CRANK_INTERVAL_MS = "0";

--- a/tests/lib/tx-queue-env-validation.poc.test.ts
+++ b/tests/lib/tx-queue-env-validation.poc.test.ts
@@ -1,0 +1,39 @@
+﻿import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/lib/metrics.js", () => ({
+  txQueueWaitSeconds: { observe: vi.fn() },
+  txQueuePending: { set: vi.fn() },
+  txQueueActive: { set: vi.fn() },
+  txQueueCompletedTotal: { inc: vi.fn() },
+  txQueueFailedTotal: { inc: vi.fn() },
+}));
+
+import { TxQueue } from "../../src/lib/tx-queue.js";
+
+describe("TxQueue env validation", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  it("falls back for non-positive env values instead of constructing an invalid queue", async () => {
+    process.env.TX_QUEUE_CRANK_CONCURRENCY = "0";
+    process.env.TX_QUEUE_CRANK_INTERVAL_CAP = "-1";
+    process.env.TX_QUEUE_CRANK_INTERVAL_MS = "0";
+
+    const queue = new TxQueue();
+
+    await expect(queue.enqueue("crank", async () => "ok")).resolves.toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens TxQueue environment parsing so queue configuration values only accept valid positive integers before being passed into `PQueue`.

Previously, `parseEnvInt()` accepted any numeric value returned by `parseInt()`, including invalid queue settings such as:

* `0`
* negative numbers like `-1`
* fractional-looking strings that could be partially parsed

Those values could then be used to construct queue lanes for liquidation, oracle, and crank work. In particular, invalid non-positive values such as `TX_QUEUE_CRANK_INTERVAL_CAP=-1` can cause `PQueue` construction to throw and prevent the keeper from initializing cleanly.

## Changes

* Update `parseEnvInt()` in `src/lib/tx-queue.ts` to:

  * trim environment input
  * fall back when the value is empty
  * parse with `Number()` instead of `parseInt()`
  * require `Number.isInteger(n)`
  * require `n > 0`
  * fall back to the safe default for invalid values

* Add regression coverage in `tests/lib/tx-queue-env-validation.poc.test.ts` proving that invalid non-positive `TX_QUEUE_*` values no longer construct an invalid queue.

## Why

TxQueue configuration comes from environment variables. If those values are accidentally set to invalid non-positive values, the keeper should not crash during queue construction. It should instead fall back to safe defaults.

This makes queue initialization more robust against misconfiguration and prevents invalid environment values from breaking keeper startup.

## Before

Invalid values such as:

```bash
TX_QUEUE_CRANK_CONCURRENCY=0
TX_QUEUE_CRANK_INTERVAL_CAP=-1
TX_QUEUE_CRANK_INTERVAL_MS=0
```

could be accepted by `parseEnvInt()` and passed into `PQueue`.

The regression test reproduced the failure:

```txt
TypeError: Expected `intervalCap` to be a number from 1 and up, got `-1` (number)
```

## After

Invalid non-positive values are rejected by `parseEnvInt()` and replaced with the configured fallback defaults.

The queue can initialize and process work normally.

## Testing

Passed:

```bash
pnpm exec vitest run tests/lib/tx-queue-env-validation.poc.test.ts --reporter=verbose
```

Result:

```txt
Test Files  1 passed (1)
Tests       1 passed (1)
```

## Notes

This PR is intentionally small and focused. It does not change queue behavior for valid environment values. It only hardens invalid environment parsing and adds regression coverage for the failure case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved queue configuration validation to strictly accept only positive integer values from environment variables, with proper fallback handling for missing or invalid inputs.

* **Tests**
  * Added test coverage for queue configuration fallback behavior with invalid environment values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->