### PR TITLE
revert(keeper): drop #306 oracle-tail caching (net-negative)

### DIFF
--- a/src/lib/v17-oracle-tail.ts
+++ b/src/lib/v17-oracle-tail.ts
@@ -24,36 +24,7 @@ export function getV17OracleTailFeeds(
   return [fallbackOracle];
 }
 
-const oracleTailCache = new Map<string, { accounts: PublicKey[]; fetchedAt: number }>();
-const ORACLE_TAIL_TTL_MS = 5 * 60_000;
-
 export async function resolveV17OracleTail(
-  market: V17OracleTailMarket,
-  fallbackOracle: PublicKey,
-  connection: Connection,
-): Promise<PublicKey[]> {
-  const slabAddr = (market as any).slabAddress;
-  if (!slabAddr) {
-    return _resolveV17OracleTailUncached(market, fallbackOracle, connection);
-  }
-
-  const cacheKey = `${slabAddr.toBase58()}:${fallbackOracle.toBase58()}`;
-  const cached = oracleTailCache.get(cacheKey);
-  if (cached && Date.now() - cached.fetchedAt < ORACLE_TAIL_TTL_MS) {
-    return cached.accounts;
-  }
-
-  try {
-    const accounts = await _resolveV17OracleTailUncached(market, fallbackOracle, connection);
-    oracleTailCache.set(cacheKey, { accounts, fetchedAt: Date.now() });
-    return accounts;
-  } catch (err) {
-    oracleTailCache.delete(cacheKey);
-    throw err;
-  }
-}
-
-async function _resolveV17OracleTailUncached(
   market: V17OracleTailMarket,
   fallbackOracle: PublicKey,
   connection: Connection,


### PR DESCRIPTION
Reverts only the #306 hunk from #308. Review found it net-negative: the underlying RPC is already process-cached in `ownerCache`, so the new 5-min cache saves sub-ms CPU while pinning a transiently-misresolved oracle for 5 minutes (undermines the deliberate no-cache-on-failure self-heal) + an unsafe `as any` cast. The #297/#298/#301/#305 fixes from #308 are kept. Tests pass.