### PR TITLE
fix(keeper): security-audit batch (#314/#321/#322/#323/#325) — remediated #327

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,8 +24,13 @@ SENTRY_DSN=
 # Health check port
 KEEPER_HEALTH_PORT=8081
 
-# Shared secret for /register endpoint (optional)
+# Shared secret for /register endpoint (optional). Also required (as the
+# x-shared-secret header) to read /health, /pause-status and /shadow/report when
+# the health server is bound to a remote address (KEEPER_HEALTH_BIND_ADDR != loopback).
 # KEEPER_REGISTER_SECRET=
+# Dedicated secret for the privileged POST /admin/budget/resume (least-privilege;
+# falls back to KEEPER_REGISTER_SECRET if unset).
+# KEEPER_ADMIN_SECRET=
 
 # ADL service (disabled by default — requires on-chain T8+T10)
 # ADL_ENABLED=true

--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -58,13 +58,16 @@ jobs:
       # input > pinned default.
       - name: Resolve SDK version
         id: sdk_ver
+        env:
+          PAYLOAD_VER: ${{ github.event.client_payload.version }}
+          INPUT_VER: ${{ inputs.sdk_version }}
         run: |
-          VERSION="${{ github.event.client_payload.version }}"
+          VERSION="$PAYLOAD_VER"
           if [ -z "$VERSION" ]; then
-            VERSION="${{ inputs.sdk_version }}"
+            VERSION="$INPUT_VER"
           fi
           if [ -z "$VERSION" ]; then
-            VERSION="${{ env.SDK_VERSION }}"
+            VERSION="${SDK_VERSION}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Testing @percolatorct/sdk@$VERSION"
@@ -77,16 +80,20 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Override SDK dep with published npm version
+        env:
+          TARGET_VER: ${{ steps.sdk_ver.outputs.version }}
         run: |
-          pnpm add "@percolatorct/sdk@${{ steps.sdk_ver.outputs.version }}" \
+          pnpm add "@percolatorct/sdk@${TARGET_VER}" \
             --no-frozen-lockfile
 
       - name: Verify installed SDK version
+        env:
+          TARGET_VER: ${{ steps.sdk_ver.outputs.version }}
         run: |
           INSTALLED=$(node -e "console.log(require('./node_modules/@percolatorct/sdk/package.json').version)")
           echo "Installed: $INSTALLED"
-          if [ "$INSTALLED" != "${{ steps.sdk_ver.outputs.version }}" ]; then
-            echo "Version mismatch: expected ${{ steps.sdk_ver.outputs.version }}, got $INSTALLED"
+          if [ "$INSTALLED" != "$TARGET_VER" ]; then
+            echo "Version mismatch: expected $TARGET_VER, got $INSTALLED"
             exit 1
           fi
 
@@ -95,10 +102,13 @@ jobs:
 
       - name: Report result
         if: always()
+        env:
+          TARGET_VER: ${{ steps.sdk_ver.outputs.version }}
+          JOB_STATUS: ${{ job.status }}
         run: |
-          if [ "${{ job.status }}" = "success" ]; then
-            echo "@percolatorct/sdk@${{ steps.sdk_ver.outputs.version }} smoke PASSED"
+          if [ "$JOB_STATUS" = "success" ]; then
+            echo "@percolatorct/sdk@${TARGET_VER} smoke PASSED"
           else
-            echo "@percolatorct/sdk@${{ steps.sdk_ver.outputs.version }} smoke FAILED"
+            echo "@percolatorct/sdk@${TARGET_VER} smoke FAILED"
             exit 1
           fi

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-store-dir=.pnpm-store

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  vite: 8.0.8
-
 importers:
 
   .:
@@ -462,7 +459,7 @@ packages:
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/13f3012918003d995ee8a3793d8817b8c19f9762':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/13f3012918003d995ee8a3793d8817b8c19f9762}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/13f3012918003d995ee8a3793d8817b8c19f9762}
     version: 3.0.0
     engines: {node: '>=20.0.0'}
 
@@ -820,7 +817,7 @@ packages:
     resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 8.0.8
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1424,7 +1421,7 @@ packages:
       '@vitest/ui': 4.1.2
       happy-dom: '*'
       jsdom: '*'
-      vite: 8.0.8
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vite: 8.0.8
+
 importers:
 
   .:
@@ -459,7 +462,7 @@ packages:
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/13f3012918003d995ee8a3793d8817b8c19f9762':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/13f3012918003d995ee8a3793d8817b8c19f9762}
+    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/13f3012918003d995ee8a3793d8817b8c19f9762}
     version: 3.0.0
     engines: {node: '>=20.0.0'}
 
@@ -817,7 +820,7 @@ packages:
     resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: 8.0.8
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1421,7 +1424,7 @@ packages:
       '@vitest/ui': 4.1.2
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: 8.0.8
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,9 @@ solBalanceCheckInterval.unref();
 // emptied, which never happened during a multi-hour DEX outage — channel got
 // nuked. Track last-alert per slab and re-fire only after STALE_ALERT_COOLDOWN_MS.
 const STALE_ALERT_COOLDOWN_MS = Number(process.env.KEEPER_STALE_ALERT_COOLDOWN_MS ?? 5 * 60_000);
+if (!Number.isFinite(STALE_ALERT_COOLDOWN_MS) || STALE_ALERT_COOLDOWN_MS < 60_000) {
+  throw new Error(`KEEPER_STALE_ALERT_COOLDOWN_MS must be >= 60000, got: ${process.env.KEEPER_STALE_ALERT_COOLDOWN_MS}`);
+}
 const lastStaleAlertByMarket = new Map<string, number>();
 
 const staleCheckInterval = setInterval(() => {
@@ -294,6 +297,11 @@ const healthPort = Number(process.env.KEEPER_HEALTH_PORT ?? 8081);
 // visible on any deploy without a firewall). Operators needing remote access must
 // set KEEPER_HEALTH_BIND_ADDR explicitly (and front it with auth/a proxy).
 const healthBindAddr = process.env.KEEPER_HEALTH_BIND_ADDR ?? "127.0.0.1";
+import net from "node:net";
+if (!net.isIP(healthBindAddr) && healthBindAddr !== "localhost") {
+  throw new Error(`Invalid KEEPER_HEALTH_BIND_ADDR: "${healthBindAddr}"`);
+}
+
 // L4: reject non-integer or out-of-range port values early so misconfiguration
 // is a startup failure rather than a confusing EACCES/EADDRINUSE at listen time.
 if (!Number.isInteger(healthPort) || healthPort < 1 || healthPort > 65535) {
@@ -306,7 +314,8 @@ if (!Number.isInteger(healthPort) || healthPort < 1 || healthPort > 65535) {
 // Prevents brute-force attacks against the shared secret.
 const REGISTER_RATE_WINDOW_MS = 60_000;
 const REGISTER_RATE_MAX_FAILURES = 5;
-const registerFailures = new Map<string, number[]>();
+import { LRUCache } from "lru-cache";
+const registerFailures = new LRUCache<string, number[]>({ max: 10_000 });
 
 function isRateLimited(ip: string): boolean {
   const now = Date.now();
@@ -320,11 +329,6 @@ function recordAuthFailure(ip: string): void {
   const timestamps = registerFailures.get(ip) ?? [];
   timestamps.push(Date.now());
   registerFailures.set(ip, timestamps);
-  // Cap map size to prevent memory exhaustion from many unique IPs
-  if (registerFailures.size > 10_000) {
-    const oldest = registerFailures.keys().next().value;
-    if (oldest !== undefined) registerFailures.delete(oldest);
-  }
 }
 
 // Periodic cleanup: purge IPs whose failure timestamps have all expired.
@@ -372,6 +376,32 @@ const secureJsonHeaders = {
 };
 
 const healthServer = http.createServer((req, res) => {
+  // Authentication check for health and sensitive endpoints when exposed remotely
+  if (healthBindAddr !== "127.0.0.1" && healthBindAddr !== "localhost" && healthBindAddr !== "::1") {
+    if ((req.url === "/health" || req.url === "/pause-status" || req.url === "/shadow/report" || req.url?.startsWith("/shadow/report?")) && req.method === "GET") {
+      const registerSecret = process.env.KEEPER_REGISTER_SECRET ?? "";
+      const provided = String(req.headers["x-shared-secret"] ?? "");
+      let contentMatch = false;
+      if (registerSecret && provided) {
+        const secretBuf = Buffer.from(registerSecret, "utf8");
+        const providedBuf = Buffer.from(provided, "utf8");
+        const maxLen = Math.max(secretBuf.length, providedBuf.length, 1);
+        const secretPad = Buffer.alloc(maxLen);
+        const providedPad = Buffer.alloc(maxLen);
+        secretBuf.copy(secretPad);
+        providedBuf.copy(providedPad);
+        const lengthMatch = secretBuf.length === providedBuf.length;
+        contentMatch = lengthMatch && timingSafeEqual(secretPad, providedPad);
+      }
+      
+      if (!contentMatch) {
+        res.writeHead(401, secureJsonHeaders);
+        res.end(JSON.stringify({ error: "Unauthorized" }));
+        return;
+      }
+    }
+  }
+
   // POST /register — hot-register a new market without waiting for discovery cycle
   // Body: { slabAddress: string, mainnetCA?: string }
   // Auth: requires x-shared-secret header matching KEEPER_REGISTER_SECRET env var (defense-in-depth; #780)
@@ -478,10 +508,10 @@ res.writeHead(401, secureJsonHeaders);
 
   // POST /admin/budget/resume — clear a latched budget circuit-breaker halt
   // without a full restart. Auth mirrors /register: x-shared-secret header
-  // matching KEEPER_REGISTER_SECRET, constant-time compare, per-IP rate limit.
+  // matching KEEPER_ADMIN_SECRET, constant-time compare, per-IP rate limit.
   if (req.url === "/admin/budget/resume" && req.method === "POST") {
-    const registerSecret = process.env.KEEPER_REGISTER_SECRET ?? "";
-    if (!registerSecret) {
+    const adminSecret = process.env.KEEPER_ADMIN_SECRET ?? "";
+    if (!adminSecret) {
       req.resume();
       res.writeHead(503, secureJsonHeaders);
       res.end(JSON.stringify({ success: false, message: "Endpoint not configured" }));
@@ -498,7 +528,7 @@ res.writeHead(401, secureJsonHeaders);
     }
 
     const provided = String(req.headers["x-shared-secret"] ?? "");
-    const secretBuf = Buffer.from(registerSecret, "utf8");
+    const secretBuf = Buffer.from(adminSecret, "utf8");
     const providedBuf = Buffer.from(provided, "utf8");
     const maxLen = Math.max(secretBuf.length, providedBuf.length, 1);
     const secretPad = Buffer.alloc(maxLen);

--- a/src/index.ts
+++ b/src/index.ts
@@ -394,7 +394,11 @@ const healthServer = http.createServer((req, res) => {
         contentMatch = lengthMatch && timingSafeEqual(secretPad, providedPad);
       }
       
-      if (!contentMatch) {
+      // #321: fail OPEN when no secret is configured (registerSecret === "") so
+      // liveness/health probes on a remote bind aren't silently 401'd before the
+      // operator has set KEEPER_REGISTER_SECRET — a one-time startup warning is
+      // emitted at .listen() time instead. When a secret IS set, enforce it.
+      if (registerSecret && !contentMatch) {
         res.writeHead(401, secureJsonHeaders);
         res.end(JSON.stringify({ error: "Unauthorized" }));
         return;
@@ -510,7 +514,12 @@ res.writeHead(401, secureJsonHeaders);
   // without a full restart. Auth mirrors /register: x-shared-secret header
   // matching KEEPER_ADMIN_SECRET, constant-time compare, per-IP rate limit.
   if (req.url === "/admin/budget/resume" && req.method === "POST") {
-    const adminSecret = process.env.KEEPER_ADMIN_SECRET ?? "";
+    // #323: prefer a dedicated KEEPER_ADMIN_SECRET (least-privilege vs the
+    // register secret), but fall back to KEEPER_REGISTER_SECRET so existing
+    // deployments that only set the register secret don't silently 503 on
+    // /admin/budget/resume during an incident (the worst time to discover it).
+    const adminSecret =
+      process.env.KEEPER_ADMIN_SECRET ?? process.env.KEEPER_REGISTER_SECRET ?? "";
     if (!adminSecret) {
       req.resume();
       res.writeHead(503, secureJsonHeaders);
@@ -871,6 +880,17 @@ async function start() {
     healthServer.listen(healthPort, healthBindAddr, () => {
       healthServer.off("error", reject);
       logger.info("Health endpoint started", { port: healthPort, host: healthBindAddr });
+      // #321: warn loudly if exposed remotely without a shared secret — the
+      // /health, /pause-status, /shadow/report gate fails OPEN in that posture
+      // (so probes work), leaving operational data unauthenticated.
+      const isRemoteBind =
+        healthBindAddr !== "127.0.0.1" && healthBindAddr !== "localhost" && healthBindAddr !== "::1";
+      if (isRemoteBind && !(process.env.KEEPER_REGISTER_SECRET ?? "")) {
+        logger.warn(
+          "Health server bound to a remote address without KEEPER_REGISTER_SECRET — /health, /pause-status and /shadow/report are UNAUTHENTICATED. Set KEEPER_REGISTER_SECRET to require the x-shared-secret header.",
+          { host: healthBindAddr },
+        );
+      }
       resolve();
     });
   });


### PR DESCRIPTION
Lands @v1ktorrr0x's #327 security fixes with three required corrections:

- **Blocker**: #327 dropped `overrides: vite: 8.0.8` from the lockfile while package.json pins it → `--frozen-lockfile` CI failed. Lockfile regenerated to match (override restored, lru-cache resolved).
- **#321**: the new health-endpoint auth gate failed **closed** when `KEEPER_REGISTER_SECRET` was unset on a remote bind → 401'd liveness probes / broke deploys. Now fails **open** (probes work) + loud startup warning; enforces the secret when set.
- **#323**: `/admin/budget/resume` → `KEEPER_ADMIN_SECRET ?? KEEPER_REGISTER_SECRET` migration fallback + `.env.example` docs (no silent 503 on existing deploys).

#314 (CI shell-injection, MED-HIGH), #322 (LRU rate-limit), #325 (env validation) land as-is. Closes #314 #321 #322 #323 #325. Credit @v1ktorrr0x. **#324 parked** (efficiency, rate-limit-capped, not security). **#326 separate** (its npm-2.0.5 pin is wrong — no npm 3.0.0; real CI/prod drift to fix by publishing/repinning). Supersedes #327. Pre-existing SDK-desync test failures are orthogonal (same on main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health check endpoints now support optional authentication via shared-secret header when exposed to remote addresses.
  * New admin secret configuration option with automatic fallback behavior.

* **Bug Fixes**
  * Enhanced startup validation to ensure configuration parameters meet requirements.

* **Documentation**
  * Updated configuration examples with new secret settings and security guidance for remote deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->