### PR TITLE
fix(keeper): v17 DoS + liquidation-health batch — #333/#334/#335/#336 (3 HIGH + 1 MED)

### DIFF
--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -6,9 +6,18 @@
  * input can drain that wallet faster than ops can notice. The budget caps
  * lamport spend per cycle / hour / day and tx count per cycle, plus a
  * rolling-window success-rate guard that catches "we're sending but nothing
- * lands". On breach, the budget halts: every subsequent canSpend() returns
- * false until an operator manually resume()s. Day-cap breaches especially
- * never auto-recover — that's a real signal something is wrong.
+ * lands". On a genuine anomaly (spend caps, non-finite cost, success-rate
+ * breaker, operator halt) the budget LATCHES a halt: every subsequent
+ * canSpend() returns false until an operator manually resume()s. Day-cap
+ * breaches especially never auto-recover — that's a real signal something is
+ * wrong.
+ *
+ * #333: the per-cycle tx-COUNT cap is deliberately NOT a latching halt. Hitting
+ * it is routine burst pressure (permissionless market creation drives crank /
+ * provisioning / lp-vault volume), so canSpend() returns false as soft
+ * backpressure and the work auto-resumes on the next window roll. A reserved
+ * slice of the count cap (reservedCriticalTxPerCycle) is held back from routine
+ * lanes so liquidation / oracle / adl always have capacity even under a flood.
  *
  * Concurrency: every public method is synchronous. Under Node's single-
  * threaded event loop, no two calls can interleave between their reads and
@@ -32,6 +41,19 @@ export interface KeeperBudgetConfig {
   maxSolPerDay: number;
   /** Cap on tx attempts per cycle (default 60). */
   maxTxPerCycle: number;
+  /**
+   * Number of per-cycle tx slots RESERVED for safety-critical lanes
+   * (liquidation / oracle / adl), default 10. Routine non-critical lanes
+   * (crank, which buckets provisioning + lp-vault) see an effective cap of
+   * `maxTxPerCycle - reservedCriticalTxPerCycle`, while critical lanes may use
+   * the full `maxTxPerCycle`. This guarantees a permissionless crank/
+   * provisioning/lp-vault flood — which an attacker can drive via market
+   * creation — can never consume the last slots liquidation needs.
+   *
+   * #333: capped to maxTxPerCycle - 1 internally so routine lanes always keep
+   * at least 1 usable slot (a reservation >= maxTxPerCycle would starve them).
+   */
+  reservedCriticalTxPerCycle: number;
   /**
    * Length of the per-cycle window in ms (default 30_000, matching the default
    * crank interval). The per-cycle caps (maxSolPerCycle / maxTxPerCycle) are a
@@ -106,6 +128,7 @@ const DEFAULTS: KeeperBudgetConfig = {
   maxSolPerHour: 500_000_000,
   maxSolPerDay: 3_000_000_000,
   maxTxPerCycle: 60,
+  reservedCriticalTxPerCycle: 10,
   cycleWindowMs: 30_000,
   txSuccessRateWindow: 60_000,
   txSuccessRateThreshold: 0.7,
@@ -120,6 +143,7 @@ const INT_ENV_KEYS: Array<[keyof KeeperBudgetConfig, string]> = [
   ["maxSolPerHour", "KEEPER_MAX_SOL_PER_HOUR"],
   ["maxSolPerDay", "KEEPER_MAX_SOL_PER_DAY"],
   ["maxTxPerCycle", "KEEPER_MAX_TX_PER_CYCLE"],
+  ["reservedCriticalTxPerCycle", "KEEPER_RESERVED_CRITICAL_TX_PER_CYCLE"],
   ["cycleWindowMs", "KEEPER_CYCLE_WINDOW_MS"],
   ["txSuccessRateWindow", "KEEPER_TX_SUCCESS_RATE_WINDOW_MS"],
   ["txSuccessRateMinSamples", "KEEPER_TX_SUCCESS_RATE_MIN_SAMPLES"],
@@ -194,11 +218,20 @@ export class KeeperBudget {
 
   /**
    * Pre-flight check: would sending a tx that costs `lamports` lamports breach
-   * any cap? Returns false on breach AND latches the halt so subsequent calls
-   * also return false until resume() is called.
+   * any cap?
    *
-   * txType is currently advisory (logged on breach); planned use is to attribute
-   * Prometheus halt counters per tx category.
+   * Two distinct refusal semantics:
+   *  - LATCHING halt (returns false until resume()): genuine anomalies —
+   *    cycle/hour/day SPEND caps, non-finite cost, the success-rate breaker, or
+   *    an explicit operator halt. These are real "something is wrong" signals.
+   *  - SOFT backpressure (returns false, NO halt, auto-clears next window): the
+   *    per-cycle tx-COUNT cap (#333) and the reservation back-pressure path.
+   *    These are routine burst pressure, not overspend, and self-heal on the
+   *    next window roll without operator action.
+   *
+   * txType selects the per-cycle tx-count cap the caller sees: safety-critical
+   * lanes (liquidation / oracle / adl) use the full maxTxPerCycle; routine
+   * lanes (crank / provisioning / lp-vault) use the reserved-adjusted cap.
    */
   canSpend(lamports: number, txType: TxType): boolean {
     if (this._isHalted) return false;
@@ -247,11 +280,24 @@ export class KeeperBudget {
       );
       return false;
     }
-    if (this._cycleTxCount + 1 > this.config.maxTxPerCycle) {
-      this._halt(
-        "cycle-tx-count-cap",
-        `proposed cycle tx count ${this._cycleTxCount + 1} > cap ${this.config.maxTxPerCycle} (txType=${txType})`,
-      );
+    // ── Count-cap saturation: SOFT BACKPRESSURE, do NOT halt ───────────────
+    // #333: exceeding the per-cycle tx-count cap is NOT an overspend anomaly —
+    // it is routine burst pressure. Permissionless market creation drives
+    // crank / provisioning / lp-vault tx volume, so a latching halt here let an
+    // attacker permanently stop ALL cranks and liquidations cross-market with
+    // mere volume. Instead, refuse this send WITHOUT setting _isHalted: the
+    // window auto-rolls (_rollCycleIfElapsed zeroes _cycleTxCount) so deferred
+    // work resumes next window with no operator action. Only genuine anomalies
+    // (day/hour/cycle SPEND, non-finite cost, success-rate breaker, operator
+    // halt) still latch above/below.
+    //
+    // Critical lanes (liquidation / oracle / adl) may use the FULL cap;
+    // routine non-critical lanes (crank, which buckets provisioning + lp-vault)
+    // see the reserved-adjusted cap so a routine flood can never consume the
+    // last slots a liquidation needs. Reservations are counted in the same
+    // unit so the backpressure path below stays consistent.
+    const effectiveTxCap = this._effectiveTxCap(txType);
+    if (this._cycleTxCount + 1 > effectiveTxCap) {
       return false;
     }
 
@@ -275,7 +321,10 @@ export class KeeperBudget {
       this._cycleSpend + this._reservedLamports + lamports > this.config.maxSolPerCycle ||
       this._hourSpendSum + this._reservedLamports + lamports > this.config.maxSolPerHour ||
       this._daySpendSum + this._reservedLamports + lamports > this.config.maxSolPerDay ||
-      this._cycleTxCount + this._reservedTxCount + 1 > this.config.maxTxPerCycle
+      // #333: in-flight reservations count against the SAME lane-aware effective
+      // cap, so a flood of in-flight routine sends can't reserve away the
+      // critical reserve either.
+      this._cycleTxCount + this._reservedTxCount + 1 > effectiveTxCap
     ) {
       return false;
     }
@@ -576,4 +625,40 @@ export class KeeperBudget {
     if (total < this.config.txSuccessRateMinSamples) return null;
     return this._txWindowSuccesses / total;
   }
+
+  /**
+   * #333: the per-cycle tx-count cap a given lane sees.
+   *
+   * Safety-critical lanes (liquidation / oracle / adl) get the FULL
+   * `maxTxPerCycle`. Routine non-critical lanes (crank — which buckets
+   * provisioning + lp-vault sends) get `maxTxPerCycle - reservedCriticalTxPerCycle`,
+   * so the reserved slots are always available when a liquidation arrives even
+   * if routine crank/provisioning volume has otherwise saturated the cycle.
+   *
+   * The reservation is clamped to [0, maxTxPerCycle - 1] so a misconfiguration
+   * (e.g. reserved >= maxTxPerCycle) can never starve routine lanes to 0 — they
+   * always keep at least one usable slot.
+   */
+  private _effectiveTxCap(txType: TxType): number {
+    if (_isCriticalLane(txType)) return this.config.maxTxPerCycle;
+    const reserved = Math.min(
+      Math.max(0, this.config.reservedCriticalTxPerCycle),
+      Math.max(0, this.config.maxTxPerCycle - 1),
+    );
+    return this.config.maxTxPerCycle - reserved;
+  }
+}
+
+/**
+ * Safety-critical lanes whose sends must always have reserved per-cycle
+ * capacity available: liquidation (resolving underwater positions), oracle
+ * (mark/index freshness that liquidation reads), and adl (auto-deleverage,
+ * the deleveraging half of the liquidation safety path). Everything else —
+ * notably "crank", which also carries provisioning and lp-vault sends — is
+ * routine and subject to the reserved-adjusted cap.
+ */
+const CRITICAL_LANES: ReadonlySet<TxType> = new Set<TxType>(["liquidation", "oracle", "adl"]);
+
+function _isCriticalLane(txType: TxType): boolean {
+  return CRITICAL_LANES.has(txType);
 }

--- a/src/lib/v17-risk.ts
+++ b/src/lib/v17-risk.ts
@@ -13,6 +13,14 @@ export const V17_ASSET_SLOT_STRIDE = 1797; // ASSET_ORACLE_WRAPPER_LEN + ENGINE_
 // offset of effective_price within EngineAssetSlotV16Account (after the ORACLE_WRAPPER prefix)
 // = 8 (market_id) + 8 (retired_slot) + 1 (lifecycle) + 8 (raw_oracle_target_price) = 25
 export const V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT = 25;
+// #335: offset of raw_oracle_target_price within EngineAssetSlotV16Account (after the
+// ORACLE_WRAPPER prefix). It is the field immediately BEFORE effective_price:
+// = 8 (market_id) + 8 (retired_slot) + 1 (lifecycle) = 17.
+// Verified against percolator engine AssetStateV16Account (src/v16.rs:4317): the Pod
+// struct is #[repr(C)] over alignment-1 byte-array fields (V16PodU64 = [u8;8], no
+// padding), so raw_oracle_target_price (V16PodU64) sits at byte 17 and effective_price
+// at byte 25. (src/v16.rs:1168 target_effective_lag_adverse_delta consumes both.)
+export const V17_RAW_ORACLE_TARGET_PRICE_OFF_IN_ASSET_SLOT = 17;
 // absolute offset of min_nonzero_mm_req in the market account data
 // = V17_ENGINE_CONFIG_OFF + V16PodU16(2) + V16PodU32(4) = 480 + 6 = 486
 export const V17_MIN_NONZERO_MM_REQ_OFF = 486;
@@ -66,6 +74,68 @@ export function readEffectivePriceForAsset(data: Uint8Array, assetIndex: number)
     + V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT;
   if (off + 8 > data.length) return 0n;
   return readU64LE(data, off);
+}
+
+/**
+ * #335: Read the raw_oracle_target_price (u64 LE) for a given asset index from raw
+ * market account bytes. Same per-asset slot layout as readEffectivePriceForAsset,
+ * but at V17_RAW_ORACLE_TARGET_PRICE_OFF_IN_ASSET_SLOT (17) within the engine asset
+ * slot. Needed to compute the engine's target/effective-price lag penalty
+ * (src/v16.rs:1168 target_effective_lag_adverse_delta).
+ *
+ * Returns 0n if the buffer is too short to contain the field. Callers MUST treat
+ * 0n as "unknown" — never as a real $0 target — so a missing read can only ever
+ * OMIT the lag penalty (conservative: it never marks a portfolio healthier).
+ */
+export function readRawOracleTargetPriceForAsset(data: Uint8Array, assetIndex: number): bigint {
+  const off = V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_LEN
+    + assetIndex * V17_ASSET_SLOT_STRIDE
+    + V17_ASSET_ORACLE_WRAPPER_LEN
+    + V17_RAW_ORACLE_TARGET_PRICE_OFF_IN_ASSET_SLOT;
+  if (off + 8 > data.length) return 0n;
+  return readU64LE(data, off);
+}
+
+/**
+ * #335: target/effective-price lag penalty, mirroring the engine exactly.
+ *
+ * Engine (verified):
+ *   src/v16.rs:1168 target_effective_lag_adverse_delta(side, effective, raw_target):
+ *     long  → effective - raw_target   when raw_target <  effective (strict)
+ *     short → raw_target - effective   when raw_target >  effective (strict)
+ *     else  → 0
+ *   src/v16.rs:1157 target_effective_lag_loss_penalty:
+ *     penalty = risk_notional_ceil(abs_pos_q, adverse_delta)
+ *             = ceil(abs_pos_q * adverse_delta / POS_SCALE)   (POS_SCALE = 1_000_000, lib.rs:15)
+ *   src/v16.rs:1207 health_requirements_from_base_and_target_lag:
+ *     leg_maintenance = base_maintenance + target_lag_penalty   (ADDED at face value)
+ *
+ * `side`: +1 for long (basisPosQ > 0), -1 for short (basisPosQ < 0).
+ * `absPos`: abs(basisPosQ). `effectivePrice`/`rawTargetPrice`: per-asset prices (E6).
+ *
+ * Returns 0n (no penalty) when rawTargetPrice is 0n ("unknown") so a missing
+ * read can only ever under-penalize toward MORE liquidations, never mask one.
+ */
+export function targetEffectiveLagPenalty(
+  absPos: bigint,
+  side: 1 | -1,
+  effectivePrice: bigint,
+  rawTargetPrice: bigint,
+): bigint {
+  // 0n target means we couldn't read it — omit the penalty (never mark healthier).
+  if (rawTargetPrice <= 0n || effectivePrice <= 0n || absPos <= 0n) return 0n;
+  let adverseDelta = 0n;
+  if (side === 1) {
+    // long: adverse when effective > raw_target
+    if (rawTargetPrice < effectivePrice) adverseDelta = effectivePrice - rawTargetPrice;
+  } else {
+    // short: adverse when raw_target > effective
+    if (rawTargetPrice > effectivePrice) adverseDelta = rawTargetPrice - effectivePrice;
+  }
+  if (adverseDelta === 0n) return 0n;
+  // ceil(absPos * adverseDelta / POS_SCALE), POS_SCALE = 1_000_000
+  const POS_SCALE = 1_000_000n;
+  return (absPos * adverseDelta + POS_SCALE - 1n) / POS_SCALE;
 }
 
 /**

--- a/src/services/fraud-detector.ts
+++ b/src/services/fraud-detector.ts
@@ -62,6 +62,21 @@ export function divergenceBps(onchain: bigint | number, offchain: bigint | numbe
 const DEFAULT_INTERVAL_MS = 30_000;
 const DEFAULT_DIVERGENCE_THRESHOLD_BPS = 500;
 const DEFAULT_PER_MINT_COOLDOWN_MS = 1_800_000;
+// #336: per-cycle market cap. The cycle iterated EVERY discovered market and
+// awaited up to 2 external HTTP calls per market — permissionless market
+// creation lets an attacker make a single cycle unbounded (and, with no
+// in-flight guard, overlap cycles). Cap markets visited per cycle and walk a
+// round-robin cursor so all admitted markets are covered over time.
+const DEFAULT_MAX_MARKETS_PER_CYCLE = 200;
+// #336: negative-cache TTL for unavailable/invalid off-chain prices, so a dead
+// attacker mint isn't re-fetched (2 HTTP calls) every single cycle.
+const DEFAULT_NEGATIVE_CACHE_TTL_MS = 300_000; // 5 min
+// #336: max alerts emitted per cycle (global budget on top of per-mint cooldown),
+// so a correlated divergence across many attacker mints can't flood the channel
+// in one cycle.
+const DEFAULT_MAX_ALERTS_PER_CYCLE = 20;
+// #336: cap on the per-mint cooldown map so it can't grow without bound.
+const MAX_TRACKED_ALERT_MINTS = 1_000;
 
 function parseBoundedIntEnv(
   name: string,
@@ -100,14 +115,41 @@ function getPerMintCooldownMs(): number {
   );
 }
 
+function getMaxMarketsPerCycle(): number {
+  return parseBoundedIntEnv("FRAUD_DETECT_MAX_MARKETS_PER_CYCLE", DEFAULT_MAX_MARKETS_PER_CYCLE, 1);
+}
+
+function getNegativeCacheTtlMs(): number {
+  return parseBoundedIntEnv("FRAUD_DETECT_NEGATIVE_CACHE_TTL_MS", DEFAULT_NEGATIVE_CACHE_TTL_MS, 0);
+}
+
+function getMaxAlertsPerCycle(): number {
+  return parseBoundedIntEnv("FRAUD_DETECT_MAX_ALERTS_PER_CYCLE", DEFAULT_MAX_ALERTS_PER_CYCLE, 0);
+}
+
 function isEnabled(): boolean {
   return process.env.FRAUD_DETECT_ENABLED !== "false";
 }
 
 export class FraudDetectorService {
-  private _timer: ReturnType<typeof setInterval> | null = null;
-  /** Map<mint, timestamp-of-last-alert> for per-mint cooldown. */
+  private _timer: ReturnType<typeof setTimeout> | null = null;
+  private _stopped = false;
+  // #336: single-flight guard. The cycle awaits external HTTP per market, so a
+  // slow cycle could overlap the next tick under the old setInterval. We now
+  // schedule the next cycle with setTimeout AFTER the previous one settles, and
+  // this flag rejects any re-entrant _runCheck() (e.g. a test or manual call
+  // landing while a cycle is mid-flight).
+  private _inFlight = false;
+  /** Map<mint, timestamp-of-last-alert> for per-mint cooldown. Bounded (#336). */
   private readonly _lastAlertByMint = new Map<string, number>();
+  // #336: round-robin cursor into the discovered-market list so the per-cycle
+  // market cap still covers every admitted market over successive cycles.
+  private _marketCursor = 0;
+  // #336: negative cache for mints whose off-chain price was unavailable/invalid,
+  // so dead attacker mints aren't re-fetched (2 HTTP calls) every cycle.
+  // Map<priceMint, expiry-timestamp-ms>. Bounded by the per-cycle market cap and
+  // pruned on expiry.
+  private readonly _negativePriceCache = new Map<string, number>();
 
   constructor(
     private readonly _oracleService: OracleService,
@@ -119,32 +161,44 @@ export class FraudDetectorService {
       logger.info("FraudDetectorService disabled via FRAUD_DETECT_ENABLED=false — no interval registered");
       return;
     }
-    if (this._timer) return;
+    if (this._timer || this._stopped) return;
 
     const intervalMs = getIntervalMs();
     logger.info("FraudDetectorService starting", {
       intervalMs,
       divergenceThresholdBps: getDivergenceThresholdBps(),
       perMintCooldownMs: getPerMintCooldownMs(),
+      maxMarketsPerCycle: getMaxMarketsPerCycle(),
+      maxAlertsPerCycle: getMaxAlertsPerCycle(),
     });
 
-    this._timer = setInterval(async () => {
-      try {
-        await this._runCheck();
-      } catch (err) {
-        logger.error("FraudDetectorService cycle failed", {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }, intervalMs);
-
-    // Do not block process exit on this observational loop.
-    this._timer.unref();
+    // #336: recursive setTimeout — the next cycle is scheduled only AFTER the
+    // current one settles, so cycles can NEVER overlap regardless of how long
+    // the external HTTP fan-out takes. The single-flight _inFlight flag is a
+    // defense-in-depth backstop for any direct _runCheck() invocation.
+    const scheduleNext = (): void => {
+      if (this._stopped) return;
+      this._timer = setTimeout(async () => {
+        try {
+          await this._runCheck();
+        } catch (err) {
+          logger.error("FraudDetectorService cycle failed", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        } finally {
+          scheduleNext();
+        }
+      }, getIntervalMs());
+      // Do not block process exit on this observational loop.
+      this._timer.unref();
+    };
+    scheduleNext();
   }
 
   stop(): void {
+    this._stopped = true;
     if (this._timer) {
-      clearInterval(this._timer);
+      clearTimeout(this._timer);
       this._timer = null;
       logger.info("FraudDetectorService stopped");
     }
@@ -152,12 +206,72 @@ export class FraudDetectorService {
 
   // Exposed for tests to invoke directly without waiting for the interval.
   async _runCheck(): Promise<void> {
+    // #336: single-flight — never run two cycles concurrently. The recursive
+    // setTimeout already serializes the scheduled path; this also covers any
+    // direct/manual _runCheck() that lands mid-cycle.
+    if (this._inFlight) {
+      logger.debug("FraudDetector: a cycle is already in flight — skipping this tick");
+      return;
+    }
+    this._inFlight = true;
+    try {
+      await this._runCheckInner();
+    } finally {
+      this._inFlight = false;
+    }
+  }
+
+  private async _runCheckInner(): Promise<void> {
     const markets = this._getMarkets();
     const thresholdBps = getDivergenceThresholdBps();
     const cooldownMs = getPerMintCooldownMs();
+    const maxMarketsPerCycle = getMaxMarketsPerCycle();
+    const negativeTtlMs = getNegativeCacheTtlMs();
+    const maxAlertsPerCycle = getMaxAlertsPerCycle();
     const now = Date.now();
 
-    for (const [slabAddress, state] of markets) {
+    // #336: prune expired negative-cache entries so the map can't grow unbounded.
+    for (const [k, expiry] of this._negativePriceCache) {
+      if (expiry <= now) this._negativePriceCache.delete(k);
+    }
+
+    // #336: select at most maxMarketsPerCycle markets, advancing a round-robin
+    // cursor so the cap still covers every admitted market over successive
+    // cycles. An attacker who creates thousands of markets can no longer make a
+    // single cycle iterate (and HTTP-fan-out over) all of them.
+    const entries = Array.from(markets.entries());
+    const totalMarkets = entries.length;
+    let selected: Array<[string, MarketCrankState]>;
+    if (totalMarkets <= maxMarketsPerCycle) {
+      selected = entries;
+      this._marketCursor = 0;
+    } else {
+      const start = ((this._marketCursor % totalMarkets) + totalMarkets) % totalMarkets;
+      selected = [];
+      for (let k = 0; k < maxMarketsPerCycle; k++) {
+        selected.push(entries[(start + k) % totalMarkets]!);
+      }
+      this._marketCursor = (start + maxMarketsPerCycle) % totalMarkets;
+      logger.debug("FraudDetector: per-cycle market cap reached — remaining markets deferred to later cycles", {
+        totalMarkets,
+        processedThisCycle: maxMarketsPerCycle,
+        cursorNext: this._marketCursor,
+      });
+    }
+
+    // #336: dedupe off-chain price fetches by priceMint WITHIN this cycle, so N
+    // markets sharing one mint cost one fetch (2 HTTP calls), not 2N. Maps
+    // priceMint → resolved off-chain price (or null when unavailable/invalid).
+    const cyclefetched = new Map<string, bigint | null>();
+    let alertsThisCycle = 0;
+
+    for (const [slabAddress, state] of selected) {
+      // #336: skip inactive markets — no point spending HTTP calls validating a
+      // market the keeper isn't cranking.
+      if (!state.isActive) {
+        continue;
+      }
+
       // HYPERP detection matches the program's oracle::is_hyperp_mode, which keys
       // ONLY off index_feed_id == [0;32]. A bootstrapped HYPERP market may carry a
       // non-zero hyperp_authority, so we must NOT additionally require
@@ -187,34 +301,58 @@ export class FraudDetectorService {
       // Off-chain consensus from OracleService (DexScreener + Jupiter median).
       // Use mainnetCA if set for devnet mirror markets.
       const priceMint = state.mainnetCA ?? mint;
-      let offChainPriceE6: bigint;
-      try {
-        const entry = await this._oracleService.fetchPrice(priceMint, slabAddress);
-        if (entry === null || entry.priceE6 === undefined || entry.priceE6 === 0n) {
-          logger.debug("FraudDetector: off-chain price unavailable for market", {
-            mint: mint.slice(0, 8),
-            slabAddress: slabAddress.slice(0, 8),
-          });
-          fraudOffchainUnavailableTotal.inc({ mint });
-          continue;
-        }
-        offChainPriceE6 = entry.priceE6;
-      } catch (err) {
-        logger.debug("FraudDetector: off-chain price fetch threw for market", {
+
+      // #336: negative cache — skip mints whose off-chain price was recently
+      // unavailable/invalid so dead attacker mints don't cost 2 HTTP calls every
+      // cycle.
+      const negExpiry = this._negativePriceCache.get(priceMint);
+      if (negExpiry !== undefined && negExpiry > now) {
+        logger.debug("FraudDetector: priceMint in negative cache — skipping fetch", {
           mint: mint.slice(0, 8),
-          slabAddress: slabAddress.slice(0, 8),
-          error: err instanceof Error ? err.message : String(err),
         });
         fraudOffchainUnavailableTotal.inc({ mint });
         continue;
       }
 
-      if (offChainPriceE6 === 0n) {
-        logger.debug("FraudDetector: off-chain price is zero — skipping market (cannot divide)", {
-          mint: mint.slice(0, 8),
-        });
-        fraudOffchainUnavailableTotal.inc({ mint });
-        continue;
+      // #336: dedupe fetch by priceMint within this cycle.
+      let offChainPriceE6: bigint;
+      if (cyclefetched.has(priceMint)) {
+        const cached = cyclefetched.get(priceMint)!;
+        if (cached === null) {
+          // Already known unavailable this cycle — no re-fetch, no re-log.
+          fraudOffchainUnavailableTotal.inc({ mint });
+          continue;
+        }
+        offChainPriceE6 = cached;
+      } else {
+        let resolved: bigint | null = null;
+        try {
+          const entry = await this._oracleService.fetchPrice(priceMint, slabAddress);
+          if (entry === null || entry.priceE6 === undefined || entry.priceE6 === 0n) {
+            logger.debug("FraudDetector: off-chain price unavailable for market", {
+              mint: mint.slice(0, 8),
+              slabAddress: slabAddress.slice(0, 8),
+            });
+            resolved = null;
+          } else {
+            resolved = entry.priceE6;
+          }
+        } catch (err) {
+          logger.debug("FraudDetector: off-chain price fetch threw for market", {
+            mint: mint.slice(0, 8),
+            slabAddress: slabAddress.slice(0, 8),
+            error: err instanceof Error ? err.message : String(err),
+          });
+          resolved = null;
+        }
+        cyclefetched.set(priceMint, resolved);
+        if (resolved === null) {
+          // #336: cache the negative result with a bounded TTL.
+          if (negativeTtlMs > 0) this._negativePriceCache.set(priceMint, now + negativeTtlMs);
+          fraudOffchainUnavailableTotal.inc({ mint });
+          continue;
+        }
+        offChainPriceE6 = resolved;
       }
 
       const bps = divergenceBps(onChainMarkE6, offChainPriceE6);
@@ -244,8 +382,20 @@ export class FraudDetectorService {
         continue;
       }
 
+      // #336: global per-cycle alert budget on top of the per-mint cooldown. A
+      // correlated divergence across many (attacker) mints can't flood the
+      // channel in a single cycle. Logged once so a sustained breach is visible.
+      if (alertsThisCycle >= maxAlertsPerCycle) {
+        logger.warn("FraudDetector: per-cycle alert budget exhausted — suppressing further alerts this cycle", {
+          maxAlertsPerCycle,
+        });
+        break;
+      }
+
       // Alert: update cooldown timestamp, increment counter, fire Discord warning.
-      this._lastAlertByMint.set(mint, now);
+      // #336: bounded cooldown map so it can't grow without limit.
+      this._setLastAlert(mint, now);
+      alertsThisCycle++;
       fraudAlertTotal.inc({ mint });
 
       const onChainUsd = (Number(onChainMarkE6) / PRICE_E6_SCALE).toFixed(6);
@@ -269,5 +419,19 @@ export class FraudDetectorService {
         { name: "Market", value: slabAddress.slice(0, 16) + "...", inline: false },
       ])?.catch(() => {});
     }
+  }
+
+  /**
+   * #336: set the per-mint last-alert timestamp, evicting the oldest-inserted
+   * entry first when the map is at capacity (FIFO; JS Map preserves insertion
+   * order). Re-setting an existing mint keeps its position, so a repeatedly-
+   * alerting mint won't evict itself.
+   */
+  private _setLastAlert(mint: string, ts: number): void {
+    if (!this._lastAlertByMint.has(mint) && this._lastAlertByMint.size >= MAX_TRACKED_ALERT_MINTS) {
+      const oldest = this._lastAlertByMint.keys().next().value;
+      if (oldest !== undefined) this._lastAlertByMint.delete(oldest);
+    }
+    this._lastAlertByMint.set(mint, ts);
   }
 }

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -30,7 +30,13 @@ import type { AccountLoader } from "../lib/account-loader.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
 import { AlertAggregator } from "../lib/alert-aggregator.js";
-import { parseV17RiskParams, V17RiskParamsCorruptedError, readEffectivePriceForAsset } from "../lib/v17-risk.js";
+import {
+  parseV17RiskParams,
+  V17RiskParamsCorruptedError,
+  readEffectivePriceForAsset,
+  readRawOracleTargetPriceForAsset,
+  targetEffectiveLagPenalty,
+} from "../lib/v17-risk.js";
 import { resolveV17OracleTail } from "../lib/v17-oracle-tail.js";
 
 const logger = createLogger("keeper:liquidation");
@@ -952,9 +958,13 @@ export class LiquidationService {
           // (which would fall through to submitting the liquidation
           // unconditionally) -- degrade to relying on the equity<=0n signal
           // alone instead.
-          let reMmBps: bigint | null = null;
+          let freshRiskParams: { maintenanceMarginBps: bigint; minNonzeroMmReq: bigint } | null = null;
           try {
-            reMmBps = parseV17RiskParams(freshMarketData).maintenanceMarginBps;
+            const parsed = parseV17RiskParams(freshMarketData);
+            freshRiskParams = {
+              maintenanceMarginBps: parsed.maintenanceMarginBps,
+              minNonzeroMmReq: parsed.minNonzeroMmReq,
+            };
             this._corruptedRiskParamsAlertedAt.delete(slabAddress.toBase58());
           } catch (err) {
             if (err instanceof V17RiskParamsCorruptedError) {
@@ -989,28 +999,38 @@ export class LiquidationService {
               return null;
             }
           }
-          // H-8: always run the recheck, even when reMmBps could not be
-          // obtained (corrupted/null) -- equity<=0n is checked unconditionally
+          // #335.1: pre-submit recheck uses the IDENTICAL aggregate-maintenance
+          // health evaluator as scanV17Portfolios — no per-leg vs aggregate
+          // divergence between scan and submit.
+          //
+          // H-8 / #335.4: equity<=0n is checked unconditionally inside the helper
           // so an outright-bankrupt position is never masked by an untrusted
-          // threshold. If reMmBps is null AND equity>0n for every leg, we have
-          // no reliable signal either way -- stillLiquidatable stays false and
-          // the function safely aborts (fails closed) rather than guessing.
+          // threshold. When freshRiskParams could not be obtained (corrupted), we
+          // CANNOT trust the maintenanceMarginBps threshold — so we degrade to a
+          // conservative equity<=0n-only check (using the same conservative
+          // equity the helper uses: positive PnL counted at 0). If equity>0n in
+          // that degraded case we have no reliable threshold signal and abort
+          // (fail closed) rather than guessing.
           {
-            const feeDebt = pf.feeCredits < 0n ? -pf.feeCredits : 0n;
-            const equity = pf.capital + pf.pnl - feeDebt;
             let stillLiquidatable = false;
-            // #329: Re-derive closeQ from the fresh portfolio. The position may
-            // have been partially closed since scan time — use the current absPos.
             let freshCloseQ = 0n;
-            for (const leg of pf.legs) {
-              if (!leg.active || leg.basisPosQ === 0n) continue;
-              const absPos = leg.basisPosQ < 0n ? -leg.basisPosQ : leg.basisPosQ;
-              const notional = absPos * freshPrice / PRICE_E6_DIVISOR;
-              if (notional === 0n) continue;
-              if (equity <= 0n || (reMmBps !== null && computeMarginRatioBps(equity, notional) < reMmBps)) {
-                stillLiquidatable = true;
-                if (freshCloseQ === 0n) freshCloseQ = absPos; // first qualifying leg
-                break;
+            if (freshRiskParams !== null) {
+              const health = evaluateV17PortfolioHealth(pf, freshMarketData, freshRiskParams, freshPrice);
+              stillLiquidatable = health.liquidatable;
+              freshCloseQ = health.closeQ;
+            } else {
+              // Corrupted/unavailable risk params: rely on equity<=0n alone, with
+              // the same conservative equity (positive PnL → 0) the helper uses.
+              const feeDebt = pf.feeCredits < 0n ? -pf.feeCredits : 0n;
+              const conservativePnl = pf.pnl < 0n ? pf.pnl : 0n;
+              const equity = pf.capital + conservativePnl - feeDebt;
+              if (equity <= 0n) {
+                for (const leg of pf.legs) {
+                  if (!leg.active || leg.basisPosQ === 0n) continue;
+                  stillLiquidatable = true;
+                  freshCloseQ = leg.basisPosQ < 0n ? -leg.basisPosQ : leg.basisPosQ; // first active leg
+                  break;
+                }
               }
             }
             if (!stillLiquidatable) {

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -134,6 +134,130 @@ const V17_PORTFOLIO_MARKET_OFFSET = 16;
  *
  * @returns Array of {portfolioPubkey, owner} tuples for liquidatable portfolios.
  */
+/**
+ * #335: SHARED v17 portfolio-health evaluator — the single source of truth used
+ * by BOTH scanV17Portfolios() (prefilter) and liquidate()'s pre-submit recheck,
+ * so the two can never diverge. Replaces the old per-leg
+ * `computeMarginRatioBps(equity, notional) < maintenanceMarginBps` recheck with
+ * the same aggregate-maintenance semantics the scanner uses.
+ *
+ * Mirrors the engine's maintenance check as closely as an off-chain keeper can:
+ *  - Aggregate maintenance across ALL active legs (not per-leg) — a portfolio is
+ *    undercollateralized when equity < sum(legMaintenance) (#330).
+ *  - Per-asset effective_price (#331) and the minNonzeroMmReq floor.
+ *  - #335.2 CONSERVATIVE equity: capital + min(pnl, 0n) - feeDebt. The engine
+ *    haircuts positive PnL down to realizable source support
+ *    (account_haircut_equity, src/v16.rs:8451; positive PnL with no source claims
+ *    contributes ZERO), which the keeper cannot reproduce off-chain. Counting
+ *    positive PnL at 0 can only ever flag MORE portfolios (safe — no false
+ *    negatives). Negative PnL is still fully counted.
+ *  - #335.3 target/effective-price lag penalty ADDED to each leg's maintenance
+ *    (src/v16.rs:1207). Computed from the leg side + the asset's
+ *    raw_oracle_target_price + effective_price. If raw_oracle_target_price is
+ *    unreadable (0n) the penalty is omitted (never used to mark healthy).
+ *  - #335.4 If a required input is missing (no price for an active leg), the leg
+ *    is treated CONSERVATIVELY — it is flagged as a candidate rather than
+ *    silently skipped, so a missing read can never produce a false "healthy".
+ *
+ * Returns:
+ *  - liquidatable: equity <= 0n OR equity < aggregateMaintenance.
+ *  - closeQ: absPos of the first active nonzero leg (the liquidation target leg),
+ *            0n if there is no active nonzero leg.
+ *  - assetIndex: assetIndex of that first active leg (-1 if none).
+ *  - deficit: max(0, aggregateMaintenance - equity) — used only for prioritization.
+ */
+export function evaluateV17PortfolioHealth(
+  pf: ReturnType<typeof parsePortfolioV17>,
+  marketData: Uint8Array,
+  riskParams: { maintenanceMarginBps: bigint; minNonzeroMmReq: bigint },
+  fallbackPrice: bigint,
+): { liquidatable: boolean; closeQ: bigint; assetIndex: number; deficit: bigint } {
+  const { maintenanceMarginBps, minNonzeroMmReq } = riskParams;
+
+  // #335.2 CONSERVATIVE equity: positive PnL contributes 0 (engine haircuts it
+  // to realizable support, which we can't compute off-chain). Negative PnL fully
+  // counted. fee debt fully subtracted.
+  const feeDebt = pf.feeCredits < 0n ? -pf.feeCredits : 0n;
+  const conservativePnl = pf.pnl < 0n ? pf.pnl : 0n;
+  const equity = pf.capital + conservativePnl - feeDebt;
+
+  let aggregateMaintenance = 0n;
+  let firstActiveAssetIndex = -1;
+  let candidateCloseQ = 0n;
+  for (const leg of pf.legs) {
+    if (!leg.active) continue;
+    if (leg.basisPosQ === 0n) continue;
+    const absPos = leg.basisPosQ < 0n ? -leg.basisPosQ : leg.basisPosQ;
+    // #331: per-asset effective_price from the market bytes; fall back to the
+    // market-level price when the buffer is too short.
+    const legPrice = readEffectivePriceForAsset(marketData, leg.assetIndex) || fallbackPrice;
+
+    if (firstActiveAssetIndex < 0) {
+      firstActiveAssetIndex = leg.assetIndex;
+      candidateCloseQ = absPos;
+    }
+
+    // #335.4 CONSERVATIVE-UNKNOWN: an active nonzero leg with no resolvable price
+    // is a verification gap, not a healthy leg. We cannot size its maintenance,
+    // so flag the whole portfolio as a candidate (do NOT silently skip → that
+    // would risk a false "healthy"). Return liquidatable with this leg as target.
+    if (legPrice <= 0n) {
+      return {
+        liquidatable: true,
+        closeQ: absPos,
+        assetIndex: leg.assetIndex,
+        deficit: aggregateMaintenance > equity ? aggregateMaintenance - equity : 0n,
+      };
+    }
+
+    // Ceiling division to match on-chain risk_notional_ceil (POS_SCALE = 1e6).
+    const notional = (absPos * legPrice + PRICE_E6_DIVISOR - 1n) / PRICE_E6_DIVISOR;
+    if (notional === 0n) continue;
+    // Base per-leg maintenance, clamped up to the minNonzeroMmReq floor.
+    const legMaintenance = notional * maintenanceMarginBps / BPS_MULTIPLIER;
+    let legMaintenanceClamped = legMaintenance < minNonzeroMmReq ? minNonzeroMmReq : legMaintenance;
+
+    // #335.3 target/effective-price lag penalty, ADDED to the per-leg maintenance
+    // exactly as the engine does (src/v16.rs:1207). Derive side from basisPosQ
+    // sign (cross-checks with leg.side: 0=long, 1=short). Penalty omitted when
+    // raw_oracle_target_price is unreadable (0n) — never marks healthier.
+    const side: 1 | -1 = leg.basisPosQ > 0n ? 1 : -1;
+    const rawTarget = readRawOracleTargetPriceForAsset(marketData, leg.assetIndex);
+    const lagPenalty = targetEffectiveLagPenalty(absPos, side, legPrice, rawTarget);
+    legMaintenanceClamped += lagPenalty;
+
+    aggregateMaintenance += legMaintenanceClamped;
+  }
+
+  if (firstActiveAssetIndex < 0) {
+    return { liquidatable: false, closeQ: 0n, assetIndex: -1, deficit: 0n };
+  }
+
+  // H-8 defense-in-depth: equity<=0n is unconditionally bankrupt.
+  // #330: check AGGREGATE maintenance, not per-leg.
+  const liquidatable = equity <= 0n || equity < aggregateMaintenance;
+  const deficit = aggregateMaintenance > equity ? aggregateMaintenance - equity : 0n;
+  return { liquidatable, closeQ: candidateCloseQ, assetIndex: firstActiveAssetIndex, deficit };
+}
+
+// ─── #334: bounded v17 portfolio enumeration constants ───────────────────────
+
+/**
+ * #334: hard cap on portfolios PARSED per market per cycle. getProgramAccounts is
+ * unbounded — an attacker can create thousands of portfolios for one market to
+ * make a single scan run unbounded and stall every other market. We cap the work
+ * per market per cycle and walk a PERSISTENT per-market rotating cursor so every
+ * portfolio is eventually scanned across cycles (fairness — none is permanently
+ * skipped). Sized generously so legitimate markets are fully covered in one cycle.
+ */
+const MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE = 512;
+
+/** #334: cap on liquidation candidates emitted per market per cycle. */
+const MAX_CANDIDATES_PER_MARKET = 64;
+
+/** #334: cap on liquidation candidates emitted globally per cycle (all markets). */
+const MAX_CANDIDATES_PER_GLOBAL_CYCLE = 256;
+
 async function scanV17Portfolios(
   connection: ReturnType<typeof getConnection>,
   programId: PublicKey,
@@ -142,7 +266,10 @@ async function scanV17Portfolios(
   price: bigint,
   marketData: Uint8Array,
   minNonzeroMmReq: bigint,
-): Promise<Array<{ portfolioPubkey: PublicKey; owner: string; assetIndex: number; closeQ: bigint }>> {
+  // #334: persistent rotating cursor map (marketKey → next start offset) so every
+  // portfolio is eventually scanned across cycles even when truncated.
+  cursors: Map<string, number>,
+): Promise<Array<{ portfolioPubkey: PublicKey; owner: string; assetIndex: number; closeQ: bigint; deficit: bigint }>> {
   const marketKey = market.slabAddress.toBase58();
   let rawPortfolios: ReadonlyArray<{ pubkey: PublicKey; account: { data: Buffer | Uint8Array } }>;
   try {
@@ -171,8 +298,53 @@ async function scanV17Portfolios(
 
   if (price === 0n) return []; // No price, can't compute margin
 
-  const candidates: Array<{ portfolioPubkey: PublicKey; owner: string; assetIndex: number; closeQ: bigint }> = [];
-  for (const { pubkey, account } of rawPortfolios) {
+  // #334: bound the per-market work. getProgramAccounts is unbounded, so an
+  // attacker can create many portfolios to make one market's scan run unbounded
+  // and stall every other market (health flaps → restart loop). We process at
+  // most MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE accounts per market per cycle and
+  // advance a PERSISTENT rotating cursor so the rest are picked up next cycle —
+  // every portfolio is eventually scanned (fairness; no permanent skip).
+  const total = rawPortfolios.length;
+  // Sort for a STABLE rotation order independent of RPC return order, so the
+  // cursor reliably advances over the same sequence across cycles.
+  const ordered =
+    total > MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE
+      ? [...rawPortfolios].sort((a, b) =>
+          a.pubkey.toBase58() < b.pubkey.toBase58() ? -1 : a.pubkey.toBase58() > b.pubkey.toBase58() ? 1 : 0,
+        )
+      : rawPortfolios;
+
+  type RawPortfolio = { pubkey: PublicKey; account: { data: Buffer | Uint8Array } };
+  let startOffset = 0;
+  let window: ReadonlyArray<RawPortfolio> = ordered;
+  if (total > MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE) {
+    startOffset = ((cursors.get(marketKey) ?? 0) % total + total) % total;
+    // Take a rotating window of size MAX_…, wrapping around the end.
+    const win: RawPortfolio[] = [];
+    for (let k = 0; k < MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE; k++) {
+      win.push(ordered[(startOffset + k) % total]!);
+    }
+    window = win;
+    // Persist the next start so subsequent cycles cover the remaining portfolios.
+    cursors.set(marketKey, (startOffset + MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE) % total);
+    logger.info("scanV17Portfolios: truncating to per-market cap — remaining portfolios deferred to later cycles", {
+      market: marketKey.slice(0, 8),
+      totalPortfolios: total,
+      processedThisCycle: MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE,
+      droppedThisCycle: total - MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE,
+      cursorStart: startOffset,
+      cursorNext: (startOffset + MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE) % total,
+    });
+  } else if (cursors.has(marketKey)) {
+    // Market shrank back under the cap — reset the cursor so we don't carry a
+    // stale offset that would skip the front of a now-small set.
+    cursors.delete(marketKey);
+  }
+
+  // #334: collect all qualifying candidates with their deficit so we can
+  // prioritize by LARGEST deficit before applying the per-market candidate cap.
+  const scored: Array<{ portfolioPubkey: PublicKey; owner: string; assetIndex: number; closeQ: bigint; deficit: bigint }> = [];
+  for (const { pubkey, account } of window) {
     try {
       const pfData = new Uint8Array(account.data);
       const pf = parsePortfolioV17(pfData);
@@ -193,56 +365,44 @@ async function scanV17Portfolios(
         continue;
       }
 
-      // #230: fee debt is portfolio-level — compute once outside the leg loop.
-      const feeDebt = pf.feeCredits < 0n ? -pf.feeCredits : 0n;
-      const equity = pf.capital + pf.pnl - feeDebt;
-
-      // #330/#331: Aggregate maintenance across all active legs using per-asset
-      // effective_price. A portfolio with N legs is undercollateralized when
-      // equity < sum(legMaintenance) even if equity >= any individual leg's
-      // maintenance — the old per-leg break missed this case.
-      let aggregateMaintenance = 0n;
-      let firstActiveAssetIndex = -1;
-      let candidateCloseQ = 0n;
-      for (const leg of pf.legs) {
-        if (!leg.active) continue;
-        if (leg.basisPosQ === 0n) continue;
-        const absPos = leg.basisPosQ < 0n ? -leg.basisPosQ : leg.basisPosQ;
-        // #331: Use per-asset effective_price from the market account bytes.
-        // Falls back to the market-level price when the buffer is too short.
-        const legPrice = readEffectivePriceForAsset(marketData, leg.assetIndex) || price;
-        // Ceiling division to match on-chain notional rounding.
-        const notional = (absPos * legPrice + PRICE_E6_DIVISOR - 1n) / PRICE_E6_DIVISOR;
-        if (notional === 0n) continue;
-        // Per-leg maintenance: clamped up to minNonzeroMmReq so even tiny
-        // positions carry the minimum margin floor.
-        const legMaintenance = notional * maintenanceMarginBps / BPS_MULTIPLIER;
-        const legMaintenanceClamped = legMaintenance < minNonzeroMmReq ? minNonzeroMmReq : legMaintenance;
-        aggregateMaintenance += legMaintenanceClamped;
-        // Track first active leg for candidate assetIndex and closeQ.
-        if (firstActiveAssetIndex < 0) {
-          firstActiveAssetIndex = leg.assetIndex;
-          candidateCloseQ = absPos;
-        }
-      }
-
-      if (firstActiveAssetIndex < 0) continue; // no active nonzero legs
-
-      // H-8 defense-in-depth: equity<=0n is unconditionally bankrupt.
-      // #330: check aggregate maintenance, not per-leg.
-      if (equity <= 0n || equity < aggregateMaintenance) {
-        candidates.push({
+      // #335: single shared health evaluator (aggregate maintenance, per-asset
+      // price, conservative equity, target-lag penalty). IDENTICAL semantics to
+      // the pre-submit recheck in liquidate().
+      const health = evaluateV17PortfolioHealth(
+        pf,
+        marketData,
+        { maintenanceMarginBps, minNonzeroMmReq },
+        price,
+      );
+      if (health.assetIndex < 0) continue; // no active nonzero legs
+      if (health.liquidatable) {
+        scored.push({
           portfolioPubkey: pubkey,
           owner: pf.owner.toBase58(),
-          assetIndex: firstActiveAssetIndex, // DESYNC-4: use leg.assetIndex, NOT slab slot index
-          closeQ: candidateCloseQ,           // #329: absPos of first active leg
+          assetIndex: health.assetIndex, // DESYNC-4: leg.assetIndex, NOT slab slot index
+          closeQ: health.closeQ,         // #329: absPos of first active leg
+          deficit: health.deficit,
         });
       }
     } catch {
       // Skip portfolios that fail to parse
     }
   }
-  return candidates;
+
+  // #334: cap candidates PER MARKET, prioritizing the largest deficit (most
+  // urgent / most insurance-fund exposure) first. The GLOBAL per-cycle cap
+  // (MAX_CANDIDATES_PER_GLOBAL_CYCLE) is enforced in scanAndLiquidateAll where
+  // candidates are consumed sequentially across markets.
+  scored.sort((a, b) => (b.deficit > a.deficit ? 1 : b.deficit < a.deficit ? -1 : 0));
+  if (scored.length > MAX_CANDIDATES_PER_MARKET) {
+    logger.info("scanV17Portfolios: per-market candidate cap reached — lower-deficit candidates deferred", {
+      market: marketKey.slice(0, 8),
+      qualifying: scored.length,
+      kept: MAX_CANDIDATES_PER_MARKET,
+      droppedThisCycle: scored.length - MAX_CANDIDATES_PER_MARKET,
+    });
+  }
+  return scored.slice(0, MAX_CANDIDATES_PER_MARKET);
 }
 
 // Oracle-drift guard (main hardening): abort liquidation if the oracle price drifts more than
@@ -441,6 +601,14 @@ export class LiquidationService {
   // PERC-484: Track markets that permanently fail with InvalidSlabLen (0x4).
   // These are test/corrupt markets with wrong slab size — skip them indefinitely.
   private readonly permanentlySkipped = new Set<string>();
+  // #334: PERSISTENT per-market rotating cursor (marketKey → next start offset
+  // into the portfolio set). When a market has more than
+  // MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE portfolios, scanV17Portfolios processes a
+  // rotating window and advances this cursor so every portfolio is eventually
+  // scanned across cycles — an attacker can't permanently hide an underwater
+  // portfolio behind a flood of dummy ones, and the scan can't run unbounded.
+  // Survives across cycles (not cleared in scanAndLiquidateAll) by design.
+  private readonly _v17PortfolioCursors = new Map<string, number>();
   // H-8: per-market cooldown latch for the "corrupted risk params" alert. A
   // corrupted/zero maintenanceMarginBps is a sustained, unchanging condition
   // re-evaluated every scan cycle (default 60s) -- not a burst of distinct
@@ -571,6 +739,7 @@ export class LiquidationService {
           price,
           data,
           v17Params.minNonzeroMmReq,
+          this._v17PortfolioCursors, // #334: persistent rotating cursor
         );
         // Map to LiquidationCandidate — v17 uses portfolio pubkey as accountIdx sentinel
         // The liquidate() method is updated below to use portfolioPubkey directly.
@@ -1265,6 +1434,15 @@ export class LiquidationService {
     const BATCH_DELAY_MS = 1_200; // ~1.2s pause between batches
     const entries = Array.from(markets.values());
 
+    // #334: global per-cycle candidate budget. Bounds the total number of
+    // (serial, RPC-heavy) liquidate() submissions a single cycle will attempt,
+    // so an attacker who spreads underwater portfolios across many markets can't
+    // make one cycle run unbounded and stall the scheduler. Candidates beyond
+    // the budget are deferred to the next cycle (the per-market deficit sort
+    // means the most urgent are processed first within each market).
+    let globalCandidatesProcessed = 0;
+    let globalBudgetLoggedThisCycle = false;
+
     for (let i = 0; i < entries.length; i += BATCH_SIZE) {
       const batch = entries.slice(i, i + BATCH_SIZE);
       // PERC-484: Skip markets permanently flagged as invalid slab (0x4 InvalidSlabLen).
@@ -1296,6 +1474,21 @@ export class LiquidationService {
         // C1: dedup per on-chain (slab, accountIdx) position; rate-limit per
         // owner across the cycle.
         for (const candidate of candidates) {
+          // #334: honor the global per-cycle candidate cap. Once exhausted, stop
+          // submitting liquidations this cycle — the remainder is picked up next
+          // cycle. Logged once so a sustained breach is operator-visible (no
+          // silent cap).
+          if (globalCandidatesProcessed >= MAX_CANDIDATES_PER_GLOBAL_CYCLE) {
+            if (!globalBudgetLoggedThisCycle) {
+              logger.info("scanAndLiquidateAll: global per-cycle candidate cap reached — remaining liquidations deferred to next cycle", {
+                cap: MAX_CANDIDATES_PER_GLOBAL_CYCLE,
+                totalCandidatesThisCycle: candidateCount,
+              });
+              globalBudgetLoggedThisCycle = true;
+            }
+            break; // stop processing this market's remaining candidates
+          }
+          globalCandidatesProcessed++;
           // C1/#218: dedup by (slab, accountIdx) + per-owner cap are enforced inside the
           // shared gate, which the LaserStream event path also uses — so neither path can
           // bypass it.

--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -69,6 +69,12 @@ export class OracleService {
     { consecutive: number; alertSent: boolean }
   >();
   private static readonly SINGLE_SOURCE_ALERT_THRESHOLD = 10;
+  // #336: bound the per-mint state maps. fetchPrice() is reachable per discovered
+  // market, and permissionless market creation means an attacker can spray
+  // distinct mints to grow these maps without limit. Cap them (mirrors the
+  // priceHistory maxTrackedMarkets pattern) and evict the oldest-inserted entry
+  // when full. Map insertion order is FIFO in JS, so the first key is the oldest.
+  private static readonly MAX_TRACKED_MINT_STATE = 500;
   // M6: per-mint dual-null state. Both DexScreener and Jupiter can return null
   // simultaneously during an outage. Track consecutive observations and escalate
   // via sendCriticalAlert at threshold so ops sees the outage immediately rather
@@ -353,7 +359,9 @@ export class OracleService {
         ])?.catch(() => {});
       }
     }
-    this._singleSourceState.set(mint, mintState);
+    // #336: bounded set — caps the per-mint state map so an attacker spraying
+    // distinct mints can't grow it without limit.
+    OracleService._setBounded(this._singleSourceState, mint, mintState, OracleService.MAX_TRACKED_MINT_STATE);
 
     // Select best available price (DexScreener preferred)
     let priceE6: bigint | null = dexPrice;
@@ -402,7 +410,8 @@ export class OracleService {
           { name: "Sources Down", value: "DexScreener + Jupiter", inline: false },
         ])?.catch(() => {});
       }
-      this._dualNullState.set(mint, dualState);
+      // #336: bounded set — see _singleSourceState above.
+      OracleService._setBounded(this._dualNullState, mint, dualState, OracleService.MAX_TRACKED_MINT_STATE);
 
       if (history && history.length > 0) {
         const last = history[history.length - 1];
@@ -430,7 +439,8 @@ export class OracleService {
         });
         dualState.consecutive = 0;
         dualState.alertSent = false;
-        this._dualNullState.set(mint, dualState);
+        // #336: bounded set (no-op for size since this re-sets an existing key).
+        OracleService._setBounded(this._dualNullState, mint, dualState, OracleService.MAX_TRACKED_MINT_STATE);
       }
     }
 
@@ -485,6 +495,21 @@ export class OracleService {
     // before this line, so they never refresh the staleness clock.
     this.lastExternalPriceMs.set(slabAddress, entry.timestamp);
     return entry;
+  }
+
+  /**
+   * #336: set a value into a per-mint state map, evicting the oldest-inserted
+   * entry first when the map is at capacity. JS Map preserves insertion order,
+   * so the first key returned by keys() is the oldest. Re-setting an existing
+   * key does NOT change its position, so a hot mint won't be evicted while it's
+   * being updated every cycle — only genuinely idle (oldest) mints are dropped.
+   */
+  private static _setBounded<V>(map: Map<string, V>, key: string, value: V, max: number): void {
+    if (!map.has(key) && map.size >= max) {
+      const oldest = map.keys().next().value;
+      if (oldest !== undefined) map.delete(oldest);
+    }
+    map.set(key, value);
   }
 
   private recordPrice(slabAddress: string, entry: PriceEntry): void {

--- a/tests/lib/budget-cycle-reset.test.ts
+++ b/tests/lib/budget-cycle-reset.test.ts
@@ -73,8 +73,12 @@ describe("KeeperBudget cycle-reset regression (drives the real keeperSend)", () 
     expect(refused).toBe(0);
   });
 
-  it("a genuine burst beyond the per-cycle cap within one window still halts, and resume() recovers", async () => {
-    // No clock advance → all sends fall in one window. The 61st trips the cap.
+  it("#333: a within-window crank burst beyond the cap is soft-refused (no halt) and auto-recovers", async () => {
+    // No clock advance → all sends fall in one window. With default config
+    // (maxTxPerCycle=60, reservedCriticalTxPerCycle=10) "crank" sees an
+    // effective cap of 50, so the 51st+ crank is refused — but as SOFT
+    // backpressure, NOT a latching halt (#333). An attacker driving crank/
+    // provisioning volume can no longer wedge the whole keeper.
     const clock = makeClock();
     const budget = new KeeperBudget({}, { now: clock.now });
     const kp = Keypair.generate();
@@ -83,14 +87,31 @@ describe("KeeperBudget cycle-reset regression (drives the real keeperSend)", () 
     for (let i = 0; i < 80; i++) {
       if ((await keeperSend(c, [ix()], [kp], "crank", budget)) === null) refused++;
     }
-    expect(budget.isHalted()).toBe(true);
-    expect(budget.getStats().haltKind).toBe("cycle-tx-count-cap");
-    expect(refused).toBeGreaterThan(0);
+    expect(budget.isHalted()).toBe(false); // soft backpressure — no latch
+    expect(budget.getStats().haltKind).toBeUndefined();
+    expect(refused).toBeGreaterThan(0); // sends past the effective cap were deferred
 
-    // Recoverable without a restart: resume + a fresh window lets sends through.
-    budget.resume("test-operator");
+    // Auto-recovers next window WITHOUT any operator resume().
     clock.advance(30_000);
     expect(await keeperSend(c, [ix()], [kp], "crank", budget)).not.toBeNull();
+    expect(budget.isHalted()).toBe(false);
+  });
+
+  it("#333: reserved critical capacity — a crank flood still leaves room for a liquidation", async () => {
+    // Saturate the routine (crank) lane within one window. The reserved slots
+    // (default 10) are held back from crank, so a liquidation still lands even
+    // though crank is fully backpressured.
+    const clock = makeClock();
+    const budget = new KeeperBudget({}, { now: clock.now });
+    const kp = Keypair.generate();
+    const c = conn();
+    for (let i = 0; i < 60; i++) {
+      await keeperSend(c, [ix()], [kp], "crank", budget); // floods up to the 50-slot crank cap
+    }
+    // crank is now refused (effective cap 50 reached)…
+    expect(await keeperSend(c, [ix()], [kp], "crank", budget)).toBeNull();
+    // …but a liquidation uses the FULL cap of 60, so reserved slots remain.
+    expect(await keeperSend(c, [ix()], [kp], "liquidation", budget)).not.toBeNull();
     expect(budget.isHalted()).toBe(false);
   });
 });

--- a/tests/lib/budget.test.ts
+++ b/tests/lib/budget.test.ts
@@ -19,6 +19,11 @@ const TIGHT_CONFIG = {
   maxSolPerHour: 5_000,
   maxSolPerDay: 20_000,
   maxTxPerCycle: 5,
+  // #333: pin the critical-reserve to 0 in the shared config so spend/reservation
+  // tests exercise the FULL count cap on the "crank" lane (matching their
+  // pre-#333 intent). The dedicated count-cap / reserved-capacity tests below set
+  // reservedCriticalTxPerCycle explicitly where the reserve is the thing under test.
+  reservedCriticalTxPerCycle: 0,
   txSuccessRateWindow: 60_000,
   txSuccessRateThreshold: 0.7,
   txSuccessRateMinSamples: 4,
@@ -154,14 +159,21 @@ describe("KeeperBudget — day spend cap", () => {
 });
 
 describe("KeeperBudget — cycle tx count cap", () => {
-  it("trips when cycle tx count would exceed cap", () => {
+  // #333: hitting the per-cycle tx-COUNT cap is soft backpressure, NOT a
+  // latching halt. The send is refused but the breaker stays un-halted so the
+  // next window auto-resumes the deferred work — an attacker can no longer
+  // wedge the whole keeper with mere crank/provisioning volume.
+  it("refuses the over-cap send WITHOUT halting (soft backpressure)", () => {
     const clock = makeClock();
-    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    // TIGHT_CONFIG pins reservedCriticalTxPerCycle:0 so "crank" sees the full
+    // count cap (5) and this test isolates the raw count-cap → soft-refuse path.
+    const b = new KeeperBudget({ ...TIGHT_CONFIG, reservedCriticalTxPerCycle: 0 }, { now: clock.now });
     for (let i = 0; i < 5; i++) {
       b.recordTx(1, "crank", "success");
     }
     expect(b.canSpend(1, "crank")).toBe(false);
-    expect(b.haltKind).toBe("cycle-tx-count-cap");
+    expect(b.isHalted()).toBe(false); // no latch
+    expect(b.haltKind).toBeUndefined();
   });
 });
 
@@ -199,19 +211,38 @@ describe("KeeperBudget — per-cycle window auto-reset", () => {
     expect(b.getStats().cycleSpend).toBe(0); // rolled
   });
 
-  it("a genuine within-window burst still trips the cap and latches (brake intact)", () => {
+  it("#333: a within-window count-cap burst refuses (soft) but does NOT latch", () => {
     const clock = makeClock();
-    const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000 }, { now: clock.now });
+    const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000, reservedCriticalTxPerCycle: 0 }, { now: clock.now });
     for (let i = 0; i < 5; i++) b.recordTx(1, "crank", "success"); // maxTxPerCycle = 5
     expect(b.canSpend(1, "crank")).toBe(false);
-    expect(b.haltKind).toBe("cycle-tx-count-cap");
+    expect(b.isHalted()).toBe(false); // soft backpressure, no halt
+    expect(b.haltKind).toBeUndefined();
   });
 
-  it("window roll does NOT clear a latched halt — resume() is still required", () => {
+  it("#333: a genuine SPEND-cap burst still latches (brake intact for real anomalies)", () => {
+    const clock = makeClock();
+    // maxSolPerCycle = 1_000; one big spend breaches it → real overspend → latch.
+    const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000 }, { now: clock.now });
+    expect(b.canSpend(2_000, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(true);
+    expect(b.haltKind).toBe("cycle-spend-cap");
+  });
+
+  it("#333: count-cap soft refusal auto-clears next window (no resume needed)", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000, reservedCriticalTxPerCycle: 0 }, { now: clock.now });
+    for (let i = 0; i < 5; i++) b.recordTx(1, "crank", "success");
+    expect(b.canSpend(1, "crank")).toBe(false); // count cap hit
+    expect(b.isHalted()).toBe(false);
+    clock.advance(30_000); // window rolls → _cycleTxCount zeroed
+    expect(b.canSpend(1, "crank")).toBe(true); // auto-resumed, no operator action
+  });
+
+  it("window roll does NOT clear a latched SPEND halt — resume() is still required", () => {
     const clock = makeClock();
     const b = new KeeperBudget({ ...TIGHT_CONFIG, cycleWindowMs: 30_000 }, { now: clock.now });
-    for (let i = 0; i < 5; i++) b.recordTx(1, "crank", "success");
-    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.canSpend(2_000, "crank")).toBe(false); // spend-cap breach → latch
     expect(b.isHalted()).toBe(true);
     clock.advance(120_000); // several windows elapse
     expect(b.isHalted()).toBe(true); // a real breach stays halted until a human resumes

--- a/tests/poc/issue-333-budget-latch.poc.test.ts
+++ b/tests/poc/issue-333-budget-latch.poc.test.ts
@@ -1,0 +1,117 @@
+/**
+ * PoC for Finding #333 [HIGH] — global budget latch DoS.
+ *
+ * ROOT CAUSE (pre-fix): KeeperBudget.canSpend() treated exceeding maxTxPerCycle
+ * as a genuine anomaly and called _halt("cycle-tx-count-cap", ...), LATCHING a
+ * permanent halt that survived the 30s window rollover and only cleared via an
+ * operator resume(). Because permissionless market creation drives crank /
+ * provisioning / lp-vault tx volume, an attacker could latch the keeper with
+ * mere volume and stop ALL cranks AND liquidations cross-market.
+ *
+ * FIX (#333):
+ *   1. De-latch the count cap → soft backpressure: canSpend() returns false
+ *      WITHOUT setting _isHalted; _rollCycleIfElapsed auto-resumes next window.
+ *   2. Reserve safety-critical capacity (reservedCriticalTxPerCycle, default 10)
+ *      so routine lanes (crank / provisioning / lp-vault) see an effective cap
+ *      of maxTxPerCycle - reserved, while critical lanes (liquidation / oracle /
+ *      adl) may use the full maxTxPerCycle.
+ *
+ * The reporter's PoC asserted the OLD (vulnerable) latch behavior. The
+ * assertions below are FLIPPED to the FIXED behavior.
+ */
+import { describe, it, expect } from "vitest";
+import { KeeperBudget } from "../../src/lib/budget.js";
+
+function makeClock(start = 1_700_000_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; } };
+}
+
+// Wide spend caps so ONLY the per-cycle tx-COUNT cap is exercised; that is the
+// lane the #333 DoS abused.
+const CONFIG = {
+  maxSolPerCycle: 1_000_000_000,
+  maxSolPerHour: 1_000_000_000,
+  maxSolPerDay: 1_000_000_000,
+  maxTxPerCycle: 60,
+  reservedCriticalTxPerCycle: 10, // routine "crank" lane effective cap = 50
+  cycleWindowMs: 30_000,
+  txSuccessRateWindow: 60_000,
+  txSuccessRateThreshold: 0.7,
+  txSuccessRateMinSamples: 1_000_000, // disable success-rate breaker for this PoC
+} as const;
+
+describe("#333 PoC — budget count-cap latch DoS is fixed", () => {
+  it("the over-cap crank returns false WITHOUT halting (soft backpressure)", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(CONFIG, { now: clock.now });
+
+    // Drive the routine "crank" lane up to its effective cap (50).
+    for (let i = 0; i < 50; i++) {
+      expect(b.canSpend(1, "crank")).toBe(true);
+      b.recordTx(1, "crank", "success");
+    }
+    // The 51st crank is refused — but as SOFT backpressure, NOT a latch.
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(false);
+    expect(b.haltKind).toBeUndefined();
+  });
+
+  it("after the window rolls (now += 31_000) crank is accepted again — no operator resume()", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(CONFIG, { now: clock.now });
+    for (let i = 0; i < 50; i++) b.recordTx(1, "crank", "success"); // saturate crank lane
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(false);
+
+    clock.advance(31_000); // window rolls → _cycleTxCount zeroed
+    expect(b.canSpend(1, "crank")).toBe(true); // auto-resumed without resume()
+    expect(b.isHalted()).toBe(false);
+  });
+
+  it("a liquidation is STILL accepted even when the non-critical (crank) lane is saturated", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(CONFIG, { now: clock.now });
+
+    // Attacker floods routine crank/provisioning volume to the crank cap.
+    for (let i = 0; i < 50; i++) b.recordTx(1, "crank", "success");
+    expect(b.canSpend(1, "crank")).toBe(false); // crank backpressured
+
+    // The reserved critical slots remain: liquidation uses the FULL cap of 60.
+    expect(b.canSpend(1, "liquidation")).toBe(true);
+    expect(b.canSpend(1, "oracle")).toBe(true);
+    expect(b.canSpend(1, "adl")).toBe(true);
+    expect(b.isHalted()).toBe(false);
+  });
+
+  it("a day-spend breach STILL latches (genuine anomalies are unchanged)", () => {
+    const clock = makeClock();
+    // Tight day cap; first big send breaches it → real overspend → latch.
+    const b = new KeeperBudget(
+      { ...CONFIG, maxSolPerDay: 1_000 },
+      { now: clock.now },
+    );
+    expect(b.canSpend(2_000, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(true);
+    expect(b.haltKind).toBe("day-spend-cap");
+
+    // And a day-cap latch is NOT cleared by a window roll — operator-only.
+    clock.advance(120_000);
+    expect(b.isHalted()).toBe(true);
+    expect(b.canSpend(1, "liquidation")).toBe(false); // even critical lanes are halted
+    b.resume("op");
+    expect(b.canSpend(1, "liquidation")).toBe(true);
+  });
+
+  it("reservation back-pressure path also honors the reserved critical capacity", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(CONFIG, { now: clock.now });
+    // Reserve (canSpend without recordTx) 50 in-flight crank slots.
+    for (let i = 0; i < 50; i++) expect(b.canSpend(1, "crank")).toBe(true);
+    // The 51st crank reservation is refused (50 reserved + 1 > effective cap 50).
+    expect(b.canSpend(1, "crank")).toBe(false);
+    expect(b.isHalted()).toBe(false);
+    // Liquidation can still reserve into the held-back slots (full cap 60).
+    expect(b.canSpend(1, "liquidation")).toBe(true);
+  });
+});

--- a/tests/poc/issue-334-unbounded-scan.poc.test.ts
+++ b/tests/poc/issue-334-unbounded-scan.poc.test.ts
@@ -1,0 +1,113 @@
+/**
+ * PoC for Finding #334 [HIGH] — unbounded v17 portfolio enumeration.
+ *
+ * ROOT CAUSE (pre-fix): scanV17Portfolios() did getProgramAccounts with no
+ * cap/pagination, parsed EVERY 9,347-byte portfolio, and processed candidates
+ * serially. An attacker who creates many portfolios makes one market's scan run
+ * unbounded, stalling all markets → health flaps → restart loop.
+ *
+ * FIX (#334):
+ *   1. Cap portfolios PARSED per market per cycle (MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE)
+ *      with a PERSISTENT per-market rotating cursor so every portfolio is
+ *      eventually scanned across cycles (fairness — none permanently skipped).
+ *   2. Cap candidates per market (MAX_CANDIDATES_PER_MARKET) AND globally per
+ *      cycle (MAX_CANDIDATES_PER_GLOBAL_CYCLE), prioritized by largest deficit.
+ *
+ * This is the deterministic MODEL test of the bounding + rotation, plus a
+ * coverage test proving the cursor eventually covers all portfolios.
+ */
+import { describe, it, expect } from "vitest";
+
+// Mirror the production constants (kept in sync with src/services/liquidation.ts).
+const MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE = 512;
+const MAX_CANDIDATES_PER_MARKET = 64;
+const MAX_CANDIDATES_PER_GLOBAL_CYCLE = 256;
+
+/**
+ * Deterministic model of the per-market rotating-window selection used in
+ * scanV17Portfolios (#334). Given the total count and the current cursor,
+ * returns the indices processed this cycle and the next cursor value.
+ */
+function rotatingWindow(total: number, cursor: number): { indices: number[]; nextCursor: number } {
+  if (total <= MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE) {
+    return { indices: Array.from({ length: total }, (_, i) => i), nextCursor: 0 };
+  }
+  const start = ((cursor % total) + total) % total;
+  const indices: number[] = [];
+  for (let k = 0; k < MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE; k++) {
+    indices.push((start + k) % total);
+  }
+  return { indices, nextCursor: (start + MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE) % total };
+}
+
+describe("#334 PoC — bounded v17 portfolio enumeration", () => {
+  it("processes at most MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE per cycle when flooded", () => {
+    const total = 50_000; // attacker-created flood
+    const { indices } = rotatingWindow(total, 0);
+    expect(indices.length).toBe(MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE);
+    expect(indices.length).toBeLessThan(total); // unbounded scan is bounded
+  });
+
+  it("a small market (<= cap) is fully covered in one cycle and resets the cursor", () => {
+    const total = 100;
+    const { indices, nextCursor } = rotatingWindow(total, 0);
+    expect(indices.length).toBe(100);
+    expect(new Set(indices).size).toBe(100); // every portfolio
+    expect(nextCursor).toBe(0);
+  });
+
+  it("the cursor ADVANCES and eventually covers ALL portfolios across cycles (fairness)", () => {
+    // 50_000 portfolios, cap 512 → needs ceil(50000/512)=98 cycles to cover all.
+    const total = 50_000;
+    const seen = new Set<number>();
+    let cursor = 0;
+    const maxCycles = Math.ceil(total / MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE) + 2; // small headroom
+    for (let cycle = 0; cycle < maxCycles; cycle++) {
+      const { indices, nextCursor } = rotatingWindow(total, cursor);
+      indices.forEach((i) => seen.add(i));
+      cursor = nextCursor;
+      if (seen.size === total) break;
+    }
+    // Every portfolio is eventually scanned — none is permanently skipped.
+    expect(seen.size).toBe(total);
+  });
+
+  it("the cursor wraps around the end of the portfolio set", () => {
+    const total = 1_000; // cap 512
+    // Start near the end so the window must wrap.
+    const { indices, nextCursor } = rotatingWindow(total, 800);
+    expect(indices.length).toBe(512);
+    // Window is [800..999, 0..311] → contains both high and low indices.
+    expect(indices).toContain(999);
+    expect(indices).toContain(0);
+    expect(indices).toContain(311);
+    expect(indices).not.toContain(312); // 800 + 512 = 1312 % 1000 = 312 is the NEXT start
+    expect(nextCursor).toBe(312);
+  });
+
+  it("caps candidates per market, keeping the LARGEST-deficit candidates", () => {
+    // Model: more qualifying candidates than the per-market cap; keep top-deficit.
+    const qualifying = Array.from({ length: 200 }, (_, i) => ({ id: i, deficit: BigInt(i) }));
+    const sorted = [...qualifying].sort((a, b) => (b.deficit > a.deficit ? 1 : b.deficit < a.deficit ? -1 : 0));
+    const kept = sorted.slice(0, MAX_CANDIDATES_PER_MARKET);
+    expect(kept.length).toBe(MAX_CANDIDATES_PER_MARKET);
+    // The single largest deficit (id 199) is kept; the smallest (id 0) is dropped.
+    expect(kept.some((c) => c.id === 199)).toBe(true);
+    expect(kept.some((c) => c.id === 0)).toBe(false);
+  });
+
+  it("caps total candidates GLOBALLY per cycle across many markets", () => {
+    // 100 markets each surfacing 64 candidates = 6_400 > global cap → bounded.
+    const perMarket = 64;
+    const markets = 100;
+    let processed = 0;
+    outer: for (let m = 0; m < markets; m++) {
+      for (let c = 0; c < perMarket; c++) {
+        if (processed >= MAX_CANDIDATES_PER_GLOBAL_CYCLE) break outer;
+        processed++;
+      }
+    }
+    expect(processed).toBe(MAX_CANDIDATES_PER_GLOBAL_CYCLE);
+    expect(processed).toBeLessThan(markets * perMarket); // genuinely bounded
+  });
+});

--- a/tests/poc/issue-335-health-divergence.poc.test.ts
+++ b/tests/poc/issue-335-health-divergence.poc.test.ts
@@ -1,0 +1,184 @@
+/**
+ * PoC for Finding #335 [HIGH] — liquidation health divergence RESIDUAL.
+ *
+ * #330/#331 already added aggregate maintenance, per-asset effective_price, and
+ * minNonzeroMmReq to scanV17Portfolios. The RESIDUAL items fixed here:
+ *   1. Pre-submit recheck shares the SAME aggregate-maintenance evaluator as the
+ *      scan (no per-leg vs aggregate divergence) — both now call
+ *      evaluateV17PortfolioHealth().
+ *   2. Positive-PnL conservatism: equity = capital + min(pnl, 0n) - feeDebt. The
+ *      engine haircuts positive PnL to realizable source support
+ *      (account_haircut_equity, percolator src/v16.rs:8451; positive PnL with no
+ *      source claims contributes ZERO), which the keeper cannot reproduce
+ *      off-chain — so it counts positive PnL at 0 (safe: only flags MORE).
+ *   3. Target/effective-price lag penalty ADDED to per-leg maintenance
+ *      (src/v16.rs:1207). long: effective>raw_target; short: raw_target>effective.
+ *   4. Conservative "unknown": a missing required input flags for verification
+ *      (treats as candidate), never returns "healthy".
+ *
+ * This drives the REAL exported evaluateV17PortfolioHealth() with byte-accurate
+ * market buffers, asserting every divergence case flags liquidatable.
+ */
+import { describe, it, expect } from "vitest";
+import { evaluateV17PortfolioHealth } from "../../src/services/liquidation.js";
+
+// Per-asset slot byte offsets (must match src/lib/v17-risk.ts).
+const V17_MARKET_GROUP_OFF = 448;
+const V17_MARKET_GROUP_LEN = 758;
+const V17_ASSET_ORACLE_WRAPPER_LEN = 512;
+const V17_ASSET_SLOT_STRIDE = 1797;
+const V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT = 25;
+const V17_RAW_ORACLE_TARGET_PRICE_OFF_IN_ASSET_SLOT = 17;
+
+function slotBase(assetIndex: number): number {
+  return V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_LEN
+    + assetIndex * V17_ASSET_SLOT_STRIDE
+    + V17_ASSET_ORACLE_WRAPPER_LEN;
+}
+
+/**
+ * Build a market-data buffer with per-asset effective_price and (optionally)
+ * raw_oracle_target_price written at the correct offsets.
+ */
+function buildMarketData(
+  assets: Array<{ assetIndex: number; effectivePrice: bigint; rawTargetPrice?: bigint }>,
+): Uint8Array {
+  let maxOff = 0;
+  for (const a of assets) {
+    maxOff = Math.max(maxOff, slotBase(a.assetIndex) + V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT + 8);
+  }
+  const buf = new Uint8Array(maxOff);
+  const dv = new DataView(buf.buffer);
+  for (const a of assets) {
+    const base = slotBase(a.assetIndex);
+    dv.setBigUint64(base + V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT, a.effectivePrice, true);
+    if (a.rawTargetPrice !== undefined) {
+      dv.setBigUint64(base + V17_RAW_ORACLE_TARGET_PRICE_OFF_IN_ASSET_SLOT, a.rawTargetPrice, true);
+    }
+  }
+  return buf;
+}
+
+// Minimal PortfolioV17-shaped object (only fields the evaluator reads).
+function mkPf(opts: {
+  capital: bigint;
+  pnl: bigint;
+  feeCredits?: bigint;
+  legs: Array<{ active: boolean; basisPosQ: bigint; assetIndex: number }>;
+}): any {
+  return {
+    capital: opts.capital,
+    pnl: opts.pnl,
+    feeCredits: opts.feeCredits ?? 0n,
+    legs: opts.legs.map((l) => ({ ...l, side: l.basisPosQ < 0n ? 1 : 0 })),
+  };
+}
+
+const RISK = { maintenanceMarginBps: 500n, minNonzeroMmReq: 0n }; // 5%
+
+describe("#335 PoC — shared aggregate-maintenance health evaluator", () => {
+  it("AGGREGATE: two legs each individually fine, aggregate insolvent → liquidatable", () => {
+    // Each leg: absPos 10_000, price $1 → notional 10_000, maintenance 500.
+    // Two legs → aggregate maintenance 1_000. Equity 900: above each leg (500),
+    // below the aggregate (1_000). The OLD per-leg check missed this; the shared
+    // evaluator catches it in BOTH scan and pre-submit recheck.
+    const md = buildMarketData([
+      { assetIndex: 0, effectivePrice: 1_000_000n },
+      { assetIndex: 1, effectivePrice: 1_000_000n },
+    ]);
+    const pf = mkPf({
+      capital: 900n,
+      pnl: 0n,
+      legs: [
+        { active: true, basisPosQ: 10_000n, assetIndex: 0 },
+        { active: true, basisPosQ: 10_000n, assetIndex: 1 },
+      ],
+    });
+    const h = evaluateV17PortfolioHealth(pf, md, RISK, 1_000_000n);
+    expect(h.liquidatable).toBe(true);
+    expect(h.deficit).toBe(100n); // 1_000 - 900
+    expect(h.closeQ).toBe(10_000n);
+  });
+
+  it("FLOOR: minNonzeroMmReq clamps tiny-position maintenance up → liquidatable", () => {
+    // Dust position: raw maintenance ~0, but minNonzeroMmReq floor = 1_000.
+    const md = buildMarketData([{ assetIndex: 0, effectivePrice: 1_000_000n }]);
+    const pf = mkPf({ capital: 500n, pnl: 0n, legs: [{ active: true, basisPosQ: 1n, assetIndex: 0 }] });
+    const h = evaluateV17PortfolioHealth(pf, md, { maintenanceMarginBps: 500n, minNonzeroMmReq: 1_000n }, 1_000_000n);
+    expect(h.liquidatable).toBe(true); // 500 < 1_000 floor
+  });
+
+  it("LAG PENALTY: long with effective > raw_target adds penalty → liquidatable", () => {
+    // absPos 10_000, effective $1.00, raw_target $0.90 (adverse for a long).
+    // base notional = 10_000, base maintenance = 500.
+    // adverse_delta = 1_000_000 - 900_000 = 100_000.
+    // lag penalty = ceil(10_000 * 100_000 / 1_000_000) = ceil(1_000_000_000/1e6) = 1_000.
+    // leg maintenance = 500 + 1_000 = 1_500. Equity 900 < 1_500 → liquidatable.
+    // WITHOUT the penalty (base 500), equity 900 would have looked HEALTHY.
+    const md = buildMarketData([
+      { assetIndex: 0, effectivePrice: 1_000_000n, rawTargetPrice: 900_000n },
+    ]);
+    const pf = mkPf({ capital: 900n, pnl: 0n, legs: [{ active: true, basisPosQ: 10_000n, assetIndex: 0 }] });
+    const h = evaluateV17PortfolioHealth(pf, md, RISK, 1_000_000n);
+    expect(h.liquidatable).toBe(true);
+
+    // Control: with raw_target == effective (no lag), equity 900 > base 500 → healthy.
+    const mdNoLag = buildMarketData([
+      { assetIndex: 0, effectivePrice: 1_000_000n, rawTargetPrice: 1_000_000n },
+    ]);
+    const hNoLag = evaluateV17PortfolioHealth(pf, mdNoLag, RISK, 1_000_000n);
+    expect(hNoLag.liquidatable).toBe(false);
+  });
+
+  it("LAG PENALTY: short with raw_target > effective adds penalty → liquidatable", () => {
+    // Short leg (negative basisPosQ). adverse when raw_target > effective.
+    const md = buildMarketData([
+      { assetIndex: 0, effectivePrice: 900_000n, rawTargetPrice: 1_000_000n },
+    ]);
+    const pf = mkPf({ capital: 900n, pnl: 0n, legs: [{ active: true, basisPosQ: -10_000n, assetIndex: 0 }] });
+    const h = evaluateV17PortfolioHealth(pf, md, RISK, 900_000n);
+    expect(h.liquidatable).toBe(true);
+  });
+
+  it("POSITIVE-PnL HAIRCUT: face-value pnl would look healthy; conservative pnl=0 flags it", () => {
+    // capital 100, positive pnl 1_000, no fee debt. Position needs maintenance 500.
+    // Face-value equity = 100 + 1_000 = 1_100 > 500 → would look HEALTHY (false neg).
+    // Conservative equity = 100 + min(1_000,0) = 100 < 500 → liquidatable (safe).
+    const md = buildMarketData([{ assetIndex: 0, effectivePrice: 1_000_000n }]);
+    const pf = mkPf({ capital: 100n, pnl: 1_000n, legs: [{ active: true, basisPosQ: 10_000n, assetIndex: 0 }] });
+    const h = evaluateV17PortfolioHealth(pf, md, RISK, 1_000_000n);
+    expect(h.liquidatable).toBe(true);
+  });
+
+  it("NEGATIVE-PnL is still fully counted", () => {
+    // capital 600, pnl -200 → equity 400 < maintenance 500 → liquidatable.
+    const md = buildMarketData([{ assetIndex: 0, effectivePrice: 1_000_000n }]);
+    const pf = mkPf({ capital: 600n, pnl: -200n, legs: [{ active: true, basisPosQ: 10_000n, assetIndex: 0 }] });
+    const h = evaluateV17PortfolioHealth(pf, md, RISK, 1_000_000n);
+    expect(h.liquidatable).toBe(true);
+  });
+
+  it("WRONG/MISSING PRICE: an active leg with no resolvable price is flagged (conservative-unknown)", () => {
+    // marketData too short to hold the asset slot AND fallbackPrice 0 → legPrice 0n.
+    // Must NOT return healthy: flag for verification (candidate).
+    const md = new Uint8Array(10); // too short
+    const pf = mkPf({ capital: 1_000_000n, pnl: 0n, legs: [{ active: true, basisPosQ: 10_000n, assetIndex: 0 }] });
+    const h = evaluateV17PortfolioHealth(pf, md, RISK, 0n);
+    expect(h.liquidatable).toBe(true);
+    expect(h.closeQ).toBe(10_000n);
+  });
+
+  it("HEALTHY: well-collateralized portfolio is NOT liquidatable (no false positives)", () => {
+    const md = buildMarketData([{ assetIndex: 0, effectivePrice: 1_000_000n, rawTargetPrice: 1_000_000n }]);
+    const pf = mkPf({ capital: 1_000_000n, pnl: 0n, legs: [{ active: true, basisPosQ: 10_000n, assetIndex: 0 }] });
+    const h = evaluateV17PortfolioHealth(pf, md, RISK, 1_000_000n);
+    expect(h.liquidatable).toBe(false);
+  });
+
+  it("equity<=0n is unconditionally liquidatable (H-8 defense-in-depth)", () => {
+    const md = buildMarketData([{ assetIndex: 0, effectivePrice: 1_000_000n }]);
+    const pf = mkPf({ capital: 0n, pnl: 0n, feeCredits: -100n, legs: [{ active: true, basisPosQ: 10_000n, assetIndex: 0 }] });
+    const h = evaluateV17PortfolioHealth(pf, md, RISK, 1_000_000n);
+    expect(h.liquidatable).toBe(true);
+  });
+});

--- a/tests/poc/issue-336-fraud-amplification.poc.test.ts
+++ b/tests/poc/issue-336-fraud-amplification.poc.test.ts
@@ -1,0 +1,185 @@
+/**
+ * PoC for Finding #336 [MEDIUM] — fraud-detector amplification.
+ *
+ * ROOT CAUSE (pre-fix): the fraud cycle iterated EVERY discovered market every
+ * 30s, awaiting 2 external HTTP calls per market; setInterval with no in-flight
+ * guard allowed overlapping cycles; per-mint (not global) alert cooldown;
+ * unbounded maps; classified HYPERP off a zero indexFeedId.
+ *
+ * FIX (#336): single-flight guard (recursive setTimeout + _inFlight),
+ * per-cycle market cap with round-robin cursor, skip !isActive, dedupe by
+ * priceMint, negative caching, global per-cycle alert budget, bounded maps.
+ *
+ * The reporter's PoC asserted the OLD (amplifying) behavior. The assertions
+ * below are FLIPPED to the FIXED behavior.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const h = vi.hoisted(() => ({ sendWarningAlert: vi.fn(() => Promise.resolve()) }));
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  sendWarningAlert: h.sendWarningAlert,
+}));
+
+import { FraudDetectorService } from "../../src/services/fraud-detector.js";
+
+function zeroFeed(): { toBytes: () => Uint8Array } {
+  return { toBytes: () => new Uint8Array(32) }; // all-zero → HYPERP
+}
+
+/**
+ * Build a HYPERP market state with a unique collateral mint so each market is a
+ * distinct priceMint (worst case for the amplification the fix bounds).
+ */
+function makeMarket(idx: number, configMark = 100_000_000n) {
+  const mint = `Mint${idx.toString().padStart(36 - 4, "0")}`.slice(0, 44);
+  return {
+    market: {
+      config: {
+        indexFeedId: zeroFeed(),
+        oracleAuthority: zeroFeed(),
+        collateralMint: { toBase58: () => mint },
+        authorityPriceE6: configMark,
+      },
+      engine: { markPriceE6: 0n },
+    },
+    isActive: true,
+    mainnetCA: undefined,
+  };
+}
+
+function makeMarkets(n: number): Map<string, any> {
+  const m = new Map<string, any>();
+  for (let i = 0; i < n; i++) m.set(`Slab${i.toString().padStart(40, "0")}`.slice(0, 44), makeMarket(i));
+  return m;
+}
+
+describe("#336 PoC — fraud-detector amplification is bounded", () => {
+  let oracle: { fetchPrice: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    oracle = { fetchPrice: vi.fn() };
+    // Reasonable test bounds via env (well under production defaults).
+    process.env.FRAUD_DETECT_MAX_MARKETS_PER_CYCLE = "50";
+    process.env.FRAUD_DETECT_MAX_ALERTS_PER_CYCLE = "10";
+    process.env.FRAUD_DETECT_PER_MINT_COOLDOWN_MS = "1800000";
+    delete process.env.FRAUD_DETECT_NEGATIVE_CACHE_TTL_MS; // use default
+  });
+
+  afterEach(() => {
+    delete process.env.FRAUD_DETECT_MAX_MARKETS_PER_CYCLE;
+    delete process.env.FRAUD_DETECT_MAX_ALERTS_PER_CYCLE;
+    delete process.env.FRAUD_DETECT_PER_MINT_COOLDOWN_MS;
+  });
+
+  it("per-cycle MARKET cap is respected: at most N markets fetched per cycle (attacker flood)", async () => {
+    // 1_000 attacker markets, cap 50 → only 50 fetches this cycle (not 1_000).
+    const markets = makeMarkets(1_000);
+    oracle.fetchPrice.mockResolvedValue({ priceE6: 50_000_000n }); // 100% divergence
+    const svc = new FraudDetectorService(oracle as any, () => markets);
+
+    await svc._runCheck();
+
+    expect(oracle.fetchPrice.mock.calls.length).toBeLessThanOrEqual(50);
+    expect(oracle.fetchPrice.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("the round-robin cursor advances so every market is eventually covered", async () => {
+    const markets = makeMarkets(120); // cap 50 → 3 cycles cover all 120
+    oracle.fetchPrice.mockResolvedValue({ priceE6: 100_000_000n }); // no divergence (avoid alert budget)
+    const svc = new FraudDetectorService(oracle as any, () => markets);
+
+    const seen = new Set<string>();
+    for (let cycle = 0; cycle < 3; cycle++) {
+      oracle.fetchPrice.mockClear();
+      await svc._runCheck();
+      for (const call of oracle.fetchPrice.mock.calls) seen.add(call[0] as string);
+    }
+    // All 120 unique priceMints scanned across the 3 cycles.
+    expect(seen.size).toBe(120);
+  });
+
+  it("a second CONCURRENT cycle is skipped by the single-flight guard", async () => {
+    const markets = makeMarkets(3);
+    let resolveFirst: (v: any) => void;
+    let firstHung = false;
+    // Hang ONLY the first fetch so the second _runCheck() lands mid-cycle;
+    // resolve every later fetch immediately so the first cycle can complete.
+    oracle.fetchPrice.mockImplementation(() => {
+      if (!firstHung) {
+        firstHung = true;
+        return new Promise((res) => { resolveFirst = res; });
+      }
+      return Promise.resolve({ priceE6: 100_000_000n });
+    });
+    const svc = new FraudDetectorService(oracle as any, () => markets);
+
+    // async fns run synchronously up to their first await, so by the time
+    // _runCheck() returns the first fetchPrice() is already pending.
+    const first = svc._runCheck();
+    const callsAfterFirstStarted = oracle.fetchPrice.mock.calls.length;
+    expect(callsAfterFirstStarted).toBe(1); // exactly one fetch in flight
+
+    const second = svc._runCheck();   // re-entrant → skipped by single-flight
+    await second;
+
+    // The second call did NOT start a new round of fetches.
+    expect(oracle.fetchPrice.mock.calls.length).toBe(callsAfterFirstStarted);
+
+    resolveFirst!({ priceE6: 100_000_000n });
+    await first; // first cycle finishes its remaining markets
+  });
+
+  it("global per-cycle ALERT budget bounds alerts even with many diverging mints", async () => {
+    // 100 distinct mints all diverging; cap markets/cycle 50, alert budget 10.
+    const markets = makeMarkets(100);
+    oracle.fetchPrice.mockResolvedValue({ priceE6: 50_000_000n }); // 100% divergence on every mint
+    const svc = new FraudDetectorService(oracle as any, () => markets);
+
+    await svc._runCheck();
+
+    // At most 10 alerts this cycle despite 50 diverging markets being scanned.
+    expect(h.sendWarningAlert.mock.calls.length).toBeLessThanOrEqual(10);
+    expect(h.sendWarningAlert.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("negative cache: an unavailable mint is not re-fetched on the next cycle", async () => {
+    const markets = makeMarkets(1); // single mint
+    oracle.fetchPrice.mockResolvedValue(null); // off-chain unavailable
+    const svc = new FraudDetectorService(oracle as any, () => markets);
+
+    await svc._runCheck();
+    const callsAfterCycle1 = oracle.fetchPrice.mock.calls.length;
+    expect(callsAfterCycle1).toBe(1);
+
+    // Next cycle within the TTL: the mint is negative-cached → no re-fetch.
+    await svc._runCheck();
+    expect(oracle.fetchPrice.mock.calls.length).toBe(callsAfterCycle1); // unchanged
+  });
+
+  it("inactive markets are skipped (no HTTP fan-out)", async () => {
+    const markets = makeMarkets(5);
+    for (const [, st] of markets) st.isActive = false;
+    oracle.fetchPrice.mockResolvedValue({ priceE6: 50_000_000n });
+    const svc = new FraudDetectorService(oracle as any, () => markets);
+
+    await svc._runCheck();
+    expect(oracle.fetchPrice).not.toHaveBeenCalled();
+  });
+
+  it("dedupe by priceMint: N markets sharing one mint cost ONE fetch", async () => {
+    // 5 markets all with the same collateral mint (same priceMint).
+    const markets = new Map<string, any>();
+    for (let i = 0; i < 5; i++) {
+      const st = makeMarket(0); // identical mint
+      markets.set(`Slab${i.toString().padStart(40, "0")}`.slice(0, 44), st);
+    }
+    oracle.fetchPrice.mockResolvedValue({ priceE6: 100_000_000n });
+    const svc = new FraudDetectorService(oracle as any, () => markets);
+
+    await svc._runCheck();
+    expect(oracle.fetchPrice).toHaveBeenCalledTimes(1); // one fetch, not 5
+  });
+});

--- a/tests/services/fraud-detector-mark.poc.test.ts
+++ b/tests/services/fraud-detector-mark.poc.test.ts
@@ -44,6 +44,8 @@ function makeState(o: MarketOpts) {
       },
       engine: { markPriceE6: o.engineMark },
     },
+    // #336: the detector skips !isActive markets; these PoC markets are active.
+    isActive: true,
     mainnetCA: undefined,
   };
 }

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -151,6 +151,12 @@ vi.mock('../../src/lib/v17-risk.js', async () => {
     // Fix #331: readEffectivePriceForAsset is used in scanV17Portfolios.
     // Return 0n (falls back to the market-level price, matching pre-fix behavior in tests).
     readEffectivePriceForAsset: vi.fn(() => 0n),
+    // #335: raw_oracle_target_price + lag penalty are read by evaluateV17PortfolioHealth.
+    // Return 0n target → real targetEffectiveLagPenalty yields 0 (no penalty), which is
+    // the behavior these legacy tests assume. Use the REAL penalty fn so its logic is
+    // exercised wherever a non-zero target is supplied.
+    readRawOracleTargetPriceForAsset: vi.fn(() => 0n),
+    targetEffectiveLagPenalty: actual.targetEffectiveLagPenalty,
   };
 });
 


### PR DESCRIPTION
Four verified findings by @tobyemerald (against `562b867`), each checked against the engine by hand before merge — not just the report.

- **#333 [HIGH]** global-budget latch DoS — hitting `maxTxPerCycle` now returns soft backpressure (auto-clears on the 30s window roll) instead of a manual-resume-only `_halt`; safety-critical lanes (`liquidation`/`oracle`/`adl`) keep a reserved slice (`reservedCriticalTxPerCycle=10`) so a routine/provisioning flood can't starve liquidations. Genuine anomalies (spend caps, non-finite cost, success-rate, operator) still latch. **Resolves the tension introduced by #332** (rent now counts toward the budget): attacker volume → temporary deferral, not a permanent cross-market outage.
- **#334 [HIGH]** unbounded v17 portfolio enumeration — `scanV17Portfolios` now bounds work to `MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE=512` via a **persistent rotating cursor** (pubkey-sorted, wraps `(start+512)%total`) so every portfolio is still eventually scanned; per-market (64) + global (256) candidate caps; drops are logged (no silent truncation).
- **#335 [HIGH]** liquidation-health divergence (residual after #330/#331) — the per-leg margin-ratio recheck is replaced by a shared `evaluateV17PortfolioHealth()` used by **both** the scan and the pre-submit recheck. It now matches the engine: conservative equity `capital + min(pnl,0) − feeDebt` (positive-PnL haircut, `v16.rs:8451`/`:7199`), aggregate maintenance, and the **target/effective-price lag penalty** `ceil(absPos·adverse_delta/1e6)` added per leg (`v16.rs:1157-1207`, `raw_oracle_target_price` @ asset-slot offset 17 — anchored to `AssetStateV16Account` field order). Missing inputs flag as candidate ("unknown→verify"), never "healthy" → no false negatives.
- **#336 [MED]** fraud-detector amplification — single-flight guard (recursive `setTimeout`), per-cycle market cap + round-robin cursor, skip `!isActive`, dedupe by `priceMint`, negative cache, global alert budget, and bounded per-mint maps.

**Verification:** the engine lag formula, the positive-PnL haircut direction, and the asset-slot offsets (17/25, `V16PodU64` align-1, no padding) were re-derived from `percolator/src/v16.rs` by hand. `pnpm build` clean; **958 tests pass / 0 fail** (+30 new PoC tests adapted from the reports, flipped to assert the fixed behavior). Keeper is cutover-gated — NOT deployed.

Closes #333, closes #334, closes #335, closes #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)