### PR TITLE
fix(keeper): accept maintenanceMarginBps==10000 (valid fast-path) — found in live devnet test

### DIFF
--- a/src/lib/v17-risk.ts
+++ b/src/lib/v17-risk.ts
@@ -198,7 +198,7 @@ export function parseV17RiskParams(data: Uint8Array): {
     data,
     V17_ENGINE_CONFIG_OFF + V17_ENGINE_CONFIG_MAINTENANCE_MARGIN_BPS_OFF,
   );
-  if (maintenanceMarginBps <= 0n || maintenanceMarginBps >= 10_000n) {
+  if (maintenanceMarginBps <= 0n || maintenanceMarginBps > 10_000n) {
     throw new V17RiskParamsCorruptedError("maintenanceMarginBps", maintenanceMarginBps);
   }
 


### PR DESCRIPTION
Live devnet functional test: an InitMarket'd v17 market (MM=10000 bps, engine fast-path) was silently skipped by discoverV17Markets because v17-risk.ts rejected `>= 10_000n`. 10000 bps is accepted by the wrapper, so the keeper must accept it; changed to `> 10_000n`. Keeper does not auto-deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted validation for risk settings so the maximum maintenance margin value is now accepted at the upper limit.
  * Inputs at exactly the allowed boundary are no longer incorrectly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->