### PR TITLE
fix: abort v17 pre-submit recheck on RPC error instead of proceeding with stale data

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -1241,9 +1241,18 @@ export class LiquidationService {
               instructions[0] = buildIx({ programId, keys: crankKeys, data: updatedCrankData });
             }
           }
-        } catch {
-          // If we can't re-verify, proceed cautiously — the on-chain program
-          // will reject if the portfolio is already closed.
+        } catch (recheckErr) {
+          // Cannot re-verify portfolio state — abort rather than submitting with
+          // scan-time data. The oracle drift guard (lines 1171-1187) lives inside
+          // this try block; proceeding past a thrown error would bypass it and
+          // allow a stale-price liquidation if the oracle moved >MAX_LIQUIDATION_DRIFT_BPS
+          // between scan and submit. Fail closed: position is re-scanned next cycle.
+          logger.warn("v17 liquidate: pre-submit recheck threw — aborting to avoid stale submission", {
+            portfolio: v17PortfolioPubkey.toBase58().slice(0, 8),
+            slabAddress: slabAddress.toBase58().slice(0, 8),
+            error: recheckErr instanceof Error ? recheckErr.message : String(recheckErr),
+          });
+          return null;
         }
       } else {
       // Bug 3: Re-read slab data and verify account before submitting (v12.x path)


### PR DESCRIPTION
Closes #352

## What

Replace the bare `catch {}` at `liquidation.ts:1244` with a named catch that logs a warning and returns `null`.

## Why

The bare catch silently swallows RPC errors thrown during the pre-submit portfolio recheck. The oracle drift guard (lines 1171-1187) lives inside that try block. When the catch fires and execution falls through, the drift guard is bypassed and the keeper submits the liquidation using scan-time `closeQ` and `scanPriceE6`, regardless of how much the oracle has moved since scan.

The on-chain program may still reject if the position is already closed, but it cannot enforce the keeper-side drift budget. Returning `null` puts the position back in the scan queue for the next cycle so the drift guard runs on fresh data.

## Change

```ts
// before
} catch {
  // ...proceed cautiously
}

// after
} catch (recheckErr) {
  logger.warn("v17 liquidate: pre-submit recheck threw -- aborting to avoid stale submission", {
    portfolio: v17PortfolioPubkey.toBase58().slice(0, 8),
    slabAddress: slabAddress.toBase58().slice(0, 8),
    error: recheckErr instanceof Error ? recheckErr.message : String(recheckErr),
  });
  return null;
}
```