### PR TITLE
fix(keeper): consolidate CRANK_KEYPAIR loading into a single parse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import "dotenv/config";
 import http from "node:http";
 import { timingSafeEqual } from "node:crypto";
-import { config, createLogger, initSentry, captureException, sendInfoAlert, sendCriticalAlert, sendWarningAlert, createServiceMonitors, getConnection, loadKeypair } from "@percolatorct/shared";
+import { config, createLogger, initSentry, captureException, sendInfoAlert, sendCriticalAlert, sendWarningAlert, createServiceMonitors, getConnection } from "@percolatorct/shared";
+import { getKeeperKeypair } from "./lib/keypair-singleton.js";
 import { OracleService } from "./services/oracle.js";
 import { CrankService } from "./services/crank.js";
 import { LiquidationService } from "./services/liquidation.js";
@@ -74,7 +75,7 @@ validateKeeperEnvGuards();
 // scope means a malformed keypair fails at boot (clean supervisor restart)
 // instead of producing a "keeper appears healthy but can't sign anything"
 // degraded state.
-const keeperKeypair = loadKeypair(process.env.CRANK_KEYPAIR!);
+const keeperKeypair = getKeeperKeypair();
 
 // If NETWORK=mainnet, the keeper runs against mainnet program (requires FORCE_MAINNET=1).
 // On mainnet, HYPERP markets (SOL-PERP, BTC-PERP, ETH-PERP) use the keeper as oracle authority

--- a/src/lib/keypair-singleton.ts
+++ b/src/lib/keypair-singleton.ts
@@ -1,0 +1,30 @@
+import { loadKeypair } from "@percolatorct/shared";
+import type { Keypair } from "@solana/web3.js";
+
+let _instance: Keypair | null = null;
+
+/**
+ * Return the keeper signing keypair, parsing CRANK_KEYPAIR exactly once.
+ *
+ * All three service-level consumers (index.ts, CrankService, LiquidationService)
+ * previously called loadKeypair() independently, producing three separate 64-byte
+ * secretKey Uint8Array allocations that persist for the process lifetime. Using a
+ * singleton reduces this to one live allocation and deletes the raw env-var string
+ * immediately after the first parse so it cannot be read by later code or appear
+ * in heap dumps and Railway log snapshots.
+ *
+ * Must be called AFTER validateKeeperEnvGuards() so boot-time validation still
+ * reads the env var before this function deletes it.
+ */
+export function getKeeperKeypair(): Keypair {
+  if (!_instance) {
+    const raw = process.env.CRANK_KEYPAIR;
+    if (!raw) throw new Error("CRANK_KEYPAIR is not set");
+    _instance = loadKeypair(raw);
+    // Overwrite then delete: narrows the window where the raw secret key string
+    // is readable via process.env (heap dumps, accidental logger.info(process.env)).
+    process.env.CRANK_KEYPAIR = "0".repeat(raw.length);
+    delete process.env.CRANK_KEYPAIR;
+  }
+  return _instance;
+}

--- a/src/lib/keypair-singleton.ts
+++ b/src/lib/keypair-singleton.ts
@@ -6,25 +6,31 @@ let _instance: Keypair | null = null;
 /**
  * Return the keeper signing keypair, parsing CRANK_KEYPAIR exactly once.
  *
- * All three service-level consumers (index.ts, CrankService, LiquidationService)
- * previously called loadKeypair() independently, producing three separate 64-byte
- * secretKey Uint8Array allocations that persist for the process lifetime. Using a
- * singleton reduces this to one live allocation and deletes the raw env-var string
- * immediately after the first parse so it cannot be read by later code or appear
- * in heap dumps and Railway log snapshots.
+ * index.ts, CrankService and LiquidationService each called loadKeypair()
+ * independently. Routing all three through here parses once and gives a single
+ * place to change how the signing key is sourced (env today, a KMS or remote
+ * signer later) without touching three call sites.
  *
- * Must be called AFTER validateKeeperEnvGuards() so boot-time validation still
- * reads the env var before this function deletes it.
+ * This deliberately does NOT scrub process.env. An earlier version overwrote
+ * the variable and then deleted it, on the theory that this kept the secret out
+ * of heap dumps. It does not — V8 strings are immutable, so assigning a new
+ * value allocates a new string and leaves the original in memory until GC. The
+ * deletion's only real effect was to break every consumer that reads the
+ * variable after the first call: vitest shares one worker process across test
+ * files, so the first service to resolve its keypair made every later service
+ * construction throw "CRANK_KEYPAIR is not set" (23 failing tests). Removing a
+ * secret from a process that must keep using it needs a different mechanism
+ * (a signer that never holds the key in this process at all), not env deletion.
+ *
+ * Presence and parseability are already enforced upstream and are not
+ * re-checked here: index.ts requires CRANK_KEYPAIR to be set before any service
+ * is constructed, and validateKeeperEnvGuards() rejects a malformed value at
+ * boot. Adding a redundant presence check here would only change WHERE a
+ * misconfiguration surfaces, and would break tests that mock loadKeypair.
  */
 export function getKeeperKeypair(): Keypair {
   if (!_instance) {
-    const raw = process.env.CRANK_KEYPAIR;
-    if (!raw) throw new Error("CRANK_KEYPAIR is not set");
-    _instance = loadKeypair(raw);
-    // Overwrite then delete: narrows the window where the raw secret key string
-    // is readable via process.env (heap dumps, accidental logger.info(process.env)).
-    process.env.CRANK_KEYPAIR = "0".repeat(raw.length);
-    delete process.env.CRANK_KEYPAIR;
+    _instance = loadKeypair(process.env.CRANK_KEYPAIR!);
   }
   return _instance;
 }

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -826,7 +826,12 @@ export class CrankService {
   private _inflightLpVaultMarkets = new Set<string>();
   private _stalePauseCheck?: (slabAddress: string) => boolean;
   // Use the process-wide keypair singleton — avoids a second secretKey allocation.
-  private get _keypair() { return getKeeperKeypair(); }
+  // Resolved eagerly at construction, not lazily via a getter: index.ts notes
+  // that loading at module scope means "a malformed keypair fails at boot
+  // (clean supervisor restart) instead of producing a 'keeper appears healthy
+  // but can't sign anything' degraded state". A getter would defer that failure
+  // to the first crank attempt and lose the property.
+  private readonly _keypair = getKeeperKeypair();
   // 6.2: Total crank cycles completed (exposed via getMetrics for health + MonitorService)
   private _totalCrankCycles = 0;
   // 6.2: Optional callback fired after each completed crank cycle

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -22,7 +22,8 @@ import {
   encodeLpVaultCrankFees,
   type DiscoveredMarket,
 } from "@percolatorct/sdk";
-import { config, getConnection, getFallbackConnection, loadKeypair, eventBus, createLogger, sendCriticalAlert, getSupabase } from "@percolatorct/shared";
+import { config, getConnection, getFallbackConnection, eventBus, createLogger, sendCriticalAlert, getSupabase } from "@percolatorct/shared";
+import { getKeeperKeypair } from "../lib/keypair-singleton.js";
 import { OracleService } from "./oracle.js";
 import { resolveExternalOracleAccount } from "../lib/oracle-account.js";
 import { recordAttempt, recordLanded, recordFailed } from "../lib/sender-metrics.js";
@@ -804,8 +805,8 @@ export class CrankService {
   /** Per-market in-flight guard for LP-vault maintenance — mirrors _inflightMarkets. */
   private _inflightLpVaultMarkets = new Set<string>();
   private _stalePauseCheck?: (slabAddress: string) => boolean;
-  // P1 FIX: Cache keypair at construction — was reading from disk on every crank cycle (every 30s)
-  private readonly _keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
+  // Use the process-wide keypair singleton — avoids a second secretKey allocation.
+  private get _keypair() { return getKeeperKeypair(); }
   // 6.2: Total crank cycles completed (exposed via getMetrics for health + MonitorService)
   private _totalCrankCycles = 0;
   // 6.2: Optional callback fired after each completed crank cycle

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -619,7 +619,10 @@ export class LiquidationService {
   private readonly _corruptedRiskParamsAlertedAt = new Map<string, number>();
   private static readonly RISK_PARAMS_ALERT_COOLDOWN_MS = 15 * 60_000; // 15 min
   // Use the process-wide keypair singleton — avoids a second secretKey allocation.
-  private get _keypair() { return getKeeperKeypair(); }
+  // Eager, not a lazy getter — see the matching note in crank.ts: deferring
+  // resolution would turn a boot-time misconfiguration into a first-liquidation
+  // failure, which is exactly the degraded state index.ts warns about.
+  private readonly _keypair = getKeeperKeypair();
   /** LaserStream account loader — injected for event-driven portfolio scanning. */
   private readonly _accountLoader?: AccountLoader;
   /** Per-account debounce timers: slab pubkey → setTimeout handle. */

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -16,7 +16,8 @@ import {
   parsePortfolioV17,
   type DiscoveredMarket,
 } from "@percolatorct/sdk";
-import { config, getConnection, loadKeypair, sendWithRetry, pollSignatureStatus, getRecentPriorityFees, checkTransactionSize, eventBus, createLogger, sendWarningAlert, sendCriticalAlert, acquireToken, getFallbackConnection, backoffMs, getErrorMessage } from "@percolatorct/shared";
+import { config, getConnection, sendWithRetry, pollSignatureStatus, getRecentPriorityFees, checkTransactionSize, eventBus, createLogger, sendWarningAlert, sendCriticalAlert, acquireToken, getFallbackConnection, backoffMs, getErrorMessage } from "@percolatorct/shared";
+import { getKeeperKeypair } from "../lib/keypair-singleton.js";
 import { OracleService } from "./oracle.js";
 import { resolveExternalOracleAccount } from "../lib/oracle-account.js";
 import { recordAttempt, recordLanded, recordFailed } from "../lib/sender-metrics.js";
@@ -616,8 +617,8 @@ export class LiquidationService {
   // (which collapses bursts within a few seconds, not a level held for hours).
   private readonly _corruptedRiskParamsAlertedAt = new Map<string, number>();
   private static readonly RISK_PARAMS_ALERT_COOLDOWN_MS = 15 * 60_000; // 15 min
-  // Cache keypair at construction — avoids re-parsing from env on every liquidate() call
-  private readonly _keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
+  // Use the process-wide keypair singleton — avoids a second secretKey allocation.
+  private get _keypair() { return getKeeperKeypair(); }
   /** LaserStream account loader — injected for event-driven portfolio scanning. */
   private readonly _accountLoader?: AccountLoader;
   /** Per-account debounce timers: slab pubkey → setTimeout handle. */

--- a/tests/lib/keypair-singleton.test.ts
+++ b/tests/lib/keypair-singleton.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * The singleton exists to parse CRANK_KEYPAIR once instead of three times
+ * (index.ts, CrankService, LiquidationService each called loadKeypair
+ * independently). It must do that WITHOUT mutating process.env.
+ *
+ * The original implementation overwrote and then deleted the variable, on the
+ * theory that this kept the secret out of heap dumps. It does not: V8 strings
+ * are immutable, so `process.env.X = "0".repeat(n)` allocates a new string and
+ * leaves the original untouched until GC. What the deletion did achieve was
+ * breaking every consumer that reads the variable after the first call —
+ * 23 tests across crank.test.ts, crank.b-fixes.test.ts and liquidation.test.ts
+ * failed with "CRANK_KEYPAIR is not set" because vitest shares one worker
+ * process across files.
+ */
+
+const hoisted = vi.hoisted(() => ({ parses: 0 }));
+
+vi.mock("@percolatorct/shared", () => ({
+  // A fresh object per call, so object identity proves the cache is real
+  // rather than proving the mock returns a constant.
+  loadKeypair: vi.fn((raw: string) => {
+    hoisted.parses += 1;
+    return { parsedFrom: raw, secretKey: new Uint8Array(64) };
+  }),
+}));
+
+const RAW = "[1,2,3,4]";
+const ORIGINAL = process.env.CRANK_KEYPAIR;
+
+async function freshModule() {
+  vi.resetModules();
+  hoisted.parses = 0;
+  return import("../../src/lib/keypair-singleton.js");
+}
+
+describe("getKeeperKeypair", () => {
+  beforeEach(() => {
+    process.env.CRANK_KEYPAIR = RAW;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.CRANK_KEYPAIR;
+    else process.env.CRANK_KEYPAIR = ORIGINAL;
+  });
+
+  it("parses CRANK_KEYPAIR once and returns that same instance thereafter", async () => {
+    const { getKeeperKeypair } = await freshModule();
+
+    const first = getKeeperKeypair();
+    const second = getKeeperKeypair();
+    const third = getKeeperKeypair();
+
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+    expect(hoisted.parses).toBe(1);
+  });
+
+  it("leaves process.env.CRANK_KEYPAIR readable after the first call", async () => {
+    const { getKeeperKeypair } = await freshModule();
+
+    getKeeperKeypair();
+
+    expect(process.env.CRANK_KEYPAIR).toBe(RAW);
+  });
+
+  it("still resolves for a consumer constructed after the first call", async () => {
+    // The regression this guards: services are constructed at different times,
+    // and CrankService/LiquidationService resolve the keypair after index.ts
+    // has already resolved it. Deleting the env var made the later ones throw.
+    const { getKeeperKeypair } = await freshModule();
+    getKeeperKeypair();
+
+    let later: unknown;
+    expect(() => {
+      later = getKeeperKeypair();
+    }).not.toThrow();
+    expect(later).toBeDefined();
+  });
+
+  it("passes the raw env value through to loadKeypair unmodified", async () => {
+    const { getKeeperKeypair } = await freshModule();
+
+    const kp = getKeeperKeypair() as unknown as { parsedFrom: string };
+
+    expect(kp.parsedFrom).toBe(RAW);
+  });
+});


### PR DESCRIPTION
Routes index.ts, CrankService and LiquidationService through one `getKeeperKeypair()` so `CRANK_KEYPAIR` is parsed once instead of three times, and gives a single place to change how the signing key is sourced (env today, a KMS or remote signer later).

**Scope corrected from the original version of this PR.** It previously also overwrote and deleted `process.env.CRANK_KEYPAIR` after the first parse, and was framed as a secret-hygiene fix. That has been removed:

- **The scrub could not work.** V8 strings are immutable, so `process.env.X = "0".repeat(n)` allocates a new string and leaves the original in memory until GC. The secret was no less present in a heap dump afterwards.
- **The deletion broke 23 tests** across `crank.test.ts`, `crank.b-fixes.test.ts` and `liquidation.test.ts` with `Error: CRANK_KEYPAIR is not set`. vitest shares one worker process across files, so the first service to resolve its keypair made every later construction throw. The same hazard applies in production to any service constructed after boot.

Genuinely removing the key from this process needs a signer that never holds it here, not env deletion — out of scope for this PR.

Also changed from the original: the keypair resolves via `private readonly _keypair = getKeeperKeypair()` rather than a lazy `get _keypair()`. `index.ts` notes that module-scope loading means "a malformed keypair fails at boot (clean supervisor restart) instead of producing a 'keeper appears healthy but can't sign anything' degraded state" — a getter would defer that failure to the first crank and lose it.

Adds `tests/lib/keypair-singleton.test.ts`: parse-once, env preservation, resolution after the first call, raw-value passthrough.

Full suite on this branch merged with `main`: **103 files, 1082 passed, 33 skipped**, clean `tsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keeper keypair initialization consistency across application services.
  * Prevented repeated keypair parsing during runtime.
  * Preserved the configured keeper keypair value for subsequent consumers.

* **Tests**
  * Added coverage verifying keypair reuse, environment preservation, and compatibility with later initialization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->