### PR TITLE
fix: validate mainnet_ca from Supabase against on-chain SPL Token mint ownership

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,19 @@ KEEPER_HEALTH_PORT=8081
 # RPC_URL=https://mainnet.helius-rpc.com/?api-key=YOUR_KEY
 # PROGRAM_ID=GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24
 
+# Mainnet endpoint used ONLY to verify `mainnet_ca` overrides (KEEPER-9).
+# `mainnet_ca` comes from Supabase and becomes the price-lookup key for a market
+# in the fraud detector, so a poisoned row can redirect that lookup at an
+# attacker-chosen token. This is a DEVNET-keeper setting: mainnet_ca exists for
+# devnet mirror-mint markets, and the mint it names lives on mainnet, so it
+# cannot be checked against the keeper's own RPC.
+# Unset (default): mainnet_ca is format-checked (base58, decodes to 32 bytes) but
+# NOT verified on-chain, and a warning is logged once per discovery cycle.
+# Set: each override must resolve to a real SPL Token / Token-2022 mint.
+# A read-only public endpoint is sufficient — this issues one batched
+# getMultipleAccountsInfo per discovery cycle.
+# MAINNET_RPC_URL=https://api.mainnet-beta.solana.com
+
 # Helius Sender (Phase 1 performance upgrade)
 # Default: USE_HELIUS_SENDER=true on mainnet (NETWORK=mainnet). Set false to opt out.
 # Requires RPC_URL to be a Helius mainnet endpoint with an api-key query param.

--- a/src/lib/mainnet-ca-validator.ts
+++ b/src/lib/mainnet-ca-validator.ts
@@ -1,0 +1,160 @@
+import { PublicKey } from "@solana/web3.js";
+import { createLogger } from "@percolatorct/shared";
+
+const logger = createLogger("keeper:mainnet-ca");
+
+/** Legacy SPL Token program. */
+export const SPL_TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+/** Token-2022. Markets collateralised by a Token-2022 mint are legitimate. */
+export const TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+
+/** Base58, 32–44 chars. Cheap pre-filter before touching the network. */
+const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+/** A bare mint is exactly 82 bytes under either token program. */
+const MINT_LEN = 82;
+/**
+ * Token-2022 extended accounts carry an AccountType discriminator at offset 165
+ * (the length of a legacy token account); 1 = Mint, 2 = Account. A plain length
+ * check cannot separate an extended mint from an extended token account, and
+ * both are owned by the same program.
+ */
+const ACCOUNT_TYPE_OFFSET = 165;
+const ACCOUNT_TYPE_MINT = 1;
+
+/** getMultipleAccountsInfo accepts at most 100 pubkeys per call. */
+const MAX_KEYS_PER_CALL = 100;
+
+export interface MainnetCaRow {
+  slab_address: string;
+  mainnet_ca?: string | null;
+}
+
+/**
+ * The slice of Connection this needs. Narrow on purpose: the validator must be
+ * usable with a MAINNET connection even when the keeper itself runs on devnet,
+ * so it takes a reader rather than reaching for getConnection().
+ */
+export interface MainnetAccountReader {
+  getMultipleAccountsInfo(
+    keys: PublicKey[],
+  ): Promise<Array<{ owner: PublicKey; data: Uint8Array } | null>>;
+}
+
+function isMint(info: { owner: PublicKey; data: Uint8Array }): boolean {
+  const owner = info.owner.toBase58();
+  if (owner !== SPL_TOKEN_PROGRAM_ID && owner !== TOKEN_2022_PROGRAM_ID) return false;
+  if (info.data.length === MINT_LEN) return true;
+  // Extended Token-2022 mint.
+  return (
+    owner === TOKEN_2022_PROGRAM_ID &&
+    info.data.length > ACCOUNT_TYPE_OFFSET &&
+    info.data[ACCOUNT_TYPE_OFFSET] === ACCOUNT_TYPE_MINT
+  );
+}
+
+/**
+ * Resolve the `mainnet_ca` override for each Supabase market row.
+ *
+ * KEEPER-9 / #356: `mainnet_ca` is used as the price-lookup key in
+ * fraud-detector.ts (`priceMint = state.mainnetCA ?? mint`), so a poisoned row
+ * redirects that lookup at an attacker-chosen token.
+ *
+ * Two properties are load-bearing:
+ *
+ * 1. Validation runs against MAINNET, supplied by the caller. `mainnet_ca`
+ *    exists only for devnet mirror-mint markets, so validating against the
+ *    keeper's own connection would look a mainnet mint up on devnet, find
+ *    nothing, and reject every override — disabling the feature.
+ *
+ * 2. Failures are isolated per row, and an RPC failure degrades to the
+ *    base58-only check rather than dropping every override. Dropping them sends
+ *    the price lookup to a devnet mirror mint with no liquidity, so the market
+ *    ages into staleness and stops cranking — a worse outcome than the threat.
+ */
+export async function resolveMainnetCAs(
+  rows: MainnetCaRow[],
+  opts: { reader: MainnetAccountReader | null },
+): Promise<Map<string, { mainnetCA?: string }>> {
+  const out = new Map<string, { mainnetCA?: string }>();
+  const candidates: Array<{ slabAddress: string; ca: string; key: PublicKey }> = [];
+
+  for (const row of rows) {
+    const ca = row.mainnet_ca ?? undefined;
+    if (!ca) {
+      out.set(row.slab_address, {});
+      continue;
+    }
+    if (!BASE58_RE.test(ca)) {
+      logger.warn("Invalid mainnet_ca from Supabase (bad base58), ignoring field", {
+        slabAddress: row.slab_address,
+        mainnetCA: ca,
+      });
+      out.set(row.slab_address, {});
+      continue;
+    }
+    // Per-row: a string can satisfy the regex and still not decode to 32 bytes.
+    // One such row must not cost every other row its override.
+    let key: PublicKey;
+    try {
+      key = new PublicKey(ca);
+    } catch {
+      logger.warn("Invalid mainnet_ca from Supabase (not a valid pubkey), ignoring field", {
+        slabAddress: row.slab_address,
+        mainnetCA: ca,
+      });
+      out.set(row.slab_address, {});
+      continue;
+    }
+    candidates.push({ slabAddress: row.slab_address, ca, key });
+  }
+
+  if (candidates.length === 0) return out;
+
+  if (!opts.reader) {
+    // No mainnet endpoint configured — base58 validation only. Logged once per
+    // discovery cycle rather than per row.
+    logger.warn(
+      "MAINNET_RPC_URL is not set — mainnet_ca values are format-checked but not " +
+        "verified on-chain. Set it to validate that each override is a real SPL " +
+        "Token / Token-2022 mint (see .env.example).",
+      { unverified: candidates.length },
+    );
+    for (const c of candidates) out.set(c.slabAddress, { mainnetCA: c.ca });
+    return out;
+  }
+
+  for (let i = 0; i < candidates.length; i += MAX_KEYS_PER_CALL) {
+    const chunk = candidates.slice(i, i + MAX_KEYS_PER_CALL);
+    let infos: Array<{ owner: PublicKey; data: Uint8Array } | null>;
+    try {
+      infos = await opts.reader.getMultipleAccountsInfo(chunk.map((c) => c.key));
+    } catch (err) {
+      logger.warn(
+        "mainnet_ca on-chain verification failed for this chunk — falling back to " +
+          "the format check rather than dropping the overrides",
+        { error: err instanceof Error ? err.message : String(err), chunk: chunk.length },
+      );
+      for (const c of chunk) out.set(c.slabAddress, { mainnetCA: c.ca });
+      continue;
+    }
+
+    for (let j = 0; j < chunk.length; j++) {
+      const c = chunk[j]!;
+      const info = infos[j];
+      if (!info || !isMint(info)) {
+        logger.warn("mainnet_ca is not a token mint on mainnet — ignoring override", {
+          slabAddress: c.slabAddress,
+          mainnetCA: c.ca,
+          actualOwner: info?.owner.toBase58() ?? "not found",
+          dataLen: info?.data.length ?? 0,
+        });
+        out.set(c.slabAddress, {});
+      } else {
+        out.set(c.slabAddress, { mainnetCA: c.ca });
+      }
+    }
+  }
+
+  return out;
+}

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -1,5 +1,7 @@
 import { PublicKey, SystemProgram, Keypair } from "@solana/web3.js";
+import { Connection as SolanaConnection } from "@solana/web3.js";
 import type { Connection, TransactionInstruction } from "@solana/web3.js";
+import { resolveMainnetCAs, type MainnetAccountReader } from "../lib/mainnet-ca-validator.js";
 import {
   discoverMarkets,
   encodePermissionlessCrank,
@@ -44,6 +46,33 @@ import { isFeeCrankEnabled, runFeeCrankPass } from "./fee-crank.js";
 export type CrankResult = "success" | "skipped" | "failed";
 
 const logger = createLogger("keeper:crank");
+
+/**
+ * Lazily-built, cached mainnet connection used solely to verify `mainnet_ca`
+ * overrides (KEEPER-9). Deliberately separate from getConnection(): the keeper
+ * that actually uses mainnet_ca runs on devnet, so its own connection cannot
+ * resolve a mainnet mint. Returns null when MAINNET_RPC_URL is unset, in which
+ * case the validator degrades to a format check.
+ */
+let _mainnetReader: MainnetAccountReader | null | undefined;
+function getMainnetReader(): MainnetAccountReader | null {
+  if (_mainnetReader !== undefined) return _mainnetReader;
+  const url = process.env.MAINNET_RPC_URL;
+  if (!url) {
+    _mainnetReader = null;
+    return null;
+  }
+  const conn = new SolanaConnection(url, "confirmed");
+  _mainnetReader = {
+    getMultipleAccountsInfo: (keys) => conn.getMultipleAccountsInfo(keys, "confirmed"),
+  };
+  return _mainnetReader;
+}
+
+/** Test seam: drops the cached mainnet connection. */
+export function __resetMainnetReaderForTests(): void {
+  _mainnetReader = undefined;
+}
 
 /** Timeout for individual RPC calls — prevents indefinite hangs on unresponsive nodes. */
 const RPC_TIMEOUT_MS = 15_000;
@@ -1215,54 +1244,12 @@ export class CrankService {
         monitors.db.recordSuccess().catch(() => {});
       }
       if (data) {
-        const base58Re = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
-        // SPL Token program ID — mainnet_ca must be an account owned by this program.
-        // This prevents a poisoned Supabase row from redirecting the fraud-detector's
-        // price lookup to an attacker-controlled address (KEEPER-9).
-        const SPL_TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
-        const conn = getConnection();
-
-        // Collect candidates that pass base58 check, then batch-validate on-chain ownership.
-        const candidates: Array<{ slabAddress: string; ca: string }> = [];
-        for (const row of data) {
-          const ca = row.mainnet_ca ?? undefined;
-          if (!ca) { dbMarkets.set(row.slab_address, {}); continue; }
-          if (!base58Re.test(ca)) {
-            logger.warn("Invalid mainnet_ca from Supabase (bad base58), ignoring", { slabAddress: row.slab_address, mainnetCA: ca });
-            dbMarkets.set(row.slab_address, {});
-            continue;
-          }
-          candidates.push({ slabAddress: row.slab_address, ca });
-        }
-
-        // Batch fetch account infos to verify each mainnet_ca is an SPL Token mint.
-        if (candidates.length > 0) {
-          try {
-            const pubkeys = candidates.map((c) => new PublicKey(c.ca));
-            const accountInfos = await conn.getMultipleAccountsInfo(pubkeys, "confirmed");
-            for (let i = 0; i < candidates.length; i++) {
-              const { slabAddress, ca } = candidates[i]!;
-              const info = accountInfos[i];
-              if (!info || info.owner.toBase58() !== SPL_TOKEN_PROGRAM) {
-                logger.warn("mainnet_ca is not an SPL Token mint — ignoring", {
-                  slabAddress,
-                  mainnetCA: ca,
-                  actualOwner: info?.owner.toBase58() ?? "not found",
-                });
-                dbMarkets.set(slabAddress, {});
-              } else {
-                dbMarkets.set(slabAddress, { mainnetCA: ca });
-              }
-            }
-          } catch (verifyErr) {
-            logger.warn("Failed to verify mainnet_ca mint ownership — ignoring all mainnet_ca overrides this cycle", {
-              error: verifyErr instanceof Error ? verifyErr.message : String(verifyErr),
-            });
-            for (const { slabAddress } of candidates) {
-              dbMarkets.set(slabAddress, {});
-            }
-          }
-        }
+        // KEEPER-9: validate each mainnet_ca before it can become a price-lookup
+        // key in fraud-detector.ts. Verification runs against MAINNET, not
+        // getConnection(): mainnet_ca exists only for devnet mirror-mint markets,
+        // so checking it on the keeper's own network would look a mainnet mint up
+        // on devnet, find nothing, and reject every override.
+        dbMarkets = await resolveMainnetCAs(data, { reader: getMainnetReader() });
       }
     } catch (err) {
       logger.warn("Failed to fetch market metadata from Supabase", {

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -1192,15 +1192,52 @@ export class CrankService {
       }
       if (data) {
         const base58Re = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
-        // M3: Validate each field independently — don't discard the entire row
-        // when only one field is invalid.
+        // SPL Token program ID — mainnet_ca must be an account owned by this program.
+        // This prevents a poisoned Supabase row from redirecting the fraud-detector's
+        // price lookup to an attacker-controlled address (KEEPER-9).
+        const SPL_TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+        const conn = getConnection();
+
+        // Collect candidates that pass base58 check, then batch-validate on-chain ownership.
+        const candidates: Array<{ slabAddress: string; ca: string }> = [];
         for (const row of data) {
-          let ca = row.mainnet_ca ?? undefined;
-          if (ca && !base58Re.test(ca)) {
-            logger.warn("Invalid mainnet_ca from Supabase, ignoring field", { slabAddress: row.slab_address, mainnetCA: ca });
-            ca = undefined;
+          const ca = row.mainnet_ca ?? undefined;
+          if (!ca) { dbMarkets.set(row.slab_address, {}); continue; }
+          if (!base58Re.test(ca)) {
+            logger.warn("Invalid mainnet_ca from Supabase (bad base58), ignoring", { slabAddress: row.slab_address, mainnetCA: ca });
+            dbMarkets.set(row.slab_address, {});
+            continue;
           }
-          dbMarkets.set(row.slab_address, { mainnetCA: ca });
+          candidates.push({ slabAddress: row.slab_address, ca });
+        }
+
+        // Batch fetch account infos to verify each mainnet_ca is an SPL Token mint.
+        if (candidates.length > 0) {
+          try {
+            const pubkeys = candidates.map((c) => new PublicKey(c.ca));
+            const accountInfos = await conn.getMultipleAccountsInfo(pubkeys, "confirmed");
+            for (let i = 0; i < candidates.length; i++) {
+              const { slabAddress, ca } = candidates[i]!;
+              const info = accountInfos[i];
+              if (!info || info.owner.toBase58() !== SPL_TOKEN_PROGRAM) {
+                logger.warn("mainnet_ca is not an SPL Token mint — ignoring", {
+                  slabAddress,
+                  mainnetCA: ca,
+                  actualOwner: info?.owner.toBase58() ?? "not found",
+                });
+                dbMarkets.set(slabAddress, {});
+              } else {
+                dbMarkets.set(slabAddress, { mainnetCA: ca });
+              }
+            }
+          } catch (verifyErr) {
+            logger.warn("Failed to verify mainnet_ca mint ownership — ignoring all mainnet_ca overrides this cycle", {
+              error: verifyErr instanceof Error ? verifyErr.message : String(verifyErr),
+            });
+            for (const { slabAddress } of candidates) {
+              dbMarkets.set(slabAddress, {});
+            }
+          }
         }
       }
     } catch (err) {

--- a/tests/lib/mainnet-ca-validator.test.ts
+++ b/tests/lib/mainnet-ca-validator.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import {
+  resolveMainnetCAs,
+  SPL_TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
+  type MainnetAccountReader,
+} from "../../src/lib/mainnet-ca-validator.js";
+
+/**
+ * KEEPER-9 / #356: `mainnet_ca` comes from Supabase and is used unvalidated as
+ * the price-lookup key for a market (fraud-detector.ts: `priceMint =
+ * state.mainnetCA ?? mint`). A poisoned row redirects that lookup to an
+ * attacker-chosen token.
+ *
+ * Validation has to run against MAINNET, which is the part the original fix got
+ * wrong: it used getConnection(), the keeper's own network. `mainnetCA` exists
+ * only for devnet mirror-mint markets, so on the only deployment that uses the
+ * field the lookup ran against devnet, found nothing, and dropped every
+ * override -- disabling the feature it was meant to protect.
+ */
+
+const REAL_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const OTHER_MINT = "So11111111111111111111111111111111111111112";
+
+const MINT_LEN = 82;
+const TOKEN_ACCOUNT_LEN = 165;
+
+/** A bare mint: exactly 82 bytes under either token program. */
+function mint(owner: string) {
+  return { owner: new PublicKey(owner), data: new Uint8Array(MINT_LEN) };
+}
+
+/** A Token-2022 mint carrying extensions: >165 bytes with AccountType::Mint (1) at 165. */
+function extendedMint(owner: string) {
+  const data = new Uint8Array(200);
+  data[TOKEN_ACCOUNT_LEN] = 1;
+  return { owner: new PublicKey(owner), data };
+}
+
+/** A token ACCOUNT — same program owner as a mint, so ownership alone won't do. */
+function tokenAccount(owner: string) {
+  return { owner: new PublicKey(owner), data: new Uint8Array(TOKEN_ACCOUNT_LEN) };
+}
+
+function reader(
+  impl: (keys: PublicKey[]) => Promise<Array<{ owner: PublicKey; data: Uint8Array } | null>>,
+): MainnetAccountReader {
+  return { getMultipleAccountsInfo: vi.fn(impl) };
+}
+
+describe("resolveMainnetCAs", () => {
+  describe("without a mainnet reader (MAINNET_RPC_URL unset)", () => {
+    it("keeps base58-valid overrides and makes no RPC call at all", async () => {
+      const out = await resolveMainnetCAs(
+        [{ slab_address: "slabA", mainnet_ca: REAL_MINT }],
+        { reader: null },
+      );
+      expect(out.get("slabA")).toEqual({ mainnetCA: REAL_MINT });
+    });
+
+    it("still rejects a malformed mainnet_ca", async () => {
+      const out = await resolveMainnetCAs(
+        [{ slab_address: "slabA", mainnet_ca: "not-base58-!!!" }],
+        { reader: null },
+      );
+      expect(out.get("slabA")).toEqual({});
+    });
+  });
+
+  describe("with a mainnet reader", () => {
+    it("accepts a legacy SPL Token mint", async () => {
+      const out = await resolveMainnetCAs(
+        [{ slab_address: "slabA", mainnet_ca: REAL_MINT }],
+        { reader: reader(async () => [mint(SPL_TOKEN_PROGRAM_ID)]) },
+      );
+      expect(out.get("slabA")).toEqual({ mainnetCA: REAL_MINT });
+    });
+
+    it("accepts a Token-2022 mint", async () => {
+      // Rejecting Token-2022 would silently disable price lookups for any market
+      // collateralised by one.
+      const out = await resolveMainnetCAs(
+        [{ slab_address: "slabA", mainnet_ca: REAL_MINT }],
+        { reader: reader(async () => [mint(TOKEN_2022_PROGRAM_ID)]) },
+      );
+      expect(out.get("slabA")).toEqual({ mainnetCA: REAL_MINT });
+    });
+
+    it("accepts a Token-2022 mint carrying extensions", async () => {
+      const out = await resolveMainnetCAs(
+        [{ slab_address: "slabA", mainnet_ca: REAL_MINT }],
+        { reader: reader(async () => [extendedMint(TOKEN_2022_PROGRAM_ID)]) },
+      );
+      expect(out.get("slabA")).toEqual({ mainnetCA: REAL_MINT });
+    });
+
+    it("rejects an address owned by some other program", async () => {
+      const out = await resolveMainnetCAs(
+        [{ slab_address: "slabA", mainnet_ca: REAL_MINT }],
+        { reader: reader(async () => [mint("11111111111111111111111111111111")]) },
+      );
+      expect(out.get("slabA")).toEqual({});
+    });
+
+    it("rejects a token ACCOUNT masquerading as a mint", async () => {
+      // Token accounts are owned by the same program as mints, so checking
+      // program ownership alone would let a poisoned row pointing at any token
+      // account through. The layout has to be a mint.
+      const out = await resolveMainnetCAs(
+        [{ slab_address: "slabA", mainnet_ca: REAL_MINT }],
+        { reader: reader(async () => [tokenAccount(SPL_TOKEN_PROGRAM_ID)]) },
+      );
+      expect(out.get("slabA")).toEqual({});
+    });
+
+    it("rejects an address that does not exist on mainnet", async () => {
+      const out = await resolveMainnetCAs(
+        [{ slab_address: "slabA", mainnet_ca: REAL_MINT }],
+        { reader: reader(async () => [null]) },
+      );
+      expect(out.get("slabA")).toEqual({});
+    });
+
+    it("isolates a bad row instead of discarding every other row", async () => {
+      // The original fix replaced per-field validation ("M3: validate each field
+      // independently -- don't discard the entire row when only one field is
+      // invalid") with a single try that dropped all overrides on any error.
+      const out = await resolveMainnetCAs(
+        [
+          { slab_address: "bad", mainnet_ca: "###not-base58###" },
+          { slab_address: "good", mainnet_ca: REAL_MINT },
+        ],
+        { reader: reader(async () => [mint(SPL_TOKEN_PROGRAM_ID)]) },
+      );
+      expect(out.get("bad")).toEqual({});
+      expect(out.get("good")).toEqual({ mainnetCA: REAL_MINT });
+    });
+
+    it("chunks requests to the 100-pubkey getMultipleAccountsInfo limit", async () => {
+      const seen: number[] = [];
+      const r = reader(async (keys) => {
+        seen.push(keys.length);
+        return keys.map(() => mint(SPL_TOKEN_PROGRAM_ID));
+      });
+      const rows = Array.from({ length: 250 }, (_, i) => ({
+        slab_address: `slab${i}`,
+        mainnet_ca: i % 2 === 0 ? REAL_MINT : OTHER_MINT,
+      }));
+
+      await resolveMainnetCAs(rows, { reader: r });
+
+      expect(seen).toEqual([100, 100, 50]);
+    });
+
+    it("falls back to base58-only rather than dropping overrides when the RPC fails", async () => {
+      // An RPC blip must not gate cranks. Dropping the override sends the price
+      // lookup to the devnet mirror mint, which has no liquidity -- the market
+      // ages into staleness and stops cranking, which is worse than the threat
+      // being defended against.
+      const out = await resolveMainnetCAs(
+        [{ slab_address: "slabA", mainnet_ca: REAL_MINT }],
+        {
+          reader: reader(async () => {
+            throw new Error("429 Too Many Requests");
+          }),
+        },
+      );
+      expect(out.get("slabA")).toEqual({ mainnetCA: REAL_MINT });
+    });
+  });
+
+  it("maps a row with no mainnet_ca to an empty entry", async () => {
+    const out = await resolveMainnetCAs(
+      [{ slab_address: "slabA", mainnet_ca: null }],
+      { reader: null },
+    );
+    expect(out.get("slabA")).toEqual({});
+  });
+});


### PR DESCRIPTION
Closes #356

## What

Add a `getMultipleAccountsInfo` ownership check in `crank.ts` before storing `mainnet_ca` addresses in the override mints table.

## Why

The previous code accepted any string that passed the base58 regex. There was no on-chain check that the address is owned by the SPL Token program. A pubkey owned by any other program would pass the regex and be stored, causing the keeper to send crank transactions against it.

## Changes

- `src/services/crank.ts` (lines 1193-1210): after the base58 filter, batch-fetch `getMultipleAccountsInfo` for all candidates. Keep only addresses whose account `owner` matches `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`. On any RPC error, discard all overrides for the cycle (fail closed).