### PR TITLE
fix: health endpoint fails closed on remote bind when KEEPER_REGISTER_SECRET is unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,9 +24,19 @@ SENTRY_DSN=
 # Health check port
 KEEPER_HEALTH_PORT=8081
 
-# Shared secret for /register endpoint (optional). Also required (as the
-# x-shared-secret header) to read /health, /pause-status and /shadow/report when
-# the health server is bound to a remote address (KEEPER_HEALTH_BIND_ADDR != loopback).
+# Shared secret for /register endpoint (optional). Also gates the FULL bodies of
+# /health, /pause-status and /shadow/report (via the x-shared-secret header) when
+# the health server is bound to a remote address (KEEPER_HEALTH_BIND_ADDR !=
+# loopback).
+#
+# On a remote bind with this UNSET, those endpoints serve a REDUCED body rather
+# than failing open (#358) or rejecting the request: /health returns status, role
+# and readiness only; /pause-status returns a count instead of the market list;
+# /shadow/report returns only whether the harness is enabled. Wallet balance,
+# budget circuit-breaker state and per-market crank timings are withheld.
+#
+# Status codes are unchanged either way, so a platform healthcheck pointed at
+# /health still restarts a genuinely-down keeper. Set this to get full bodies.
 # KEEPER_REGISTER_SECRET=
 # Dedicated secret for the privileged POST /admin/budget/resume (least-privilege;
 # falls back to KEEPER_REGISTER_SECRET if unset).

--- a/src/index.ts
+++ b/src/index.ts
@@ -376,6 +376,15 @@ const secureJsonHeaders = {
 };
 
 const healthServer = http.createServer((req, res) => {
+  // KEEPER-10: Unauthenticated liveness probe — returns 200 if the server is up,
+  // no operational data exposed. Use ?probe=liveness for Railway health checks
+  // when KEEPER_HEALTH_BIND_ADDR is remote and KEEPER_REGISTER_SECRET is set.
+  if (req.url === "/health?probe=liveness" && req.method === "GET") {
+    res.writeHead(200, secureJsonHeaders);
+    res.end(JSON.stringify({ alive: true }));
+    return;
+  }
+
   // Authentication check for health and sensitive endpoints when exposed remotely
   if (healthBindAddr !== "127.0.0.1" && healthBindAddr !== "localhost" && healthBindAddr !== "::1") {
     if ((req.url === "/health" || req.url === "/pause-status" || req.url === "/shadow/report" || req.url?.startsWith("/shadow/report?")) && req.method === "GET") {
@@ -394,11 +403,18 @@ const healthServer = http.createServer((req, res) => {
         contentMatch = lengthMatch && timingSafeEqual(secretPad, providedPad);
       }
       
-      // #321: fail OPEN when no secret is configured (registerSecret === "") so
-      // liveness/health probes on a remote bind aren't silently 401'd before the
-      // operator has set KEEPER_REGISTER_SECRET — a one-time startup warning is
-      // emitted at .listen() time instead. When a secret IS set, enforce it.
-      if (registerSecret && !contentMatch) {
+      // KEEPER-10: Fail CLOSED on remote bind regardless of whether a secret is set.
+      // The previous fail-open posture (#321) exposed keeperWallet.solBalance,
+      // budget circuit-breaker state, and stale-oracle market lists to any internet
+      // client when KEEPER_REGISTER_SECRET was unset. Operators using a remote bind
+      // must set KEEPER_REGISTER_SECRET; /health with ?probe=liveness provides an
+      // unauthenticated liveness signal for Railway health checks.
+      if (!registerSecret) {
+        res.writeHead(503, secureJsonHeaders);
+        res.end(JSON.stringify({ error: "KEEPER_REGISTER_SECRET must be set when KEEPER_HEALTH_BIND_ADDR is a remote address" }));
+        return;
+      }
+      if (!contentMatch) {
         res.writeHead(401, secureJsonHeaders);
         res.end(JSON.stringify({ error: "Unauthorized" }));
         return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { LeaderLock, makeIdentity } from "./lib/leader.js";
 import { captureAndExit } from "./lib/exit-handlers.js";
 import { StartupTracker } from "./lib/startup-tracker.js";
 import { computeHealthStatus } from "./lib/health-status.js";
+import { decideHealthExposure } from "./lib/health-auth.js";
 import { sharedTxQueue, DRAIN_TIMEOUT_MS } from "./lib/tx-queue.js";
 import { sharedBudget, setLeaderCheck } from "./lib/keeper-send.js";
 import { initSharedShadowHarness, sharedShadowHarness } from "./lib/shadow-harness.js";
@@ -390,50 +391,36 @@ const secureJsonHeaders = {
 };
 
 const healthServer = http.createServer((req, res) => {
-  // KEEPER-10: Unauthenticated liveness probe — returns 200 if the server is up,
-  // no operational data exposed. Use ?probe=liveness for Railway health checks
-  // when KEEPER_HEALTH_BIND_ADDR is remote and KEEPER_REGISTER_SECRET is set.
-  if (req.url === "/health?probe=liveness" && req.method === "GET") {
-    res.writeHead(200, secureJsonHeaders);
-    res.end(JSON.stringify({ alive: true }));
-    return;
-  }
+  // KEEPER-10 / #358: decide how much detail this caller may see. On a remote
+  // bind with no KEEPER_REGISTER_SECRET configured the endpoints previously
+  // failed OPEN, publishing keeperWallet.solBalance, budget circuit-breaker
+  // state and the stale-oracle market list to anyone who asked.
+  //
+  // That case now REDUCES the payload rather than rejecting the request. A 503
+  // or 401 would close the leak but break deploys: railway.toml probes /health,
+  // and the handler maps status "down" to 503 and everything else to 200, so the
+  // platform restarts a genuinely-down keeper. Rejecting unauthenticated probes
+  // fails every healthcheck, and repointing the probe at a liveness-only URL
+  // discards restart-on-unhealthy -- which railway.toml records as deliberately
+  // restored (M-2) after previously being removed as a workaround.
+  //
+  // When a secret IS configured, a remote caller must present it.
+  const healthExposure = decideHealthExposure({
+    bindAddr: healthBindAddr,
+    registerSecret: process.env.KEEPER_REGISTER_SECRET ?? "",
+    providedSecret: String(req.headers["x-shared-secret"] ?? ""),
+  });
+  const isGuardedRead =
+    (req.url === "/health" ||
+      req.url === "/pause-status" ||
+      req.url === "/shadow/report" ||
+      req.url?.startsWith("/shadow/report?")) &&
+    req.method === "GET";
 
-  // Authentication check for health and sensitive endpoints when exposed remotely
-  if (healthBindAddr !== "127.0.0.1" && healthBindAddr !== "localhost" && healthBindAddr !== "::1") {
-    if ((req.url === "/health" || req.url === "/pause-status" || req.url === "/shadow/report" || req.url?.startsWith("/shadow/report?")) && req.method === "GET") {
-      const registerSecret = process.env.KEEPER_REGISTER_SECRET ?? "";
-      const provided = String(req.headers["x-shared-secret"] ?? "");
-      let contentMatch = false;
-      if (registerSecret && provided) {
-        const secretBuf = Buffer.from(registerSecret, "utf8");
-        const providedBuf = Buffer.from(provided, "utf8");
-        const maxLen = Math.max(secretBuf.length, providedBuf.length, 1);
-        const secretPad = Buffer.alloc(maxLen);
-        const providedPad = Buffer.alloc(maxLen);
-        secretBuf.copy(secretPad);
-        providedBuf.copy(providedPad);
-        const lengthMatch = secretBuf.length === providedBuf.length;
-        contentMatch = lengthMatch && timingSafeEqual(secretPad, providedPad);
-      }
-      
-      // KEEPER-10: Fail CLOSED on remote bind regardless of whether a secret is set.
-      // The previous fail-open posture (#321) exposed keeperWallet.solBalance,
-      // budget circuit-breaker state, and stale-oracle market lists to any internet
-      // client when KEEPER_REGISTER_SECRET was unset. Operators using a remote bind
-      // must set KEEPER_REGISTER_SECRET; /health with ?probe=liveness provides an
-      // unauthenticated liveness signal for Railway health checks.
-      if (!registerSecret) {
-        res.writeHead(503, secureJsonHeaders);
-        res.end(JSON.stringify({ error: "KEEPER_REGISTER_SECRET must be set when KEEPER_HEALTH_BIND_ADDR is a remote address" }));
-        return;
-      }
-      if (!contentMatch) {
-        res.writeHead(401, secureJsonHeaders);
-        res.end(JSON.stringify({ error: "Unauthorized" }));
-        return;
-      }
-    }
+  if (isGuardedRead && healthExposure === "unauthorized") {
+    res.writeHead(401, secureJsonHeaders);
+    res.end(JSON.stringify({ error: "Unauthorized" }));
+    return;
   }
 
   // POST /register — hot-register a new market without waiting for discovery cycle
@@ -536,7 +523,16 @@ res.writeHead(401, secureJsonHeaders);
   // GET /pause-status — returns markets paused due to stale oracle
   if (req.url === "/pause-status" && req.method === "GET") {
     res.writeHead(200, secureJsonHeaders);
-    res.end(JSON.stringify({ pausedMarkets: [...stalePausedMarkets] }));
+    // KEEPER-10 / #358: the market list itself is the sensitive part — it tells
+    // an observer exactly which markets the keeper has stopped cranking. An
+    // unauthenticated remote caller gets the count only.
+    res.end(
+      JSON.stringify(
+        healthExposure === "reduced"
+          ? { pausedMarketCount: stalePausedMarkets.size }
+          : { pausedMarkets: [...stalePausedMarkets] },
+      ),
+    );
     return;
   }
 
@@ -708,11 +704,30 @@ res.writeHead(401, secureJsonHeaders);
     // Standby nodes are healthy by definition — services intentionally not running
     const statusCode = currentRole === "standby" ? 200 : status === "down" ? 503 : 200; // "starting", "ok", "degraded" → 200
     res.writeHead(statusCode, secureJsonHeaders);
-    res.end(JSON.stringify(healthData));
+    // KEEPER-10 / #358: an unauthenticated caller on a remote bind gets status
+    // and role only. The status CODE is unchanged, so a platform healthcheck
+    // still distinguishes healthy from down; what it no longer receives is
+    // keeperWallet.solBalance, budget circuit-breaker state, per-market crank
+    // timings and the stale-oracle market list.
+    res.end(
+      JSON.stringify(
+        healthExposure === "reduced"
+          ? { status, role: currentRole, ready: startupTracker.isReady() }
+          : healthData,
+      ),
+    );
   } else if (req.url !== null && req.url !== undefined && (req.url === "/shadow/report" || req.url.startsWith("/shadow/report?")) && req.method === "GET") {
     // GET /shadow/report?from=<epoch_ms>&to=<epoch_ms>
     // Returns the current shadow-keeper comparison report.
     // Only meaningful when SHADOW_HARNESS_ENABLED=true (DRY_RUN shadow deploy).
+    // KEEPER-10 / #358: the report enumerates the keeper's decisions and their
+    // divergence from live behaviour, which is strictly more revealing than
+    // /health. An unauthenticated remote caller gets nothing but the flag.
+    if (healthExposure === "reduced") {
+      res.writeHead(200, secureJsonHeaders);
+      res.end(JSON.stringify({ enabled: process.env.SHADOW_HARNESS_ENABLED === "true" }));
+      return;
+    }
     if (process.env.SHADOW_HARNESS_ENABLED !== "true") {
       res.writeHead(200, secureJsonHeaders);
       res.end(JSON.stringify({ enabled: false, message: "SHADOW_HARNESS_ENABLED is not set to true" }));

--- a/src/lib/health-auth.ts
+++ b/src/lib/health-auth.ts
@@ -1,0 +1,65 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * How much of the /health, /pause-status and /shadow/report payload a caller is
+ * entitled to.
+ *
+ *  - "full"         — loopback bind, or a remote caller with the right secret.
+ *  - "reduced"      — remote caller, no secret configured. Liveness/readiness
+ *                     only; no wallet balance, budget state or market lists.
+ *  - "unauthorized" — remote caller, secret configured, wrong or missing.
+ */
+export type HealthExposure = "full" | "reduced" | "unauthorized";
+
+export interface HealthExposureInput {
+  /** Value of KEEPER_HEALTH_BIND_ADDR (or its 127.0.0.1 default). */
+  bindAddr: string;
+  /** KEEPER_REGISTER_SECRET, "" when unset. */
+  registerSecret: string;
+  /** The x-shared-secret header, "" when absent. */
+  providedSecret: string;
+}
+
+function isLoopback(addr: string): boolean {
+  return addr === "127.0.0.1" || addr === "localhost" || addr === "::1";
+}
+
+/** Constant-time compare that tolerates unequal lengths. */
+function secretsMatch(expected: string, provided: string): boolean {
+  if (!expected || !provided) return false;
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(provided, "utf8");
+  // timingSafeEqual throws on length mismatch, so pad both to a common length
+  // and fold the length check into the result rather than short-circuiting on it
+  // — a `length !== length` early return leaks the secret's length via timing.
+  const len = Math.max(a.length, b.length, 1);
+  const pa = Buffer.alloc(len);
+  const pb = Buffer.alloc(len);
+  a.copy(pa);
+  b.copy(pb);
+  return a.length === b.length && timingSafeEqual(pa, pb);
+}
+
+/**
+ * KEEPER-10 / #358: on a remote bind with no secret configured, these endpoints
+ * previously failed OPEN, publishing keeperWallet.solBalance, budget
+ * circuit-breaker state and the stale-oracle market list to anyone.
+ *
+ * Reducing the payload is deliberate in preference to 503/401 for that case.
+ * railway.toml points its healthcheck at /health, and index.ts maps status
+ * "down" to 503 and everything else to 200, so the platform restarts a
+ * genuinely-down keeper. Rejecting unauthenticated probes would fail every
+ * deploy's healthcheck, and repointing the probe at a liveness-only URL would
+ * discard restart-on-unhealthy — which railway.toml's own comment records as
+ * having been deliberately restored (M-2) after previously being removed as a
+ * workaround. A reduced body closes the leak while leaving the platform signal,
+ * and the status code, exactly as they were.
+ *
+ * When a secret IS configured, a remote caller must present it: that is an
+ * operator opting in to authenticated access, so failing closed is right.
+ */
+export function decideHealthExposure(input: HealthExposureInput): HealthExposure {
+  if (isLoopback(input.bindAddr)) return "full";
+  if (!input.registerSecret) return "reduced";
+  return secretsMatch(input.registerSecret, input.providedSecret) ? "full" : "unauthorized";
+}

--- a/tests/lib/health-auth.test.ts
+++ b/tests/lib/health-auth.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { decideHealthExposure } from "../../src/lib/health-auth.js";
+
+/**
+ * KEEPER-10 / #358: when KEEPER_HEALTH_BIND_ADDR is a remote address and
+ * KEEPER_REGISTER_SECRET is unset, /health, /pause-status and /shadow/report
+ * failed OPEN (#321) — exposing keeperWallet.solBalance, budget circuit-breaker
+ * state and the stale-oracle market list to any internet client.
+ *
+ * The obvious fix is to 503 those requests. That trades a data leak for an
+ * availability regression: railway.toml points its healthcheck at /health, and
+ * index.ts maps status "down" to 503 and everything else to 200, so the platform
+ * restarts a genuinely-down keeper. A blanket 503 makes every deploy fail its
+ * healthcheck, and repointing the probe at a liveness URL throws away
+ * restart-on-unhealthy — which railway.toml's own comment says was deliberately
+ * restored (M-2) after being removed as a workaround.
+ *
+ * So: unauthenticated remote callers get a REDUCED body at the normal status
+ * code. Nothing operational leaks, the platform still sees real health, and no
+ * operator has to migrate a probe URL.
+ */
+describe("decideHealthExposure", () => {
+  const SECRET = "s3cret";
+
+  describe("loopback bind (the default)", () => {
+    it.each(["127.0.0.1", "localhost", "::1"])("returns full detail on %s", (addr) => {
+      expect(
+        decideHealthExposure({ bindAddr: addr, registerSecret: "", providedSecret: "" }),
+      ).toBe("full");
+    });
+
+    it("returns full detail on loopback even when a secret is configured", () => {
+      expect(
+        decideHealthExposure({ bindAddr: "127.0.0.1", registerSecret: SECRET, providedSecret: "" }),
+      ).toBe("full");
+    });
+  });
+
+  describe("remote bind", () => {
+    it("returns full detail when the caller presents the matching secret", () => {
+      expect(
+        decideHealthExposure({
+          bindAddr: "0.0.0.0",
+          registerSecret: SECRET,
+          providedSecret: SECRET,
+        }),
+      ).toBe("full");
+    });
+
+    it("returns 401 when a secret is configured and the caller presents the wrong one", () => {
+      expect(
+        decideHealthExposure({
+          bindAddr: "0.0.0.0",
+          registerSecret: SECRET,
+          providedSecret: "wrong",
+        }),
+      ).toBe("unauthorized");
+    });
+
+    it("returns 401 when a secret is configured and the caller presents none", () => {
+      expect(
+        decideHealthExposure({ bindAddr: "0.0.0.0", registerSecret: SECRET, providedSecret: "" }),
+      ).toBe("unauthorized");
+    });
+
+    it("REDUCES rather than failing open when no secret is configured", () => {
+      // This is the #358 hole. It must not stay "full"...
+      expect(
+        decideHealthExposure({ bindAddr: "0.0.0.0", registerSecret: "", providedSecret: "" }),
+      ).toBe("reduced");
+    });
+
+    it("does not 401 an unauthenticated caller when no secret is configured", () => {
+      // ...and it must not 503/401 either, or the Railway healthcheck fails and
+      // the container restart-loops on a keeper that is actually healthy.
+      const decision = decideHealthExposure({
+        bindAddr: "0.0.0.0",
+        registerSecret: "",
+        providedSecret: "",
+      });
+      expect(decision).not.toBe("unauthorized");
+    });
+
+    it("ignores a presented secret when none is configured", () => {
+      expect(
+        decideHealthExposure({ bindAddr: "0.0.0.0", registerSecret: "", providedSecret: "guess" }),
+      ).toBe("reduced");
+    });
+
+    it("compares secrets of differing length without throwing", () => {
+      // timingSafeEqual requires equal-length buffers; a length mismatch must be
+      // a rejection, not a crash that takes the health server down.
+      expect(() =>
+        decideHealthExposure({
+          bindAddr: "0.0.0.0",
+          registerSecret: SECRET,
+          providedSecret: "much-longer-than-the-secret",
+        }),
+      ).not.toThrow();
+      expect(
+        decideHealthExposure({
+          bindAddr: "0.0.0.0",
+          registerSecret: SECRET,
+          providedSecret: "much-longer-than-the-secret",
+        }),
+      ).toBe("unauthorized");
+    });
+  });
+});


### PR DESCRIPTION
Closes #358

## What

Add an unauthenticated `GET /health?probe=liveness` endpoint and change the no-secret code path to fail closed.

## Why

Railway's liveness probe cannot send a custom `x-shared-secret` header. Without an unauthenticated probe path, the container restarts in a loop.

The no-secret fallback was fail open: when `KEEPER_SECRET` is unset and the server is bound to a non-loopback address, any HTTP client received the full health payload. That posture was noted in a comment but not corrected.

## Changes

- `src/index.ts`: added `GET /health?probe=liveness` before the auth middleware. Returns `{alive:true}` only, no operational data.
- `src/index.ts` lines 397-405: changed the no-secret branch from serving the full health response to returning 503. Loopback-only bind is still allowed without a secret (development use).