### PR TITLE
fix: LaserStream-triggered gatedLiquidate calls no longer consume per-owner cap slots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -195,3 +195,11 @@ KEEPER_FEE_CRANK_ENABLED=false
 # (ATA of the ["vault", market] authority PDA for the collateral mint). A single
 # process-wide env var could only ever be right for one market, and the wrapper's
 # F-VAULT-FRAG pin rejects any other address as InvalidVaultAccount (12).
+
+# Per-owner liquidation caps (KEEPER-11). Two independent budgets per cycle so a
+# LaserStream burst covering several positions of one owner cannot exhaust the
+# polling scan's allowance and starve genuinely underwater accounts. Both are
+# defence-in-depth against keeper-side mispricing, so neither path is unbounded;
+# raise them during a genuine cascade rather than removing them.
+# KEEPER_MAX_LIQ_PER_OWNER_PER_CYCLE=3         # polling scan
+# KEEPER_MAX_LIQ_PER_OWNER_PER_CYCLE_EVENT=10  # LaserStream event path

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -948,6 +948,13 @@ export class LiquidationService {
       scanPriceE6: bigint;
       closeQ?: bigint;
     },
+    // KEEPER-11: LaserStream-triggered calls do NOT count against _cycleOwnerCounts.
+    // The per-owner cap was designed to bound the polling scan from over-liquidating a
+    // single owner within one cycle. A burst of LaserStream events for distinct positions
+    // of the same owner would exhaust the cap before the polling scan could reach those
+    // positions, causing valid liquidation candidates to be skipped. Event-driven calls
+    // are already deduplicated by _cycleSeenPositions and _inFlightPositions.
+    source: "polling" | "laserstream" = "polling",
   ): Promise<string | null> {
     const positionKey = candidate.v17PortfolioPubkey
       ? `${candidate.slabAddress}:v17:${candidate.v17PortfolioPubkey.toBase58()}`
@@ -970,16 +977,18 @@ export class LiquidationService {
       });
       return null;
     }
-    const ownerCount = this._cycleOwnerCounts.get(candidate.owner) ?? 0;
-    if (ownerCount >= LiquidationService.MAX_LIQ_PER_OWNER_PER_CYCLE) {
-      logger.debug("Owner hit per-cycle liquidation cap", {
-        owner: candidate.owner.slice(0, 8),
-        cap: LiquidationService.MAX_LIQ_PER_OWNER_PER_CYCLE,
-      });
-      return null;
+    if (source === "polling") {
+      const ownerCount = this._cycleOwnerCounts.get(candidate.owner) ?? 0;
+      if (ownerCount >= LiquidationService.MAX_LIQ_PER_OWNER_PER_CYCLE) {
+        logger.debug("Owner hit per-cycle liquidation cap", {
+          owner: candidate.owner.slice(0, 8),
+          cap: LiquidationService.MAX_LIQ_PER_OWNER_PER_CYCLE,
+        });
+        return null;
+      }
+      this._cycleOwnerCounts.set(candidate.owner, ownerCount + 1);
     }
     this._cycleSeenPositions.add(positionKey);
-    this._cycleOwnerCounts.set(candidate.owner, ownerCount + 1);
     this._inFlightPositions.add(positionKey);
     try {
       return (await this.liquidate(
@@ -1616,8 +1625,10 @@ export class LiquidationService {
             this.scanMarket(market.market).then(async (candidates) => {
               for (const c of candidates) {
                 // #218: route through the shared gate so the event path honors the same
-                // per-cycle dedup + per-owner cap as the polling path (no double-liquidation).
-                const sig = await this.gatedLiquidate(market.market, c);
+                // per-cycle dedup + in-flight guard as the polling path (no double-liquidation).
+                // KEEPER-11: pass "laserstream" so LaserStream bursts do not exhaust the
+                // per-owner cap (_cycleOwnerCounts) for the polling scan.
+                const sig = await this.gatedLiquidate(market.market, c, "laserstream");
                 if (sig) {
                   logger.info("Event-driven liquidation complete", {
                     slabAddress: slabKey,

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -649,7 +649,28 @@ export class LiquidationService {
   // scan budget. Residual positions above the cap are picked up next cycle.
   private _cycleSeenPositions = new Set<string>();
   private _cycleOwnerCounts = new Map<string, number>();
-  private static readonly MAX_LIQ_PER_OWNER_PER_CYCLE = 3;
+  private static readonly MAX_LIQ_PER_OWNER_PER_CYCLE =
+    Number(process.env.KEEPER_MAX_LIQ_PER_OWNER_PER_CYCLE ?? 3);
+  /**
+   * KEEPER-11: the event path gets its OWN per-owner budget rather than sharing
+   * the polling scan's.
+   *
+   * The bug being fixed is that a LaserStream burst covering several positions of
+   * one owner consumed the shared cap before the polling scan reached those
+   * positions, so genuinely underwater accounts were skipped. Exempting the event
+   * path entirely would fix that but leave it unbounded — and it is the one path
+   * an attacker can provoke on demand by touching their own account. The cap is
+   * defence-in-depth against the KEEPER's own mispricing, not against the
+   * attacker, so removing it multiplies the blast radius of a keeper-side price
+   * bug on precisely the cheapest path to trigger.
+   *
+   * Two counters, two limits: a burst can no longer starve the scan, and neither
+   * path is unbounded. Both are env-tunable so the limits can be raised during a
+   * genuine cascade without a redeploy.
+   */
+  private _eventCycleOwnerCounts = new Map<string, number>();
+  private static readonly MAX_LIQ_PER_OWNER_PER_CYCLE_EVENT =
+    Number(process.env.KEEPER_MAX_LIQ_PER_OWNER_PER_CYCLE_EVENT ?? 10);
   // H-1: positions with a liquidate() call currently in flight (added before
   // awaiting liquidate(), removed in a finally once it settles). Intentionally
   // separate from _cycleSeenPositions above: that Set is cleared at the start
@@ -989,17 +1010,25 @@ export class LiquidationService {
       });
       return null;
     }
-    if (source === "polling") {
-      const ownerCount = this._cycleOwnerCounts.get(candidate.owner) ?? 0;
-      if (ownerCount >= LiquidationService.MAX_LIQ_PER_OWNER_PER_CYCLE) {
-        logger.debug("Owner hit per-cycle liquidation cap", {
-          owner: candidate.owner.slice(0, 8),
-          cap: LiquidationService.MAX_LIQ_PER_OWNER_PER_CYCLE,
-        });
-        return null;
-      }
-      this._cycleOwnerCounts.set(candidate.owner, ownerCount + 1);
+    // KEEPER-11: independent budgets per source. An event burst draws on
+    // _eventCycleOwnerCounts, so it cannot exhaust the polling scan's allowance
+    // for the same owner — and it is still bounded.
+    const counts =
+      source === "laserstream" ? this._eventCycleOwnerCounts : this._cycleOwnerCounts;
+    const cap =
+      source === "laserstream"
+        ? LiquidationService.MAX_LIQ_PER_OWNER_PER_CYCLE_EVENT
+        : LiquidationService.MAX_LIQ_PER_OWNER_PER_CYCLE;
+    const ownerCount = counts.get(candidate.owner) ?? 0;
+    if (ownerCount >= cap) {
+      logger.debug("Owner hit per-cycle liquidation cap", {
+        owner: candidate.owner.slice(0, 8),
+        cap,
+        source,
+      });
+      return null;
     }
+    counts.set(candidate.owner, ownerCount + 1);
     this._cycleSeenPositions.add(positionKey);
     this._inFlightPositions.add(positionKey);
     try {
@@ -1486,6 +1515,9 @@ export class LiquidationService {
     // away part of the exposure; partial-fill retry is intentional).
     this._cycleSeenPositions.clear();
     this._cycleOwnerCounts.clear();
+    // KEEPER-11: the event budget resets on the same cycle boundary, so an
+    // exhausted event allowance recovers rather than latching for the process.
+    this._eventCycleOwnerCounts.clear();
 
     // P2 FIX: Periodically clear permanentlySkipped to allow recovery when SDK is updated.
     // Markets re-add themselves on next parse failure, so this is safe.

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -1743,3 +1743,125 @@ describe('LiquidationService', () => {
     });
   });
 });
+
+/**
+ * KEEPER-11: a LaserStream burst for several positions of one owner used to
+ * consume MAX_LIQ_PER_OWNER_PER_CYCLE before the polling scan could reach those
+ * positions, so genuinely underwater accounts were skipped.
+ *
+ * The original fix exempted the event path from the cap entirely. That is the
+ * one path an attacker can trigger on demand (by touching their own account),
+ * and the cap is defence-in-depth against the KEEPER's own mispricing rather
+ * than against the attacker -- so removing it multiplies the blast radius of a
+ * keeper-side price bug on exactly the path that is cheapest to provoke.
+ *
+ * Two independent budgets instead: the polling scan keeps its cap, and the event
+ * path gets its own, larger one. A burst can no longer starve the scan, and
+ * neither path is unbounded.
+ */
+describe('KEEPER-11: per-owner caps are independent per source', () => {
+  // mockOracleService lives inside the LiquidationService describe; this block
+  // is top-level, so it supplies its own. Only fetchPrice is reached here.
+  const oracleStub: any = {
+    fetchPrice: vi.fn().mockResolvedValue({
+      priceE6: 1_000_000n,
+      source: 'dexscreener',
+      timestamp: 1_700_000_000_000,
+    }),
+  };
+
+  function makeMarketAt(slabAddr: string) {
+    return {
+      slabAddress: { toBase58: () => slabAddr, equals: () => false },
+      programId: { toBase58: () => 'ProgramId1111111111111111111111111111111' },
+      config: {
+        collateralMint: { toBase58: () => 'Mint111111111111111111111111111111111111' },
+        oracleAuthority: mockZeroKey(),
+        indexFeedId: mockNonZeroKey('feed'),
+      },
+      params: { maintenanceMarginBps: 500n },
+      header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+    };
+  }
+
+  function candidateAt(slab: string, accountIdx: number, owner: string) {
+    return {
+      slabAddress: slab,
+      accountIdx,
+      owner,
+      positionSize: 1_000n,
+      capital: 100n,
+      pnl: -50n,
+      marginRatio: 4.0,
+      maintenanceMarginBps: 500n,
+    };
+  }
+
+  /** Distinct positions of ONE owner, so only the per-owner cap can stop them. */
+  async function drain(
+    svc: any, market: any, owner: string, n: number, source?: string, idxFrom = 0,
+  ) {
+    let landed = 0;
+    for (let i = 0; i < n; i++) {
+      // Distinct accountIdx per call: _cycleSeenPositions dedups by position, so
+      // reusing indices would mask the per-owner cap under the dedup guard.
+      const sig = await svc.gatedLiquidate(market, candidateAt('Slab', idxFrom + i, owner), source);
+      if (sig) landed++;
+    }
+    return landed;
+  }
+
+  it('still caps the polling path at MAX_LIQ_PER_OWNER_PER_CYCLE', async () => {
+    const svc: any = new LiquidationService(oracleStub);
+    vi.spyOn(svc, 'liquidate').mockResolvedValue('sig');
+    const cap = LiquidationService['MAX_LIQ_PER_OWNER_PER_CYCLE'];
+
+    expect(await drain(svc, makeMarketAt('Slab'), 'OwnerPoll', cap + 5, 'polling')).toBe(cap);
+  });
+
+  it('gives the event path its own, larger budget rather than no budget at all', async () => {
+    const svc: any = new LiquidationService(oracleStub);
+    vi.spyOn(svc, 'liquidate').mockResolvedValue('sig');
+    const eventCap = LiquidationService['MAX_LIQ_PER_OWNER_PER_CYCLE_EVENT'];
+
+    expect(eventCap).toBeGreaterThan(LiquidationService['MAX_LIQ_PER_OWNER_PER_CYCLE']);
+    // Bounded: an event burst cannot liquidate an owner without limit.
+    expect(await drain(svc, makeMarketAt('Slab'), 'OwnerEvt', eventCap + 5, 'laserstream')).toBe(eventCap);
+  });
+
+  it('an event burst does not consume the polling scan budget (the original bug)', async () => {
+    const svc: any = new LiquidationService(oracleStub);
+    vi.spyOn(svc, 'liquidate').mockResolvedValue('sig');
+    const owner = 'OwnerShared';
+    const pollCap = LiquidationService['MAX_LIQ_PER_OWNER_PER_CYCLE'];
+
+    // Exhaust the event budget first...
+    await drain(svc, makeMarketAt('Slab'), owner, LiquidationService['MAX_LIQ_PER_OWNER_PER_CYCLE_EVENT'], 'laserstream');
+    // ...the polling scan must still get its full allowance for the same owner,
+    // on positions the event path did not already take.
+    const polled = await drain(svc, makeMarketAt('Slab'), owner, pollCap + 3, 'polling', 1_000);
+
+    expect(polled).toBe(pollCap);
+  });
+
+  it('defaults to the polling budget when no source is given', async () => {
+    const svc: any = new LiquidationService(oracleStub);
+    vi.spyOn(svc, 'liquidate').mockResolvedValue('sig');
+    const cap = LiquidationService['MAX_LIQ_PER_OWNER_PER_CYCLE'];
+
+    expect(await drain(svc, makeMarketAt('Slab'), 'OwnerDefault', cap + 5)).toBe(cap);
+  });
+
+  it('clears both counters at the cycle boundary', async () => {
+    const svc: any = new LiquidationService(oracleStub);
+    vi.spyOn(svc, 'liquidate').mockResolvedValue('sig');
+    await drain(svc, makeMarketAt('Slab'), 'OwnerReset', 2, 'polling');
+    await drain(svc, makeMarketAt('Slab'), 'OwnerReset', 2, 'laserstream');
+
+    svc._cycleOwnerCounts.clear();
+    svc._eventCycleOwnerCounts.clear();
+
+    expect(svc._cycleOwnerCounts.size).toBe(0);
+    expect(svc._eventCycleOwnerCounts.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #360

## What

Add a `source: "polling" | "laserstream"` parameter to `gatedLiquidate()` and apply the per-owner cycle cap only on polling calls.

## Why

`MAX_LIQ_PER_OWNER_PER_CYCLE = 3` bounds how many of a single owner's positions the polling scan can liquidate in one cycle. LaserStream fires one event per position. Both paths shared the same `_cycleOwnerCounts` map, so a burst of LaserStream events exhausted the polling cap and blocked valid liquidations for that owner in the same window.

LaserStream calls are already protected against duplicates by `_cycleSeenPositions` and `_inFlightPositions`, so they do not need the polling cap.

## Changes

- `src/services/liquidation.ts`: added `source` parameter to `gatedLiquidate()`. Owner-count check and increment wrapped in `if (source === "polling")`. LaserStream call site passes `"laserstream"`.