### PR TITLE
fix: add wall-clock time gate to H1 deviation-acceptance to block rapid dual-source manipulation

### DIFF
--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -122,18 +122,33 @@ export class OracleService {
   private deviationRejections = new Map<string, number>();
   private deviationFirstRejectedAt = new Map<string, number>();
   private static readonly DEVIATION_ACCEPT_AFTER = 5;
-  // Minimum elapsed time since the first consecutive rejection before H1 fires.
-  // Default: 5 minutes — ensures a sustained legitimate move, not a 25-second trade.
-  private static readonly DEVIATION_ACCEPT_AFTER_MS =
-    Number(process.env.ORACLE_DEVIATION_ACCEPT_AFTER_MS ?? 5 * 60 * 1000);
+  /**
+   * Minimum elapsed time since the first rejection of the current streak before
+   * H1 fires. Instance state, read at construction rather than at module load,
+   * so it can be injected in tests — matching the `now` clock beside it. A
+   * `static readonly` initialised from process.env is fixed the moment the
+   * module is first imported, which no test can influence.
+   *
+   * 60s, not the 5 minutes first proposed. The gate trades liveness for
+   * manipulation resistance and these are memecoin perps: a legitimate >30% move
+   * inside five minutes is ordinary, and while the price is rejected the market
+   * ages into staleness, gets paused, and stops cranking — suppressing
+   * liquidations during exactly the volatility that produces bad debt. 60s still
+   * forces an attacker to hold a dual-source manipulation across 5+ fetches
+   * rather than the ~25s the count-only gate allowed.
+   */
+  private readonly _deviationAcceptAfterMs: number;
 
   /** Injectable clock — defaults to Date.now() in production; overridden in
    *  tests so price freshness / staleness is deterministic without faking the
    *  global Date around the async fetch path. */
   private readonly now: () => number;
 
-  constructor(opts?: { now?: () => number }) {
+  constructor(opts?: { now?: () => number; deviationAcceptAfterMs?: number }) {
     this.now = opts?.now ?? (() => Date.now());
+    this._deviationAcceptAfterMs =
+      opts?.deviationAcceptAfterMs ??
+      Number(process.env.ORACLE_DEVIATION_ACCEPT_AFTER_MS ?? 60_000);
     // M5: DexScreener and Jupiter REST APIs return prices with NO publisher
     // signature and NO slot field. Cross-source validation (10% deviation) +
     // min-liquidity filter ($1000) + historical deviation cap (30%) mitigate
@@ -513,7 +528,7 @@ export class OracleService {
           const firstRejectedAt = this.deviationFirstRejectedAt.get(slabAddress) ?? this.now();
           const elapsedMs = this.now() - firstRejectedAt;
           const countGate = consecutiveCount >= OracleService.DEVIATION_ACCEPT_AFTER;
-          const timeGate = elapsedMs >= OracleService.DEVIATION_ACCEPT_AFTER_MS;
+          const timeGate = elapsedMs >= this._deviationAcceptAfterMs;
           if (!countGate || !timeGate) {
             logger.warn("Price deviation exceeds threshold", {
               mint,
@@ -524,7 +539,7 @@ export class OracleService {
               source,
               consecutiveRejections: consecutiveCount,
               acceptAfterCount: OracleService.DEVIATION_ACCEPT_AFTER,
-              acceptAfterMs: OracleService.DEVIATION_ACCEPT_AFTER_MS,
+              acceptAfterMs: this._deviationAcceptAfterMs,
               elapsedMs: Math.round(elapsedMs),
             });
             return null;

--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -91,9 +91,20 @@ export class OracleService {
   // staleness rather than cranking on a frozen price forever.
   private lastExternalPriceMs = new Map<string, number>();
   // H1: Track consecutive deviation rejections per slab to avoid permanent anchor lock.
-  // After DEVIATION_ACCEPT_AFTER consecutive rejections, accept the price as legitimate.
+  // After DEVIATION_ACCEPT_AFTER consecutive rejections AND at least
+  // DEVIATION_ACCEPT_AFTER_MS have elapsed since the FIRST rejection in the current
+  // streak, accept the price as legitimate.
+  // KEEPER-12: the count-only guard allowed a ~25-second coordinated dual-source
+  // manipulation (attacker moves a thin pool that both DexScreener and Jupiter index;
+  // both feeds agree so cross-validation passes; H1 fires after 5 * 5s cycles).
+  // Adding a wall-clock minimum ensures rapid manipulation cannot win the race.
   private deviationRejections = new Map<string, number>();
+  private deviationFirstRejectedAt = new Map<string, number>();
   private static readonly DEVIATION_ACCEPT_AFTER = 5;
+  // Minimum elapsed time since the first consecutive rejection before H1 fires.
+  // Default: 5 minutes — ensures a sustained legitimate move, not a 25-second trade.
+  private static readonly DEVIATION_ACCEPT_AFTER_MS =
+    Number(process.env.ORACLE_DEVIATION_ACCEPT_AFTER_MS ?? 5 * 60 * 1000);
 
   /** Injectable clock — defaults to Date.now() in production; overridden in
    *  tests so price freshness / staleness is deterministic without faking the
@@ -460,7 +471,16 @@ export class OracleService {
         if (deviationBps > HISTORICAL_DEVIATION_MAX_BPS) {
           const consecutiveCount = (this.deviationRejections.get(slabAddress) ?? 0) + 1;
           this.deviationRejections.set(slabAddress, consecutiveCount);
-          if (consecutiveCount < OracleService.DEVIATION_ACCEPT_AFTER) {
+          // Track the timestamp of the first consecutive rejection so we can enforce
+          // a wall-clock minimum in addition to the count gate (KEEPER-12).
+          if (consecutiveCount === 1) {
+            this.deviationFirstRejectedAt.set(slabAddress, this.now());
+          }
+          const firstRejectedAt = this.deviationFirstRejectedAt.get(slabAddress) ?? this.now();
+          const elapsedMs = this.now() - firstRejectedAt;
+          const countGate = consecutiveCount >= OracleService.DEVIATION_ACCEPT_AFTER;
+          const timeGate = elapsedMs >= OracleService.DEVIATION_ACCEPT_AFTER_MS;
+          if (!countGate || !timeGate) {
             logger.warn("Price deviation exceeds threshold", {
               mint,
               deviationBps,
@@ -469,14 +489,17 @@ export class OracleService {
               newPrice: priceE6.toString(),
               source,
               consecutiveRejections: consecutiveCount,
-              acceptAfter: OracleService.DEVIATION_ACCEPT_AFTER,
+              acceptAfterCount: OracleService.DEVIATION_ACCEPT_AFTER,
+              acceptAfterMs: OracleService.DEVIATION_ACCEPT_AFTER_MS,
+              elapsedMs: Math.round(elapsedMs),
             });
             return null;
           }
-          logger.warn("Accepting deviated price after consecutive rejections (H1)", {
+          logger.warn("Accepting deviated price after consecutive rejections + time gate (H1)", {
             mint,
             deviationBps,
             consecutiveRejections: consecutiveCount,
+            elapsedMs: Math.round(elapsedMs),
             lastPrice: lastPrice.toString(),
             newPrice: priceE6.toString(),
             source,
@@ -484,8 +507,9 @@ export class OracleService {
         }
       }
     }
-    // H1: Price accepted — reset consecutive rejection counter
+    // H1: Price accepted — reset consecutive rejection counter and first-rejection timestamp
     this.deviationRejections.delete(slabAddress);
+    this.deviationFirstRejectedAt.delete(slabAddress);
 
     const entry: PriceEntry = { priceE6, source, timestamp: this.now() };
     this.recordPrice(slabAddress, entry);

--- a/tests/services/oracle-deviation.test.ts
+++ b/tests/services/oracle-deviation.test.ts
@@ -224,11 +224,17 @@ describe('Cross-source deviation — actual boundary conditions', () => {
 // ─── 2. Historical deviation boundary tests ────────────────────────────────────
 
 describe('Historical deviation — boundary conditions', () => {
+  // KEEPER-12 added a wall-clock minimum alongside the consecutive-rejection
+  // count, so the two H1 escape-hatch tests below have to be able to advance
+  // time. Everything else in this block is time-independent.
+  let clockMs = 1_700_000_000_000;
+  const advanceClock = (ms: number) => { clockMs += ms; };
   let svc: OracleService;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    svc = new OracleService();
+    clockMs = 1_700_000_000_000;
+    svc = new OracleService({ now: () => clockMs });
   });
 
   async function seedPrice(slab: string, usd: number): Promise<bigint> {
@@ -345,6 +351,12 @@ describe('Historical deviation — boundary conditions', () => {
       expect(r).toBeNull();
     }
 
+    // KEEPER-12: acceptance now needs the count AND a sustained deviation, so
+    // the move has to persist past the wall-clock gate as well. The property
+    // this test guards — H1 can still escape, the anchor is not permanently
+    // bricked — is unchanged; only the cost of escaping went up.
+    advanceClock(61_000);
+
     // 5th consecutive rejection — should be accepted
     const mintAccept = freshMint();
     mockBothSources(2.00, 2.00, mintAccept);
@@ -376,6 +388,11 @@ describe('Historical deviation — boundary conditions', () => {
       mockBothSources(2.00, 2.00, mint);
       expect(await svc.fetchPrice(mint, slab)).toBeNull();
     }
+
+    // KEEPER-12: the wall-clock gate also restarts with the streak, so the new
+    // streak has to age past it on its own — it inherits no credit from the
+    // rejections that preceded the accepted price.
+    advanceClock(61_000);
 
     // 5th consecutive from fresh counter — NOW accepted
     const mintFinal = freshMint();
@@ -545,4 +562,97 @@ describe('HYPERP vs Pyth scenario table', () => {
       }
     });
   }
+});
+
+/**
+ * KEEPER-12: the H1 escape hatch (accept a deviated price after N consecutive
+ * rejections) was count-only, so a manipulation that moved a thin pool both
+ * DexScreener and Jupiter index could clear it in ~25 seconds. A wall-clock
+ * minimum makes the attacker hold the manipulation instead of just outlasting a
+ * counter.
+ *
+ * The gate is deliberately 60s and not the 5 minutes originally proposed. These
+ * are memecoin perps: a legitimate >30% move inside five minutes is routine, and
+ * while the price is being rejected the market ages into staleness, gets paused,
+ * and stops cranking -- so an over-long gate suppresses liquidations during
+ * exactly the volatility that creates bad debt.
+ */
+describe('KEEPER-12: wall-clock gate on H1 deviation acceptance', () => {
+  function makeSvc(deviationAcceptAfterMs?: number) {
+    let t = 1_700_000_000_000;
+    const svc = new OracleService({ now: () => t, deviationAcceptAfterMs });
+    return { svc, advance: (ms: number) => { t += ms; } };
+  }
+
+  async function seed(svc: OracleService, slab: string, usd: number) {
+    const mint = freshMint();
+    mockBothSources(usd, usd, mint);
+    const r = await svc.fetchPrice(mint, slab);
+    expect(r).not.toBeNull();
+  }
+
+  async function offer(svc: OracleService, slab: string, usd: number) {
+    const mint = freshMint();
+    mockBothSources(usd, usd, mint);
+    return svc.fetchPrice(mint, slab);
+  }
+
+  it('keeps rejecting a deviated price while the burst is faster than the gate', async () => {
+    const { svc } = makeSvc(60_000);
+    const slab = freshSlab();
+    await seed(svc, slab, 1.0);
+
+    // Ten consecutive rejections, zero elapsed time: the count gate is long
+    // satisfied, so only the clock is holding the line.
+    for (let i = 0; i < 10; i++) {
+      expect(await offer(svc, slab, 2.0)).toBeNull();
+    }
+  });
+
+  it('accepts once the deviation has persisted past the gate', async () => {
+    const { svc, advance } = makeSvc(60_000);
+    const slab = freshSlab();
+    await seed(svc, slab, 1.0);
+
+    for (let i = 0; i < 4; i++) {
+      expect(await offer(svc, slab, 2.0)).toBeNull();
+    }
+    advance(61_000);
+
+    const accepted = await offer(svc, slab, 2.0);
+    expect(accepted).not.toBeNull();
+    expect(accepted!.priceE6).toBe(toE6(2.0));
+  });
+
+  it('defaults the gate to 60s rather than 5 minutes', async () => {
+    const { svc, advance } = makeSvc(); // no override — exercise the default
+    const slab = freshSlab();
+    await seed(svc, slab, 1.0);
+
+    for (let i = 0; i < 4; i++) {
+      expect(await offer(svc, slab, 2.0)).toBeNull();
+    }
+    advance(61_000);
+
+    expect(await offer(svc, slab, 2.0)).not.toBeNull();
+  });
+
+  it('restarts the clock when an in-band price resets the streak', async () => {
+    // The gate measures from the FIRST rejection of the current streak, so an
+    // accepted price in between must clear the timestamp too -- otherwise a
+    // later streak inherits credit for time it did not spend deviating.
+    const { svc, advance } = makeSvc(60_000);
+    const slab = freshSlab();
+    await seed(svc, slab, 1.0);
+
+    expect(await offer(svc, slab, 2.0)).toBeNull(); // streak starts here
+    advance(59_000);
+    await seed(svc, slab, 1.05);                    // in band -> streak reset
+
+    for (let i = 0; i < 4; i++) {
+      expect(await offer(svc, slab, 2.1)).toBeNull();
+    }
+    advance(30_000); // 89s since the ORIGINAL first rejection, 30s since reset
+    expect(await offer(svc, slab, 2.1)).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #362

## What

Add a time gate to `oracle.ts` so that a deviated price requires both `DEVIATION_ACCEPT_AFTER` consecutive rejections AND at least `ORACLE_DEVIATION_ACCEPT_AFTER_MS` (default 5 minutes) of elapsed wall-clock time before acceptance.

## Why

The count-only gate allowed a deviated price to be accepted after 5 * `ORACLE_RATE_LIMIT_MS` (~25 s). An attacker who moves a pool indexed by both DexScreener and Jupiter satisfies cross-source validation (both feeds agree on the manipulated price) and then triggers the count gate after 25 s.

A 5-minute time gate makes a sustained oracle drift distinguishable from a short-term manipulation. The count gate is kept to avoid accepting a fast-moving real price after a single cycle.

## Changes

- `src/services/oracle.ts`:
  - Added `deviationFirstRejectedAt: Map<string, number>` to track when each slab's current rejection streak started.
  - Added `DEVIATION_ACCEPT_AFTER_MS` static (default `5 * 60 * 1000`, overridable via `ORACLE_DEVIATION_ACCEPT_AFTER_MS` env var).
  - On first rejection in a streak (`consecutiveCount === 1`), record `now()` in the map.
  - Both `countGate` and `timeGate` must be true before the price is accepted.
  - Clear `deviationFirstRejectedAt` entry when a price is accepted.