### PR TITLE
fix(keeper): require USE_HELIUS_SENDER=true on mainnet

### DIFF
--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -279,5 +279,27 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
           "would fire and vanish with no operator-visible signal.",
       );
     }
+
+    // BUG-101: keeper-send.ts's isMainnetSender() is a literal
+    // `USE_HELIUS_SENDER === "true"` check with no NETWORK-based default --
+    // unset or any non-"true" value silently falls back to plain
+    // sendRawTransaction broadcast (skipPreflight, no Jito bundle) to public
+    // RPCs, exposing the liquidation target pubkey and close size to any RPC
+    // operator or mempool listener before confirmation (front-running /
+    // liquidation-sniping). .env.example documents USE_HELIUS_SENDER=true as
+    // the mainnet default, but nothing enforced it -- a deployment built from
+    // a partial env (not copying that line) degraded silently with zero
+    // boot-time signal, unlike every other mainnet-critical setting in this
+    // file. Require it explicitly, mirroring the H-7 DISCORD_ALERT_WEBHOOK guard.
+    if (env.USE_HELIUS_SENDER !== "true") {
+      throw new Error(
+        "USE_HELIUS_SENDER must be set to 'true' when NETWORK=mainnet. It is " +
+          "unset or not 'true', and keeper-send.ts's isMainnetSender() would " +
+          "silently fall back to plain sendRawTransaction broadcast to public " +
+          "RPCs with no Jito-bundle protection -- exposing the liquidation " +
+          "target and size to front-running/sandwiching before confirmation. " +
+          "Set USE_HELIUS_SENDER=true (see .env.example) for mainnet.",
+      );
+    }
   }
 }

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -168,6 +168,7 @@ describe("validateKeeperEnvGuards", () => {
         KEEPER_REDIS_URL: "https://fake-host.upstash.io",
         KEEPER_REDIS_TOKEN: "fake-token",
         DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+        USE_HELIUS_SENDER: "true",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -357,6 +358,7 @@ describe("validateKeeperEnvGuards", () => {
         FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
         RPC_URL: "https://mainnet.helius-rpc.com/?api-key=xxx",
         DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+        USE_HELIUS_SENDER: "true",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -514,6 +516,7 @@ describe("validateKeeperEnvGuards", () => {
         FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
         RPC_URL: MAINNET,
         DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+        USE_HELIUS_SENDER: "true",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -527,6 +530,7 @@ describe("validateKeeperEnvGuards", () => {
         RPC_URL: "https://my-devnet-migration.example.com",
         FALLBACK_RPC_URL: "https://my-devnet-migration.example.com",
         DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+        USE_HELIUS_SENDER: "true",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -613,11 +617,59 @@ describe("validateKeeperEnvGuards", () => {
         RPC_URL: MAINNET,
         FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
         DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+        USE_HELIUS_SENDER: "true",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
 
     it("does NOT require DISCORD_ALERT_WEBHOOK off mainnet (devnet/unset)", () => {
+      expect(() =>
+        validateKeeperEnvGuards({ NETWORK: "devnet" } as NodeJS.ProcessEnv),
+      ).not.toThrow();
+      expect(() => validateKeeperEnvGuards({} as NodeJS.ProcessEnv)).not.toThrow();
+    });
+  });
+
+  // BUG-101: keeper-send.ts's isMainnetSender() is a literal `=== "true"` check
+  // with no NETWORK-based default -- unset silently degrades to a public,
+  // unprotected sendRawTransaction broadcast on mainnet.
+  describe("BUG-101: USE_HELIUS_SENDER required on mainnet", () => {
+    const MAINNET = "https://mainnet.helius-rpc.com/?api-key=test";
+    const baseMainnetEnv = {
+      NETWORK: "mainnet",
+      SOLANA_RPC_URL: MAINNET,
+      RPC_URL: MAINNET,
+      FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
+      DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+    };
+
+    it("throws when USE_HELIUS_SENDER is unset on mainnet", () => {
+      const env = { ...baseMainnetEnv } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /USE_HELIUS_SENDER must be set to 'true'.*NETWORK=mainnet/i,
+      );
+    });
+
+    it("throws when USE_HELIUS_SENDER=false on mainnet", () => {
+      const env = { ...baseMainnetEnv, USE_HELIUS_SENDER: "false" } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /USE_HELIUS_SENDER must be set to 'true'/i,
+      );
+    });
+
+    it("throws when USE_HELIUS_SENDER is an arbitrary non-'true' string on mainnet", () => {
+      const env = { ...baseMainnetEnv, USE_HELIUS_SENDER: "1" } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /USE_HELIUS_SENDER must be set to 'true'/i,
+      );
+    });
+
+    it("accepts USE_HELIUS_SENDER=true on mainnet", () => {
+      const env = { ...baseMainnetEnv, USE_HELIUS_SENDER: "true" } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
+
+    it("does NOT require USE_HELIUS_SENDER off mainnet (devnet/unset)", () => {
       expect(() =>
         validateKeeperEnvGuards({ NETWORK: "devnet" } as NodeJS.ProcessEnv),
       ).not.toThrow();


### PR DESCRIPTION
## Problem

`isMainnetSender()` in `src/lib/keeper-send.ts` is a literal `USE_HELIUS_SENDER === "true"` check with no `NETWORK`-based default:

```ts
function isMainnetSender(): boolean {
  return (
    isMainnetNetwork(process.env.NETWORK) &&
    process.env.USE_HELIUS_SENDER === "true"
  );
}
```

When `USE_HELIUS_SENDER` is unset or any non-`"true"` value, the keeper silently falls back to plain `sendRawTransaction` broadcast (`skipPreflight: true`, no Jito bundle) to public RPCs. This exposes the liquidation target pubkey and close size to any RPC operator or mempool listener before confirmation — enabling front-running/sandwiching, or outright liquidation-sniping (a third party copying the observed instruction with their own fee payer to capture the liquidation incentive).

`.env.example` documents `USE_HELIUS_SENDER=true` as the recommended mainnet default, but nothing in code enforces it. A deployment built from a partial/incomplete env (not copying that line, or built directly from Railway env vars without referencing `.env.example`) degrades silently with zero boot-time signal — unlike every other mainnet-critical setting already guarded in `env-guards.ts` (`DISCORD_ALERT_WEBHOOK`, `KEEPER_REDIS_URL`/`KEEPER_REDIS_TOKEN`, RPC URL scheme/host checks).

## Production Impact

On mainnet, with `USE_HELIUS_SENDER` unset (a plausible operator mistake given it's optional in code), every liquidation and crank transaction broadcasts to public RPCs pre-confirmation with no MEV protection. A searcher watching the keeper's known fee-payer pubkey can observe a pending liquidation instruction and either sandwich it or race a copy of it with a higher fee, stealing the liquidation reward. This is a silent degradation — the keeper runs and appears healthy with no indication that it's operating without its intended MEV protection.

## Fix

Add a boot-time guard in `validateKeeperEnvGuards()` requiring `USE_HELIUS_SENDER=true` when `NETWORK=mainnet`, mirroring the existing `DISCORD_ALERT_WEBHOOK` (H-7) fail-loud pattern. Off mainnet (devnet/local dev), the setting remains optional as before.

## Proof of Fix

New tests in `tests/env-guards.test.ts` (`BUG-101: USE_HELIUS_SENDER required on mainnet`):
- Throws when unset on mainnet
- Throws when `"false"` on mainnet
- Throws when an arbitrary non-`"true"` string on mainnet
- Accepts `"true"` on mainnet
- Does not require it off mainnet

Existing mainnet-accepting test fixtures elsewhere in the file were updated to include `USE_HELIUS_SENDER: "true"` so they continue to exercise the happy path correctly.

## Test Output

```
 Test Files  1 failed | 93 passed | 2 skipped (96)
      Tests  1 failed | 979 passed | 33 skipped (1013)
```

The one failure (`tests/v17-risk-params.poc.test.ts`) is pre-existing and unrelated to this change — a stale assertion left over from commit `8ee810d` (#345), which changed production code to *accept* `maintenanceMarginBps==10000` but didn't update that older PoC test. Confirmed unrelated by file scope (no overlap with `env-guards.ts`/`keeper-send.ts`).

`pnpm build` — clean, zero errors.