### PR TITLE
fix(keeper): back off retries for a position that keeps failing liquidation

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -650,6 +650,18 @@ export class LiquidationService {
   // gatedLiquidate is the sole entry point for both the polling path and the
   // LaserStream event path, so guarding here covers both unconditionally.
   private readonly _inFlightPositions = new Set<string>();
+  // BUG-103: per-position failure backoff. _cycleSeenPositions/_inFlightPositions
+  // only prevent *concurrent* double-submission within or across one cycle --
+  // neither remembers that a liquidate() attempt for a given position failed,
+  // so a position whose liquidate() keeps failing (e.g. an owner racing a cheap
+  // top-up between the keeper's scan and submit to flip stillLiquidatable just
+  // before send) gets re-attempted at full tx-fee cost on every single polling
+  // cycle, forever, with zero increasing cost to the owner. Cleared on a
+  // successful liquidation; capped so a position already known to be
+  // liquidatable is never throttled past POSITION_BACKOFF_MAX_MS.
+  private readonly _positionBackoff = new Map<string, { failures: number; retryAfter: number }>();
+  private static readonly POSITION_BACKOFF_BASE_MS = 5_000;
+  private static readonly POSITION_BACKOFF_MAX_MS = 300_000; // 5 min, matches maxBackoffMs
   // B5: collapse per-liquidation Discord alerts into a single summary alert per
   // market within a 5 s window — prevents cascade-driven channel flooding.
   private readonly _liquidationAlertAggregator = new AlertAggregator(
@@ -963,6 +975,18 @@ export class LiquidationService {
       });
       return null;
     }
+    // BUG-103: a position that keeps failing gets an escalating cooldown
+    // instead of an unconditional retry on every cycle/event.
+    const backoff = this._positionBackoff.get(positionKey);
+    if (backoff && Date.now() < backoff.retryAfter) {
+      logger.debug("Skipping position in per-position failure backoff", {
+        positionKey,
+        owner: candidate.owner.slice(0, 8),
+        failures: backoff.failures,
+        retryInMs: backoff.retryAfter - Date.now(),
+      });
+      return null;
+    }
     if (this._cycleSeenPositions.has(positionKey)) {
       logger.debug("Skipping position already targeted this cycle", {
         positionKey,
@@ -982,13 +1006,35 @@ export class LiquidationService {
     this._cycleOwnerCounts.set(candidate.owner, ownerCount + 1);
     this._inFlightPositions.add(positionKey);
     try {
-      return (await this.liquidate(
-        market,
-        candidate.accountIdx,
-        candidate.v17PortfolioPubkey,
-        candidate.scanPriceE6,
-        candidate.closeQ ?? 0n,
-      )) ?? null;
+      const sig =
+        (await this.liquidate(
+          market,
+          candidate.accountIdx,
+          candidate.v17PortfolioPubkey,
+          candidate.scanPriceE6,
+          candidate.closeQ ?? 0n,
+        )) ?? null;
+      if (sig) {
+        // BUG-103: a landed liquidation clears any prior failure history --
+        // the position is gone, and a future reuse of this key (a new
+        // position at the same slot) deserves a clean slate.
+        this._positionBackoff.delete(positionKey);
+      } else {
+        const prev = this._positionBackoff.get(positionKey);
+        const failures = (prev?.failures ?? 0) + 1;
+        // The first failure is free (immediate retry permitted) -- a single
+        // recheck-abort (oracle moved, owner topped up once) is routine and
+        // must not delay a position that's still genuinely liquidatable.
+        // Backoff only escalates once a position has failed repeatedly.
+        const delay = failures <= 1
+          ? 0
+          : Math.min(
+              LiquidationService.POSITION_BACKOFF_BASE_MS * Math.pow(2, failures - 2),
+              LiquidationService.POSITION_BACKOFF_MAX_MS,
+            );
+        this._positionBackoff.set(positionKey, { failures, retryAfter: Date.now() + delay });
+      }
+      return sig;
     } finally {
       // Always release, regardless of success, a returned null (race-
       // condition abort inside liquidate()), or an unexpected thrown error.

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -1,3 +1,4 @@
+import { LRUCache } from "lru-cache";
 import { PublicKey, TransactionInstruction, SYSVAR_CLOCK_PUBKEY } from "@solana/web3.js";
 import {
   fetchSlab,
@@ -665,15 +666,35 @@ export class LiquidationService {
   // BUG-103: per-position failure backoff. _cycleSeenPositions/_inFlightPositions
   // only prevent *concurrent* double-submission within or across one cycle --
   // neither remembers that a liquidate() attempt for a given position failed,
-  // so a position whose liquidate() keeps failing (e.g. an owner racing a cheap
-  // top-up between the keeper's scan and submit to flip stillLiquidatable just
-  // before send) gets re-attempted at full tx-fee cost on every single polling
-  // cycle, forever, with zero increasing cost to the owner. Cleared on a
-  // successful liquidation; capped so a position already known to be
-  // liquidatable is never throttled past POSITION_BACKOFF_MAX_MS.
-  private readonly _positionBackoff = new Map<string, { failures: number; retryAfter: number }>();
+  // so a position whose submitted liquidation keeps reverting gets re-attempted
+  // at full tx-fee cost on every polling cycle.
+  //
+  // Armed ONLY when a transaction was actually broadcast (see _submitAttempts)
+  // and the budget breaker is not halted. Both exclusions matter:
+  //   - Every pre-submit `return null` in liquidate() (oracle-drift guard, the
+  //     #373 fail-closed re-verification, "no longer undercollateralized") sits
+  //     above recordAttempt() and costs no fee. Backing off on those would blind
+  //     the keeper to a genuinely underwater position because an RPC call failed.
+  //   - A halted budget makes keeperSend return null for EVERY position
+  //     (keeper-send.ts: `if (!budget.canSpend(...)) return null`), so arming
+  //     there would put the entire book into escalating cooldown at once and
+  //     keep the keeper idle well past the operator's resume().
+  //
+  // LRU-bounded: entries are only deleted on a landed liquidation, so a position
+  // closed by its owner or liquidated by someone else would otherwise leave its
+  // entry behind for the life of the process.
+  private readonly _positionBackoff = new LRUCache<string, { failures: number; retryAfter: number }>({
+    max: 2_000,
+  });
   private static readonly POSITION_BACKOFF_BASE_MS = 5_000;
-  private static readonly POSITION_BACKOFF_MAX_MS = 300_000; // 5 min, matches maxBackoffMs
+  // 60s, not the 5 minutes originally proposed: a position that is genuinely
+  // liquidatable must not be ignored long enough for a cascade to accrue bad
+  // debt the protocol then absorbs.
+  private static readonly POSITION_BACKOFF_MAX_MS = 60_000;
+  // Incremented in liquidate() at the recordAttempt() line, i.e. once the tx is
+  // about to go to keeperSend. gatedLiquidate compares this across the call to
+  // tell "broadcast and failed" from "aborted before broadcasting".
+  private _submitAttempts = 0;
   // B5: collapse per-liquidation Discord alerts into a single summary alert per
   // market within a 5 s window — prevents cascade-driven channel flooding.
   private readonly _liquidationAlertAggregator = new AlertAggregator(
@@ -1018,6 +1039,7 @@ export class LiquidationService {
     this._cycleOwnerCounts.set(candidate.owner, ownerCount + 1);
     this._inFlightPositions.add(positionKey);
     try {
+      const attemptsBefore = this._submitAttempts;
       const sig =
         (await this.liquidate(
           market,
@@ -1026,12 +1048,16 @@ export class LiquidationService {
           candidate.scanPriceE6,
           candidate.closeQ ?? 0n,
         )) ?? null;
+      // Did a transaction actually reach the wire? Everything that returns null
+      // above recordAttempt() cost an RPC call, not a fee, and must not throttle
+      // a position that may still be underwater.
+      const broadcast = this._submitAttempts > attemptsBefore;
       if (sig) {
         // BUG-103: a landed liquidation clears any prior failure history --
         // the position is gone, and a future reuse of this key (a new
         // position at the same slot) deserves a clean slate.
         this._positionBackoff.delete(positionKey);
-      } else {
+      } else if (broadcast && !sharedBudget.isHalted()) {
         const prev = this._positionBackoff.get(positionKey);
         const failures = (prev?.failures ?? 0) + 1;
         // The first failure is free (immediate retry permitted) -- a single
@@ -1431,6 +1457,10 @@ export class LiquidationService {
       //   - Multi-RPC parallel broadcast (+20-40% landing rate)
       //   - Simulation-based tight CU limit (better queue position)
       const __t0 = Date.now();
+      // BUG-103: everything above this line is a pre-submit abort. Past it we are
+      // committed to putting a transaction on the wire, so this is the point that
+      // distinguishes "cost us a fee" from "cost us an RPC call".
+      this._submitAttempts++;
       recordAttempt();
       let sig: string;
       try {

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -1466,4 +1466,120 @@ describe('LiquidationService', () => {
       expect(await firstCall).toBe('sig-first');
     });
   });
+
+  // BUG-103: a position whose liquidate() keeps failing must not be retried
+  // at full tx-fee cost on every single cycle/event forever -- that is an
+  // unbounded, asymmetric-cost DoS surface (a cheap owner-side action timed
+  // against the keeper's scan/submit window beats the recheck every time).
+  describe('BUG-103: per-position failure backoff', () => {
+    function makeMarketAt(slabAddr: string) {
+      return {
+        slabAddress: { toBase58: () => slabAddr, equals: () => false },
+        programId: { toBase58: () => 'ProgramId1111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'Mint111111111111111111111111111111111111' },
+          oracleAuthority: mockZeroKey(),
+          indexFeedId: mockNonZeroKey('feed'),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+      };
+    }
+
+    function makeCandidate(slabAddress: string, accountIdx: number, owner: string) {
+      return {
+        slabAddress,
+        accountIdx,
+        owner,
+        positionSize: 1_000n,
+        capital: 100n,
+        pnl: -50n,
+        marginRatio: 4.0,
+        maintenanceMarginBps: 500n,
+      };
+    }
+
+    // gatedLiquidate's _cycleSeenPositions/_cycleOwnerCounts are normally
+    // cleared per-cycle by scanAndLiquidateAll; calling gatedLiquidate
+    // directly back-to-back (as the H-1 suite above also does) requires
+    // clearing them manually to simulate the next cycle's boundary.
+    function clearCycleState(svc: any): void {
+      svc._cycleSeenPositions.clear();
+      svc._cycleOwnerCounts.clear();
+    }
+
+    it('allows an immediate retry after exactly one failure (first failure is free)', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const owner = 'OwnerBackoff1111111111111111111111111111111';
+      const slab = 'SlabBackoff111111111111111111111111111111111';
+      const market = makeMarketAt(slab);
+      const candidate = makeCandidate(slab, 1, owner);
+
+      const liquidateSpy = vi
+        .spyOn(svc, 'liquidate')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('sig-ok');
+
+      const first = await (svc as any).gatedLiquidate(market, candidate);
+      expect(first).toBeNull();
+      clearCycleState(svc);
+      const second = await (svc as any).gatedLiquidate(market, candidate);
+      expect(second).toBe('sig-ok');
+      expect(liquidateSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('throttles a position after repeated consecutive failures instead of retrying every call', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const owner = 'OwnerGrief111111111111111111111111111111111';
+      const slab = 'SlabGrief1111111111111111111111111111111111';
+      const market = makeMarketAt(slab);
+      const candidate = makeCandidate(slab, 1, owner);
+
+      const liquidateSpy = vi.spyOn(svc, 'liquidate').mockResolvedValue(null);
+
+      // Failure 1: free retry (matches existing single-abort semantics).
+      expect(await (svc as any).gatedLiquidate(market, candidate)).toBeNull();
+      clearCycleState(svc);
+      // Failure 2: now backed off -- a third immediate call must NOT re-invoke
+      // liquidate() again before the cooldown elapses.
+      expect(await (svc as any).gatedLiquidate(market, candidate)).toBeNull();
+      expect(liquidateSpy).toHaveBeenCalledTimes(2);
+      clearCycleState(svc);
+
+      const third = await (svc as any).gatedLiquidate(market, candidate);
+      expect(third).toBeNull();
+      // Still only 2 -- the third call was skipped by the backoff, not a new
+      // (failed) liquidate() attempt.
+      expect(liquidateSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears the backoff on a successful liquidation', async () => {
+      const svc = new LiquidationService(mockOracleService as any);
+      const owner = 'OwnerRecover111111111111111111111111111111';
+      const slab = 'SlabRecover11111111111111111111111111111111';
+      const market = makeMarketAt(slab);
+      const candidate = makeCandidate(slab, 1, owner);
+
+      const liquidateSpy = vi
+        .spyOn(svc, 'liquidate')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('sig-final');
+
+      expect(await (svc as any).gatedLiquidate(market, candidate)).toBeNull(); // failure 1 (free)
+      clearCycleState(svc);
+      expect(await (svc as any).gatedLiquidate(market, candidate)).toBeNull(); // failure 2 (backed off after this)
+      clearCycleState(svc);
+
+      // Manually expire the backoff window to simulate time passing, then land.
+      const positionKey = `${slab}:v12:1`;
+      const entry = (svc as any)._positionBackoff.get(positionKey);
+      expect(entry).toBeDefined();
+      entry.retryAfter = Date.now() - 1;
+
+      expect(await (svc as any).gatedLiquidate(market, candidate)).toBe('sig-final');
+      expect(liquidateSpy).toHaveBeenCalledTimes(3);
+      expect((svc as any)._positionBackoff.has(positionKey)).toBe(false);
+    });
+  });
 });

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -1791,9 +1791,13 @@ describe('LiquidationService', () => {
       const market = makeMarketAt(slab);
       const candidate = makeCandidate(slab, 1, owner);
 
+      // Model a transaction that was actually broadcast and failed. liquidate()
+      // calls recordAttempt() (bumping _submitAttempts) immediately before handing
+      // the tx to keeperSend, and every earlier `return null` sits above that line.
+      // Only a post-submit failure costs a fee, so only that arms the backoff.
       const liquidateSpy = vi
         .spyOn(svc, 'liquidate')
-        .mockResolvedValueOnce(null)
+        .mockImplementationOnce(async () => { (svc as any)._submitAttempts++; return null; })
         .mockResolvedValueOnce('sig-ok');
 
       const first = await (svc as any).gatedLiquidate(market, candidate);
@@ -1811,7 +1815,9 @@ describe('LiquidationService', () => {
       const market = makeMarketAt(slab);
       const candidate = makeCandidate(slab, 1, owner);
 
-      const liquidateSpy = vi.spyOn(svc, 'liquidate').mockResolvedValue(null);
+      const liquidateSpy = vi
+        .spyOn(svc, 'liquidate')
+        .mockImplementation(async () => { (svc as any)._submitAttempts++; return null; });
 
       // Failure 1: free retry (matches existing single-abort semantics).
       expect(await (svc as any).gatedLiquidate(market, candidate)).toBeNull();
@@ -1838,8 +1844,8 @@ describe('LiquidationService', () => {
 
       const liquidateSpy = vi
         .spyOn(svc, 'liquidate')
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(null)
+        .mockImplementationOnce(async () => { (svc as any)._submitAttempts++; return null; })
+        .mockImplementationOnce(async () => { (svc as any)._submitAttempts++; return null; })
         .mockResolvedValueOnce('sig-final');
 
       expect(await (svc as any).gatedLiquidate(market, candidate)).toBeNull(); // failure 1 (free)
@@ -1856,6 +1862,109 @@ describe('LiquidationService', () => {
       expect(await (svc as any).gatedLiquidate(market, candidate)).toBe('sig-final');
       expect(liquidateSpy).toHaveBeenCalledTimes(3);
       expect((svc as any)._positionBackoff.has(positionKey)).toBe(false);
+    });
+
+    it('does NOT arm backoff when liquidate aborts before broadcasting anything', async () => {
+      // Every pre-submit `return null` in liquidate() -- the oracle-drift guard,
+      // the #373 fail-closed re-verification, "no longer undercollateralized" --
+      // sits ABOVE recordAttempt(), so none of them costs a transaction fee.
+      // Backing off on those would blind the keeper to a genuinely underwater
+      // position because an RPC call happened to fail, which is the opposite of
+      // what a liquidator should do during the volatility that causes bad debt.
+      const svc = new LiquidationService(mockOracleService as any);
+      const slab = 'SlabAbort11111111111111111111111111111111111';
+      const market = makeMarketAt(slab);
+      const candidate = makeCandidate(slab, 1, 'OwnerAbort11111111111111111111111111111111');
+
+      // No _submitAttempts bump: nothing reached the wire.
+      const liquidateSpy = vi.spyOn(svc, 'liquidate').mockResolvedValue(null);
+
+      for (let i = 0; i < 3; i++) {
+        expect(await (svc as any).gatedLiquidate(market, candidate)).toBeNull();
+        clearCycleState(svc);
+      }
+
+      expect(liquidateSpy).toHaveBeenCalledTimes(3);
+      expect((svc as any)._positionBackoff.size).toBe(0);
+    });
+
+    it('does NOT arm backoff while the budget circuit breaker is halted', async () => {
+      // A halted budget makes keeperSend return null for EVERY position
+      // (keeper-send.ts: `if (!budget.canSpend(...)) return null`). Arming backoff
+      // there would put every tracked position into escalating cooldown
+      // simultaneously, so the keeper would still be refusing to liquidate long
+      // after an operator resumed it -- turning one halt into a much longer outage.
+      const svc = new LiquidationService(mockOracleService as any);
+      const slab = 'SlabHalt111111111111111111111111111111111111';
+      const market = makeMarketAt(slab);
+      const candidate = makeCandidate(slab, 1, 'OwnerHalt111111111111111111111111111111111');
+
+      const liquidateSpy = vi
+        .spyOn(svc, 'liquidate')
+        .mockImplementation(async () => { (svc as any)._submitAttempts++; return null; });
+
+      keeperSendModule.sharedBudget.haltManually('test cordon');
+      try {
+        for (let i = 0; i < 3; i++) {
+          expect(await (svc as any).gatedLiquidate(market, candidate)).toBeNull();
+          clearCycleState(svc);
+        }
+      } finally {
+        keeperSendModule.sharedBudget.resume('test');
+      }
+
+      expect(liquidateSpy).toHaveBeenCalledTimes(3);
+      expect((svc as any)._positionBackoff.size).toBe(0);
+    });
+
+    it('caps the escalating cooldown at 60s rather than 5 minutes', async () => {
+      // 300s was chosen to "match maxBackoffMs", but a position that is genuinely
+      // liquidatable must not be ignored for five minutes -- that is long enough
+      // for a cascade to accrue bad debt the protocol then eats.
+      const svc = new LiquidationService(mockOracleService as any);
+      const slab = 'SlabCap1111111111111111111111111111111111111';
+      const market = makeMarketAt(slab);
+      const candidate = makeCandidate(slab, 1, 'OwnerCap1111111111111111111111111111111111');
+      const positionKey = `${slab}:v12:1`;
+
+      vi.spyOn(svc, 'liquidate')
+        .mockImplementation(async () => { (svc as any)._submitAttempts++; return null; });
+
+      let lastDelay = 0;
+      for (let i = 0; i < 8; i++) {
+        const t = Date.now();
+        await (svc as any).gatedLiquidate(market, candidate);
+        clearCycleState(svc);
+        const entry = (svc as any)._positionBackoff.get(positionKey);
+        lastDelay = entry.retryAfter - t;
+        entry.retryAfter = Date.now() - 1; // expire so the next call escalates
+      }
+
+      expect(lastDelay).toBeLessThanOrEqual(60_000);
+      // ...and it really did escalate rather than the cap being trivially met.
+      expect(lastDelay).toBeGreaterThan(30_000);
+    });
+
+    it('bounds the backoff map so positions that vanish cannot leak', async () => {
+      // Entries are only deleted on a landed liquidation. A position that is
+      // closed by its owner, or liquidated by somebody else, leaves its entry
+      // behind forever -- an unbounded Map on a long-running process.
+      const svc = new LiquidationService(mockOracleService as any);
+      const slab = 'SlabLeak111111111111111111111111111111111111';
+      const market = makeMarketAt(slab);
+
+      vi.spyOn(svc, 'liquidate')
+        .mockImplementation(async () => { (svc as any)._submitAttempts++; return null; });
+
+      const cap = (svc as any)._positionBackoff.max;
+      expect(cap).toBeTypeOf('number'); // a plain Map has no `max`
+
+      for (let i = 0; i < cap + 50; i++) {
+        await (svc as any).gatedLiquidate(market, makeCandidate(slab, i, `Owner${i}`));
+        clearCycleState(svc);
+      }
+
+      expect((svc as any)._positionBackoff.size).toBeLessThanOrEqual(cap);
     });
   });
 });

--- a/tests/v17-liquidation-dedup.poc.test.ts
+++ b/tests/v17-liquidation-dedup.poc.test.ts
@@ -1,3 +1,4 @@
+import { LRUCache } from "lru-cache";
 import { PublicKey } from "@solana/web3.js";
 import { describe, expect, it, vi } from "vitest";
 import { LiquidationService } from "../src/services/liquidation.js";
@@ -30,6 +31,12 @@ function makeHarness(): {
   // H-1: bypassing the constructor via Object.create skips class field
   // initializers, so this must be seeded explicitly too.
   service._inFlightPositions = new Set<string>();
+  // BUG-103 added a _positionBackoff field that gatedLiquidate dereferences on
+  // its first line, so it has to be seeded here for the same reason as above.
+  service._positionBackoff = new LRUCache<string, { failures: number; retryAfter: number }>({
+    max: 2_000,
+  });
+  service._submitAttempts = 0;
   service.liquidate = vi.fn(async () => `sig-${service.liquidate.mock.calls.length}`);
   return { service };
 }


### PR DESCRIPTION
## Problem

`LiquidationService`'s dedup state is purely about concurrency, not history:

- `_cycleSeenPositions` / `_cycleOwnerCounts` are cleared every polling cycle (`scanAndLiquidateAll`).
- `_inFlightPositions` only guards true concurrent execution.

Nothing remembers that a `liquidate()` call for a given position **failed**. A position whose liquidation keeps failing — for example, an owner racing a cheap top-up timed to land between the keeper's scan and its pre-submit recheck, repeatedly flipping `stillLiquidatable` to false right before send — gets re-attempted at full transaction-fee cost on **every single polling cycle and LaserStream event, forever**, with zero increasing cost to the owner.

This is an asymmetric-cost DoS surface: the attacker's action (a tiny, cheap on-chain state change) costs far less than the keeper's resulting paid transaction attempt, and no existing breaker catches it — `KeeperBudget`'s circuit breaker is global (cycle/hour/day spend + success-rate), not keyed per-position, so a slow background drain across several flapping accounts can sit under the global threshold indefinitely.

## Production Impact

An attacker can keep N marginal accounts permanently flapping at the liquidation boundary, each costing the keeper a real priority-fee-bearing transaction every ~60s cycle (or faster via LaserStream-triggered re-evaluation), draining the keeper's hot wallet at a steady rate with no alert and no escalating cost to the attacker.

## Fix

Added a per-position failure-backoff map (`_positionBackoff`) in `LiquidationService`, checked in `gatedLiquidate()` (the single entry point for both the polling and LaserStream paths) before the existing in-flight/cycle-dedup checks:

- The **first** failure is free — immediate retry permitted. A single recheck-abort (oracle moved, owner topped up once) is routine and must not delay a position that's still genuinely liquidatable. This preserves the existing `H-1` test's documented intent ("a null (aborted) resolution must release the in-flight guard... otherwise every legitimate recheck-abort would permanently wedge the position").
- From the **second** consecutive failure onward, the retry cooldown escalates exponentially (5s, 10s, 20s, ... capped at 5 minutes — mirroring the existing cycle-level `maxBackoffMs` constant already used for whole-cycle failures).
- A **successful** liquidation clears the position's failure history.
- The position is never permanently skipped — the cooldown always expires, preserving the protocol guarantee that a genuinely undercollateralized position will eventually be liquidated.

This also saves the RPC cost of the expensive pre-submit recheck (oracle drift guard, `stillLiquidatable`, fresh slab fetch) for backed-off positions, not just the final send.

## Proof of Fix

New tests in `tests/services/liquidation.test.ts` (`BUG-103: per-position failure backoff`):
- Allows an immediate retry after exactly one failure (free first failure)
- Throttles a position after repeated consecutive failures — a third immediate call does not re-invoke `liquidate()`
- Clears the backoff once a liquidation lands successfully

## Test Output

```
 Test Files  1 passed (1)
      Tests  35 passed (35)
```

Full suite: 979 passed, 33 skipped, 1 pre-existing unrelated failure (`tests/v17-risk-params.poc.test.ts` — stale assertion from #345, out of scope here).

`pnpm build` — clean, zero errors.