### PR TITLE
fix(keeper): rate-limit per-market event-driven liquidation scans

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -623,6 +623,17 @@ export class LiquidationService {
   /** Per-account debounce timers: slab pubkey → setTimeout handle. */
   private readonly _debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly _DEBOUNCE_MS = 1_000;
+  // BUG-104: the debounce above only coalesces updates *within* one window --
+  // it does not bound the sustained rate of distinct windows. Rapid
+  // open/close/reopen on a single account re-arms a fresh 1s timer each time,
+  // so an owner toggling state just over 1s apart (well under the 60s polling
+  // interval) can force a full scanMarket() + pre-submit RPC fan-out on every
+  // window, far more often than one polling cycle would. This map tracks the
+  // last time an event-driven scan actually ran per market, so a window that
+  // fires too soon after the previous one is deferred (not dropped) instead
+  // of executing immediately.
+  private readonly _lastEventScanAt = new Map<string, number>();
+  private static readonly MIN_EVENT_SCAN_INTERVAL_MS = 5_000;
   private _unsubLoader?: () => void;
   // C1 (post-mainnet-audit): per-cycle dedup keyed on the unique on-chain
   // liquidation target. Legacy slabs use (slabAddress, accountIdx); v17 markets
@@ -1526,6 +1537,50 @@ export class LiquidationService {
     return { scanned, candidates: candidateCount, liquidated };
   }
 
+  /**
+   * BUG-104: runs (or defers) the event-driven scan for one market once its
+   * debounce window has settled. If a scan for this market already ran more
+   * recently than MIN_EVENT_SCAN_INTERVAL_MS, reschedules for the remaining
+   * wait instead of firing immediately or dropping the trigger -- bounding
+   * the worst-case event-scan rate per market without ever silently missing
+   * an update.
+   */
+  private _maybeRunEventScan(slabKey: string, market: DiscoveredMarket): void {
+    const now = Date.now();
+    const last = this._lastEventScanAt.get(slabKey) ?? 0;
+    const elapsed = now - last;
+    if (elapsed < LiquidationService.MIN_EVENT_SCAN_INTERVAL_MS) {
+      const remaining = LiquidationService.MIN_EVENT_SCAN_INTERVAL_MS - elapsed;
+      this._debounceTimers.set(
+        slabKey,
+        setTimeout(() => this._maybeRunEventScan(slabKey, market), remaining),
+      );
+      return;
+    }
+    this._lastEventScanAt.set(slabKey, now);
+    this._debounceTimers.delete(slabKey);
+    // Single-market scan — fire-and-forget; errors logged inside scanMarket.
+    this.scanMarket(market).then(async (candidates) => {
+      for (const c of candidates) {
+        // #218: route through the shared gate so the event path honors the same
+        // per-cycle dedup + per-owner cap as the polling path (no double-liquidation).
+        const sig = await this.gatedLiquidate(market, c);
+        if (sig) {
+          logger.info("Event-driven liquidation complete", {
+            slabAddress: slabKey,
+            accountIdx: c.accountIdx,
+            signature: sig,
+          });
+        }
+      }
+    }).catch((err: unknown) => {
+      logger.warn("Event-driven scan/liquidate failed", {
+        slabAddress: slabKey,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+
   start(getMarkets: () => Map<string, { market: DiscoveredMarket }>): void {
     if (this.timer) return;
     logger.info("Liquidation service starting", { intervalMs: this.intervalMs });
@@ -1610,29 +1665,7 @@ export class LiquidationService {
         if (existing) clearTimeout(existing);
         this._debounceTimers.set(
           slabKey,
-          setTimeout(() => {
-            this._debounceTimers.delete(slabKey);
-            // Single-market scan — fire-and-forget; errors logged inside scanMarket.
-            this.scanMarket(market.market).then(async (candidates) => {
-              for (const c of candidates) {
-                // #218: route through the shared gate so the event path honors the same
-                // per-cycle dedup + per-owner cap as the polling path (no double-liquidation).
-                const sig = await this.gatedLiquidate(market.market, c);
-                if (sig) {
-                  logger.info("Event-driven liquidation complete", {
-                    slabAddress: slabKey,
-                    accountIdx: c.accountIdx,
-                    signature: sig,
-                  });
-                }
-              }
-            }).catch((err: unknown) => {
-              logger.warn("Event-driven scan/liquidate failed", {
-                slabAddress: slabKey,
-                error: err instanceof Error ? err.message : String(err),
-              });
-            });
-          }, this._DEBOUNCE_MS),
+          setTimeout(() => this._maybeRunEventScan(slabKey, market.market), this._DEBOUNCE_MS),
         );
       });
       logger.info("Liquidation service: event-driven mode active", {

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -1466,4 +1466,119 @@ describe('LiquidationService', () => {
       expect(await firstCall).toBe('sig-first');
     });
   });
+
+  // BUG-104: the LaserStream event path's 1s debounce only coalesces updates
+  // *within* one window -- it does not bound the sustained rate of distinct
+  // windows. Rapid open/close/reopen on a single account re-arms a fresh
+  // debounce timer each time, forcing a full scanMarket() RPC fan-out far
+  // more often than the 60s polling cycle would, with no breaker noticing
+  // (no liquidation tx is ever sent, so the SOL-spend budget is untouched --
+  // only RPC quota/CPU is burned).
+  describe('BUG-104: per-market event-scan rate limit', () => {
+    function makeMarketAt(slabAddr: string) {
+      return {
+        slabAddress: { toBase58: () => slabAddr, equals: () => false },
+        programId: { toBase58: () => 'ProgramId1111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'Mint111111111111111111111111111111111111' },
+          oracleAuthority: mockZeroKey(),
+          indexFeedId: mockNonZeroKey('feed'),
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'Admin111111111111111111111111111111111' } },
+      };
+    }
+
+    function setupEventDrivenService(slab: string) {
+      const market = makeMarketAt(slab);
+      let onAccountCb: ((update: { pubkey: string }) => void) | undefined;
+      const accountLoader = {
+        onAccount: (cb: (update: { pubkey: string }) => void) => {
+          onAccountCb = cb;
+          return () => {};
+        },
+      };
+      const svc = new LiquidationService(mockOracleService as any, 60_000, accountLoader as any);
+      const scanMarketSpy = vi.spyOn(svc, 'scanMarket').mockResolvedValue([]);
+      const getMarkets = () => new Map([[slab, { market: market as any }]]);
+      process.env.KEEPER_USE_LASERSTREAM = 'true';
+      svc.start(getMarkets);
+      return {
+        svc,
+        scanMarketSpy,
+        fireUpdate: () => onAccountCb!({ pubkey: slab }),
+      };
+    }
+
+    afterEach(() => {
+      delete process.env.KEEPER_USE_LASERSTREAM;
+    });
+
+    it('debounces a burst of rapid updates into a single scan (existing behavior, unaffected)', async () => {
+      vi.useFakeTimers();
+      try {
+        const { scanMarketSpy, fireUpdate } = setupEventDrivenService(
+          'SlabEvtBurst1111111111111111111111111111111',
+        );
+        fireUpdate();
+        await vi.advanceTimersByTimeAsync(200);
+        fireUpdate(); // re-arms the 1s debounce before it fires
+        await vi.advanceTimersByTimeAsync(1_100);
+        expect(scanMarketSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('defers (does not drop) a second event-scan that arrives within MIN_EVENT_SCAN_INTERVAL_MS of the last one', async () => {
+      vi.useFakeTimers();
+      try {
+        const { scanMarketSpy, fireUpdate } = setupEventDrivenService(
+          'SlabEvtRate1111111111111111111111111111111',
+        );
+
+        // First update: debounce settles after 1s, scan #1 runs immediately
+        // (no prior scan recorded for this market).
+        fireUpdate();
+        await vi.advanceTimersByTimeAsync(1_100);
+        expect(scanMarketSpy).toHaveBeenCalledTimes(1);
+
+        // Second update arrives well over 1s later (debounce settles cleanly)
+        // but under the 5s minimum event-scan interval -- must be deferred,
+        // not executed immediately.
+        fireUpdate();
+        await vi.advanceTimersByTimeAsync(1_100);
+        expect(scanMarketSpy).toHaveBeenCalledTimes(1);
+
+        // Once the remainder of the 5s window elapses, the deferred scan runs.
+        await vi.advanceTimersByTimeAsync(4_000);
+        expect(scanMarketSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('continuous churn produces no more than one scan per rate-limit window, never zero forever', async () => {
+      vi.useFakeTimers();
+      try {
+        const { scanMarketSpy, fireUpdate } = setupEventDrivenService(
+          'SlabEvtChurn1111111111111111111111111111111',
+        );
+
+        // Simulate an attacker toggling state just over the 1s debounce
+        // window, repeatedly, for 12 seconds straight.
+        for (let i = 0; i < 10; i++) {
+          fireUpdate();
+          await vi.advanceTimersByTimeAsync(1_100);
+        }
+        // Bounded: far fewer scans than the 10 updates/11s of churn would
+        // produce with no rate limit (which would be ~10).
+        expect(scanMarketSpy.mock.calls.length).toBeLessThanOrEqual(3);
+        // Not permanently starved either -- at least one scan got through.
+        expect(scanMarketSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The LaserStream event path in `LiquidationService.start()` debounces account updates per market (`_debounceTimers`, keyed by `slabKey`, 1s window) before firing `scanMarket()`. That debounce only coalesces updates **within** one window — it does not bound the *sustained rate* of distinct windows. Each new update clears and restarts a fresh 1s timer for that market, so an owner toggling their own account state just over 1s apart (well under the 60s polling interval) can force a full `scanMarket()` RPC fan-out (`getProgramAccounts`-style scan + `fetchSlabWithRetry`) on every settled window, repeatedly, for as long as the churn continues.

This is invisible to every existing breaker: most of these resolve as "not liquidatable" inside `gatedLiquidate`'s pre-submit recheck and return early, so no liquidation transaction is ever sent — the SOL-spend circuit breaker in `budget.ts` never sees it. Only RPC quota and CPU are burned, and nothing in `account-loader.ts` or `liquidation.ts` bounds event-trigger frequency.

## Production Impact

A single misbehaving (or merely active) account can force the keeper into a sustained, much-higher-than-intended RPC call rate for its market, well beyond what the 60s polling cycle would generate — degrading RPC quota availability for all markets and burning CPU, with no operator-visible signal since no spend/success-rate metric is affected.

## Fix

Added a per-market minimum event-scan interval (`MIN_EVENT_SCAN_INTERVAL_MS = 5_000`) via a new `_maybeRunEventScan()` method, checked when a debounce window settles:
- If no prior scan has run for the market, proceed immediately (first event always reacts fast).
- If a scan for that market ran within the last 5s, **defer** (re-arm the timer for the remaining wait) rather than executing immediately or dropping the trigger.

Sustained churn now produces at most one scan per 5s window per market — a bounded ~12x reduction from the unbounded worst case — while still reacting roughly 12x faster than the 60s polling fallback once churn settles, and never starving a market permanently (the deferred scan always eventually runs).

## Proof of Fix

New tests in `tests/services/liquidation.test.ts` (`BUG-104: per-market event-scan rate limit`):
- Confirms the existing within-window debounce-coalescing behavior is unaffected
- A second event-scan arriving within the 5s window is deferred, not dropped — and runs once the window elapses
- Continuous churn over 11s of simulated time produces far fewer scans than updates, but at least one (no permanent starvation)

## Test Output

```
 Test Files  1 passed (1)
      Tests  35 passed (35)
```

Full suite: 979 passed, 33 skipped, 1 pre-existing unrelated failure (`tests/v17-risk-params.poc.test.ts` — stale assertion from #345, out of scope here).

`pnpm build` — clean, zero errors.