### PR TITLE
fix(keeper): surface oracle staleness in /health's top-level status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -614,6 +614,9 @@ res.writeHead(401, secureJsonHeaders);
       timeSinceLastCrank,
       liqScanRunning: liqScanStatus.running,
       timeSinceLiqScan: liqScanStatus.lastScanTime > 0 ? now - liqScanStatus.lastScanTime : Infinity,
+      // BUG-109: surface the same oracle-staleness signal /pause-status already
+      // reports (stalePausedMarkets) into the top-level health status.
+      stalePausedMarketCount: stalePausedMarkets.size,
     });
     
     // ADL removed in v17 — always disabled.

--- a/src/lib/health-status.ts
+++ b/src/lib/health-status.ts
@@ -11,6 +11,13 @@ export interface HealthStatusInput {
   liqScanRunning: boolean;
   /** Milliseconds since the liquidation scanner's last scan, or Infinity if it has never scanned. */
   timeSinceLiqScan: number;
+  /**
+   * BUG-109: number of markets oracleService.getStaleMarkets() currently
+   * reports as stale-paused (external DexScreener/Jupiter fetch hasn't
+   * succeeded recently for that market). Optional/defaults to 0 so existing
+   * callers/tests that don't pass it are unaffected.
+   */
+  stalePausedMarketCount?: number;
 }
 
 /**
@@ -32,7 +39,15 @@ export interface HealthStatusInput {
 export function computeHealthStatus(
   input: HealthStatusInput,
 ): "ok" | "degraded" | "down" | "starting" {
-  const { uptimeMs, mostRecentCrank, marketsTracked, timeSinceLastCrank, liqScanRunning, timeSinceLiqScan } = input;
+  const {
+    uptimeMs,
+    mostRecentCrank,
+    marketsTracked,
+    timeSinceLastCrank,
+    liqScanRunning,
+    timeSinceLiqScan,
+    stalePausedMarketCount = 0,
+  } = input;
 
   // Grace period: allow 5 minutes after startup before marking as "down".
   if (uptimeMs < 300_000 && mostRecentCrank === 0) {
@@ -58,6 +73,21 @@ export function computeHealthStatus(
       status = "down"; // Liquidation scan stalled >5 min
     } else if (timeSinceLiqScan > 120_000 && status === "ok") {
       status = "degraded"; // Liquidation scan stalled >2 min
+    }
+  }
+
+  // BUG-109: an external oracle outage (DexScreener + Jupiter both down)
+  // already pauses affected HYPERP markets via stalePausedMarkets (visible
+  // on /pause-status), but that signal previously never reached /health's
+  // top-level status -- an operator alerting only on /health would see "ok"
+  // through a real, ongoing oracle outage. Every tracked market stale-paused
+  // is treated as severely as a stalled crank/scan loop; a partial outage
+  // only degrades (never de-escalates an already-"down" status).
+  if (stalePausedMarketCount > 0) {
+    if (marketsTracked > 0 && stalePausedMarketCount >= marketsTracked && status !== "down") {
+      status = "down";
+    } else if (status === "ok") {
+      status = "degraded";
     }
   }
 

--- a/tests/lib/health-status.test.ts
+++ b/tests/lib/health-status.test.ts
@@ -81,4 +81,58 @@ describe("computeHealthStatus", () => {
     });
     expect(status).toBe("ok");
   });
+
+  // BUG-109: an oracle outage already pauses affected markets (visible on
+  // /pause-status via stalePausedMarkets), but that signal never reached
+  // /health's top-level status before this fix.
+  describe("BUG-109: oracle staleness gates status", () => {
+    it("is unaffected when stalePausedMarketCount is omitted (default 0)", () => {
+      expect(computeHealthStatus(base())).toBe("ok");
+    });
+
+    it("is unaffected when stalePausedMarketCount is explicitly 0", () => {
+      const status = computeHealthStatus({ ...base(), stalePausedMarketCount: 0 });
+      expect(status).toBe("ok");
+    });
+
+    it("downgrades 'ok' to 'degraded' when some (but not all) tracked markets are stale-paused", () => {
+      const status = computeHealthStatus({
+        ...base(),
+        marketsTracked: 5,
+        stalePausedMarketCount: 2,
+      });
+      expect(status).toBe("degraded");
+    });
+
+    it("escalates to 'down' when every tracked market is stale-paused", () => {
+      const status = computeHealthStatus({
+        ...base(),
+        marketsTracked: 3,
+        stalePausedMarketCount: 3,
+      });
+      expect(status).toBe("down");
+    });
+
+    it("does not de-escalate an already-'down' status from a partial oracle outage", () => {
+      const status = computeHealthStatus({
+        ...base(),
+        timeSinceLastCrank: 400_000, // already "down" on crank staleness alone
+        marketsTracked: 5,
+        stalePausedMarketCount: 1,
+      });
+      expect(status).toBe("down");
+    });
+
+    it("does not escalate to 'down' from a total oracle outage when marketsTracked is 0", () => {
+      // stalePausedMarketCount can't legitimately exceed marketsTracked, but
+      // marketsTracked===0 must keep short-circuiting to "ok" regardless.
+      const status = computeHealthStatus({
+        ...base(),
+        marketsTracked: 0,
+        timeSinceLastCrank: Infinity,
+        stalePausedMarketCount: 0,
+      });
+      expect(status).toBe("ok");
+    });
+  });
 });


### PR DESCRIPTION
## Problem

An external oracle outage (DexScreener + Jupiter both down) already pauses affected HYPERP markets via `stalePausedMarkets` (`src/index.ts`), correctly visible on `GET /pause-status`. But `/health`'s top-level `status` field is computed by `computeHealthStatus()` (`src/lib/health-status.ts`) using only crank cadence and liquidation-scan liveness — `timeSinceLastOracle` is surfaced as a raw informational JSON field in the `/health` response but never feeds into the `status` decision, and `oracleService.getStaleMarkets()` is never consulted by `/health` at all.

## Production Impact

If all external oracle sources go down simultaneously while the crank loop keeps ticking on schedule (cranking with the on-chain fallback price, capped at `ON_CHAIN_FALLBACK_MAX_MS`), `/health` reports `status: "ok"` / HTTP 200 indefinitely. An operator or orchestrator alerting only on `/health`'s top-level status — the natural single endpoint to watch for uptime/paging — would miss a real, ongoing oracle outage that `/pause-status` already correctly tracks. The two endpoints disagree on health for the same condition.

## Fix

Added an optional `stalePausedMarketCount` input to `computeHealthStatus()`, defaulting to `0` so every existing caller/test is unaffected. Wired from `index.ts`'s existing `stalePausedMarkets` set size. Mirrors the existing crank/liquidation-scan staleness pattern already in this function (the `GH#2025` block):
- A partial outage (some but not all tracked markets stale-paused) degrades `"ok"` → `"degraded"`.
- Every tracked market being stale-paused escalates to `"down"`.
- An already-`"down"` status (e.g. from stalled crank) is never de-escalated by a partial oracle outage.

## Proof of Fix

New tests in `tests/lib/health-status.test.ts` (`BUG-109: oracle staleness gates status`):
- Omitted/zero `stalePausedMarketCount` is a no-op (confirms zero behavior change for existing callers)
- Partial outage degrades `"ok"` to `"degraded"`
- Total outage (every tracked market stale-paused) escalates to `"down"`
- An already-`"down"` status is not de-escalated
- `marketsTracked === 0` still short-circuits to `"ok"` regardless

## Test Output

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

`pnpm build` — clean, zero errors.