### PR TITLE
fix(keeper): pin @percolatorct/shared to its npm release, not a raw git SHA

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#59441ff3",
-    "@percolatorct/shared": "github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f",
+    "@percolatorct/shared": "1.0.0-beta.8",
     "@solana/web3.js": "^1.98.0",
     "@upstash/redis": "^1.38.0",
     "dotenv": "^16.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: github:dcccrypto/percolator-sdk#59441ff3
         version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@percolatorct/shared':
-        specifier: github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f
-        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        specifier: 1.0.0-beta.8
+        version: 1.0.0-beta.8(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -462,12 +462,12 @@ packages:
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e}
     version: 3.0.0
     engines: {node: '>=20.0.0'}
 
-  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f}
+  '@percolatorct/shared@1.0.0-beta.8':
+    resolution: {integrity: sha512-o8h5mL3oqzivUUbgmJ9jQc0nVsMerJf/2vQarZ1lETadNhYj8cPvvhYVbZKCKKw/SqkYn7MDHOYd6oqEw07gEg==}
     version: 1.0.0-beta.8
     peerDependencies:
       '@percolatorct/sdk': '>=2.0.5'
@@ -1891,7 +1891,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/shared@1.0.0-beta.8(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@percolatorct/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@sentry/node': 10.46.0


### PR DESCRIPTION
## Problem

`package.json` pins `@percolatorct/shared` to a raw git commit SHA:

```json
"@percolatorct/shared": "github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f"
```

Resolved via a `codeload.github.com` tarball URL with **no integrity hash** in `pnpm-lock.yaml`. This is a second, distinct non-registry dependency from the already-fixed #326 (which covered `@percolatorct/sdk`'s identical git-SHA-pin problem) — same weakness, different package.

## Production Impact

A force-push or history rewrite at that commit ref (or a compromised GitHub tarball cache) silently changes what production installs, with no npm provenance and no hash to detect tampering on `pnpm install` — on a process that holds a hot signing wallet.

## Fix

The pinned git SHA's own `package.json` reports `"version": "1.0.0-beta.8"`, which is also published to npm under the `beta` dist-tag with a real `sha512` integrity hash. Switched the dependency to that exact version — same code, now hash-verified on every install:

```diff
-"@percolatorct/shared": "github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f",
+"@percolatorct/shared": "1.0.0-beta.8",
```

`pnpm-lock.yaml` now carries a `sha512` integrity hash for this dependency instead of a bare git-tarball reference.

## Proof of Fix

- `pnpm install` — clean; lockfile entry confirmed to carry `integrity: sha512-...`.
- `pnpm build` — clean, zero errors.
- Full test suite: **974 passed, 33 skipped**, 1 pre-existing unrelated failure (`tests/v17-risk-params.poc.test.ts` — stale assertion from #345, out of scope here). No regressions from the dependency swap, confirming the npm-published `1.0.0-beta.8` is behaviorally identical to the previously-pinned git SHA.

## Test Output

```
 Test Files  1 failed | 93 passed | 2 skipped (96)
      Tests  1 failed | 974 passed | 33 skipped (1008)
```