### PR TITLE
fix(keeper): override ws to 8.21.0, closing two reachable memory-exhaustion CVEs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   vite: 8.0.8
+  ws: ^8.21.0
 
 importers:
 
@@ -462,12 +463,12 @@ packages:
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e}
     version: 3.0.0
     engines: {node: '>=20.0.0'}
 
   '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f}
     version: 1.0.0-beta.8
     peerDependencies:
       '@percolatorct/sdk': '>=2.0.5'
@@ -1072,7 +1073,7 @@ packages:
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
     peerDependencies:
-      ws: '*'
+      ws: ^8.21.0
 
   jayson@4.3.0:
     resolution: {integrity: sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==}
@@ -1456,20 +1457,8 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1900,7 +1889,7 @@ snapshots:
       bs58: 6.0.0
       dotenv: 16.6.1
       tweetnacl: 1.0.3
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - bufferutil
@@ -2216,7 +2205,7 @@ snapshots:
       '@supabase/phoenix': 0.4.0
       '@types/ws': 8.18.1
       tslib: 2.8.1
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -2549,9 +2538,9 @@ snapshots:
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
-  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isomorphic-ws@4.0.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -2562,11 +2551,11 @@ snapshots:
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isomorphic-ws: 4.0.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
       uuid: 8.3.2
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -2756,7 +2745,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.4
       uuid: 11.1.0
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
@@ -2882,12 +2871,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-
-  ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 overrides:
   vite: 8.0.8
+  ws: ^8.21.0


### PR DESCRIPTION
## Problem

`pnpm audit` flags two distinct `ws` advisories — both titled "Memory exhaustion DoS from tiny fragments and data chunks" (GHSA-96hv-2xvq-fx4p) — reachable via two separate transitive paths in the resolved dependency tree:

- `rpc-websockets>ws`, pulled in via `@solana/web3.js` for account-subscription websockets (vulnerable `>=8.0.0 <8.21.0`)
- `jayson>isomorphic-ws>ws`, pulled in via `@solana/web3.js`'s JSON-RPC client (vulnerable `>=7.0.0 <7.5.11`)

Both are on the keeper's live account-watching/RPC hot path, not a dev-only dependency.

## Production Impact

A malicious or compromised RPC websocket endpoint could send tiny fragmented frames to exhaust the keeper process's memory, crashing the liquidation/crank loop — availability risk on a 24/7 liquidation bot.

## Fix

Added a `pnpm.overrides` entry in `pnpm-workspace.yaml` forcing `ws` to `^8.21.0` across the whole resolved tree:

```diff
 overrides:
   vite: 8.0.8
+  ws: ^8.21.0
```

`pnpm why ws` confirms a single deduplicated `8.21.0` (patched for both advisories) now replaces the previously-resolved `7.5.10` and `8.20.0`.

## Proof of Fix

- `pnpm install` — clean; `pnpm audit` no longer lists either `ws` advisory.
- `pnpm why ws` — "Found 1 version of ws" (8.21.0), used by both the `rpc-websockets` and `jayson`/`isomorphic-ws` paths.
- `pnpm build` — clean, zero errors.
- Full test suite: **974 passed, 33 skipped**, 1 pre-existing unrelated failure (`tests/v17-risk-params.poc.test.ts` — stale assertion from #345, out of scope here). No regressions from the version bump across either consuming path.

## Test Output

```
 Test Files  1 failed | 93 passed | 2 skipped (96)
      Tests  1 failed | 974 passed | 33 skipped (1008)
```