### PR TITLE
fix(oracle): reject DexScreener pairs where the queried mint is the quote token

### DIFF
--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -40,12 +40,32 @@ const DEX_SCREENER_CACHE_TTL_MS = 10_000;
 const DEX_SCREENER_CACHE_MAX_SIZE = 1_000;
 
 interface DexScreenerResponse {
-  pairs?: Array<{ priceUsd?: string; liquidity?: { usd?: number } }>;
+  pairs?: Array<{
+    priceUsd?: string;
+    liquidity?: { usd?: number };
+    baseToken?: { address?: string };
+    quoteToken?: { address?: string };
+  }>;
 }
 
-function sortPairsByLiquidity(pairs: DexScreenerResponse["pairs"]): DexScreenerResponse["pairs"] {
-  if (!pairs) return pairs;
-  return [...pairs].sort((a, b) => (b.liquidity?.usd ?? 0) - (a.liquidity?.usd ?? 0));
+/**
+ * #380: DexScreener's token endpoint returns every pair the mint appears in —
+ * including pairs where it is the *quote* side. `priceUsd` always describes the
+ * pair's BASE token, so a high-liquidity SOL/USDC pair returned for a USDC query
+ * would otherwise hand back SOL's price as USDC's. Filter to pairs where the
+ * queried mint is the base token before ranking by liquidity.
+ *
+ * Match is exact: Solana mint addresses are base58 and case-significant, so
+ * case-insensitive comparison would risk conflating distinct mints.
+ */
+function selectPairForMint(
+  pairs: DexScreenerResponse["pairs"],
+  mint: string,
+): NonNullable<DexScreenerResponse["pairs"]>[number] | undefined {
+  if (!pairs) return undefined;
+  return pairs
+    .filter((p) => p.baseToken?.address === mint)
+    .sort((a, b) => (b.liquidity?.usd ?? 0) - (a.liquidity?.usd ?? 0))[0];
 }
 
 interface JupiterResponse {
@@ -158,7 +178,7 @@ export class OracleService {
         const age = now - cached.fetchedAt;
         if (age < DEX_SCREENER_CACHE_TTL_MS) {
           // Cache hit — return cached value
-          const pair = sortPairsByLiquidity(cached.data.pairs)?.[0];
+          const pair = selectPairForMint(cached.data.pairs, mint);
           if (!pair?.priceUsd) return null;
           if ((pair.liquidity?.usd ?? 0) < MIN_LIQUIDITY_USD) return null;
           const p = parseFloat(pair.priceUsd);
@@ -190,7 +210,7 @@ export class OracleService {
 
       // M7: Validate BEFORE caching — don't cache bad responses that would
       // suppress fresh fetches for the full TTL window.
-      const pair = sortPairsByLiquidity(json.pairs)?.[0];
+      const pair = selectPairForMint(json.pairs, mint);
       if (!pair?.priceUsd) return null;
       if ((pair.liquidity?.usd ?? 0) < MIN_LIQUIDITY_USD) return null;
       const parsed = parseFloat(pair.priceUsd);

--- a/tests/services/oracle-deviation.test.ts
+++ b/tests/services/oracle-deviation.test.ts
@@ -72,7 +72,7 @@ function freshSlab(): string {
 function mockBothSources(dexUsd: number | null, jupUsd: number | null, mint?: string) {
   const jupKey = mint ?? `MINT_${mintCounter}`;
   const dexResp = dexUsd !== null && dexUsd > 0
-    ? { pairs: [{ priceUsd: String(dexUsd), liquidity: { usd: 500_000 } }] }
+    ? { pairs: [{ priceUsd: String(dexUsd), liquidity: { usd: 500_000 }, baseToken: { address: jupKey } }] }
     : { pairs: [] };
 
   const jupResp = jupUsd !== null && jupUsd > 0
@@ -198,7 +198,7 @@ describe('Cross-source deviation — actual boundary conditions', () => {
     const mint = freshMint();
     // priceUsd='0' → parseFloat=0 → fails >0 check → treated as null → fallback to Jupiter
     vi.mocked(fetch)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ pairs: [{ priceUsd: '0', liquidity: { usd: 500_000 } }] }) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ pairs: [{ priceUsd: '0', liquidity: { usd: 500_000 }, baseToken: { address: mint } }] }) } as Response)
       .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { [mint]: { price: '1.00' } } }) } as Response);
     const r = await svc.fetchPrice(mint, freshSlab());
     expect(r).not.toBeNull();

--- a/tests/services/oracle-quote-token.test.ts
+++ b/tests/services/oracle-quote-token.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Regression tests for #380 — DexScreener quote-side price injection.
+ *
+ * DexScreener's /latest/dex/tokens/<mint> endpoint returns every pair the mint
+ * appears in, including pairs where it is the QUOTE token. `priceUsd` always
+ * describes the pair's BASE token, so accepting the highest-liquidity pair
+ * without checking `baseToken.address` lets an unrelated asset's price be
+ * attributed to the queried mint.
+ *
+ * NOTE: the DexScreener response cache is module-level and keyed by mint, so it
+ * survives both `new OracleService()` and test boundaries. Each test therefore
+ * uses its own unique mint to stay isolated.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+
+global.fetch = vi.fn();
+
+const hoisted = vi.hoisted(() => ({
+  loggerWarn: vi.fn(),
+  sendWarningAlert: vi.fn().mockResolvedValue(undefined),
+  sendCriticalAlert: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@percolatorct/sdk", () => ({
+  encodePushOraclePrice: vi.fn(() => Buffer.from([1])),
+  buildAccountMetas: vi.fn(() => []),
+  buildIx: vi.fn(() => ({})),
+  ACCOUNTS_PUSH_ORACLE_PRICE: {},
+}));
+
+vi.mock("@percolatorct/shared", () => ({
+  config: {
+    programId: "11111111111111111111111111111111",
+    crankKeypair: "mock-keypair-path",
+  },
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: hoisted.loggerWarn,
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  getConnection: vi.fn(() => ({ getAccountInfo: vi.fn() })),
+  loadKeypair: vi.fn(() => ({
+    publicKey: new PublicKey("11111111111111111111111111111111"),
+    secretKey: new Uint8Array(64),
+  })),
+  eventBus: { publish: vi.fn() },
+  getErrorMessage: (err: unknown) => String(err),
+  sendWarningAlert: hoisted.sendWarningAlert,
+  sendCriticalAlert: hoisted.sendCriticalAlert,
+}));
+
+import { OracleService } from "../../src/services/oracle.js";
+
+/** The unrelated high-liquidity asset whose price must never leak through. */
+const OTHER_MINT = "So11111111111111111111111111111111111111112";
+
+/** Unique per-test mint — the module-level response cache is keyed by mint. */
+let mintCounter = 0;
+function uniqueMint(): string {
+  mintCounter += 1;
+  return `Mint${String(mintCounter).padStart(40, "0")}`;
+}
+
+/** Reach the private DexScreener fetch without exercising the whole crank. */
+function fetchDex(oracle: OracleService, mint: string): Promise<bigint | null> {
+  return (
+    oracle as unknown as {
+      _fetchDexScreenerPriceInternal(m: string): Promise<bigint | null>;
+    }
+  )._fetchDexScreenerPriceInternal(mint);
+}
+
+function mockDexPairs(pairs: unknown[]): void {
+  vi.mocked(global.fetch).mockResolvedValue({
+    ok: true,
+    json: async () => ({ pairs }),
+  } as Response);
+}
+
+describe("#380 DexScreener quote-token confusion", () => {
+  let oracle: OracleService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    oracle = new OracleService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects a high-liquidity pair where the queried mint is the quote token", async () => {
+    const mint = uniqueMint();
+    mockDexPairs([
+      {
+        // SOL/<mint>: priceUsd is SOL's price, not the queried mint's.
+        baseToken: { address: OTHER_MINT },
+        quoteToken: { address: mint },
+        priceUsd: "200.00",
+        liquidity: { usd: 50_000_000 },
+      },
+    ]);
+
+    await expect(fetchDex(oracle, mint)).resolves.toBeNull();
+  });
+
+  it("prefers the queried mint's own pair over a higher-liquidity quote-side pair", async () => {
+    const mint = uniqueMint();
+    mockDexPairs([
+      {
+        baseToken: { address: OTHER_MINT },
+        quoteToken: { address: mint },
+        priceUsd: "200.00",
+        liquidity: { usd: 50_000_000 },
+      },
+      {
+        baseToken: { address: mint },
+        quoteToken: { address: OTHER_MINT },
+        priceUsd: "1.0001",
+        liquidity: { usd: 250_000 },
+      },
+    ]);
+
+    // 1.0001 * 1e6 — the queried mint's real price, not SOL's 200.
+    await expect(fetchDex(oracle, mint)).resolves.toBe(1_000_100n);
+  });
+
+  it("still ranks base-token pairs by liquidity", async () => {
+    const mint = uniqueMint();
+    mockDexPairs([
+      { baseToken: { address: mint }, priceUsd: "0.90", liquidity: { usd: 5_000 } },
+      { baseToken: { address: mint }, priceUsd: "1.00", liquidity: { usd: 900_000 } },
+    ]);
+
+    await expect(fetchDex(oracle, mint)).resolves.toBe(1_000_000n);
+  });
+
+  it("rejects pairs that omit baseToken entirely", async () => {
+    const mint = uniqueMint();
+    mockDexPairs([{ priceUsd: "200.00", liquidity: { usd: 50_000_000 } }]);
+
+    await expect(fetchDex(oracle, mint)).resolves.toBeNull();
+  });
+
+  it("does not match a mint that differs only by case", async () => {
+    const mint = uniqueMint();
+    mockDexPairs([
+      {
+        baseToken: { address: mint.toUpperCase() },
+        priceUsd: "200.00",
+        liquidity: { usd: 50_000_000 },
+      },
+    ]);
+
+    await expect(fetchDex(oracle, mint)).resolves.toBeNull();
+  });
+
+  it("applies the base-token check on the cached path too", async () => {
+    const mint = uniqueMint();
+    // A response containing both a quote-side pair (higher liquidity) and a
+    // legitimate base-side pair caches successfully on the fresh path...
+    mockDexPairs([
+      {
+        baseToken: { address: OTHER_MINT },
+        quoteToken: { address: mint },
+        priceUsd: "200.00",
+        liquidity: { usd: 50_000_000 },
+      },
+      {
+        baseToken: { address: mint },
+        quoteToken: { address: OTHER_MINT },
+        priceUsd: "1.0001",
+        liquidity: { usd: 250_000 },
+      },
+    ]);
+    await expect(fetchDex(oracle, mint)).resolves.toBe(1_000_100n);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    // ...and the subsequent cache hit must re-apply the same filter rather than
+    // taking the highest-liquidity (quote-side) pair off the cached payload.
+    await expect(fetchDex(oracle, mint)).resolves.toBe(1_000_100n);
+    expect(global.fetch).toHaveBeenCalledTimes(1); // served from cache
+  });
+});

--- a/tests/services/oracle-stale.test.ts
+++ b/tests/services/oracle-stale.test.ts
@@ -65,7 +65,11 @@ describe('OracleService.getStaleMarkets', () => {
     vi.mocked(fetch).mockImplementation(async (input: any) => {
       const url = String(input);
       if (url.includes('dexscreener')) {
-        return { ok: true, json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }] }) } as any;
+        // Thread the queried mint out of the request URL so the fixture's
+        // baseToken always matches whichever mint is being fetched (MINT_A,
+        // MINT_C, MINT_E, MINT_X, MINT_Y, ...).
+        const dexMint = decodeURIComponent(url.split('/tokens/')[1] ?? '');
+        return { ok: true, json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 }, baseToken: { address: dexMint } }] }) } as any;
       }
       const mint = decodeURIComponent(url.split('ids=')[1] ?? '');
       return { ok: true, json: async () => ({ data: { [mint]: { price: '1.00' } } }) } as any;

--- a/tests/services/oracle.b-fixes.test.ts
+++ b/tests/services/oracle.b-fixes.test.ts
@@ -56,11 +56,11 @@ const sendWarningAlert = hoisted.sendWarningAlert;
 
 import { OracleService } from "../../src/services/oracle.js";
 
-function mockDexResponse(priceUsd: string, liquidityUsd = 100_000) {
+function mockDexResponse(priceUsd: string, mint: string, liquidityUsd = 100_000) {
   vi.mocked(fetch).mockResolvedValueOnce({
     ok: true,
     json: async () => ({
-      pairs: [{ priceUsd, liquidity: { usd: liquidityUsd } }],
+      pairs: [{ priceUsd, liquidity: { usd: liquidityUsd }, baseToken: { address: mint } }],
     }),
   } as any);
 }
@@ -84,14 +84,14 @@ describe("oracle B-fixes — B8 priceE6===0n short-circuit", () => {
   afterEach(() => vi.restoreAllMocks());
 
   it("DexScreener: rejects sub-precision prices that would round to 0n", async () => {
-    mockDexResponse("0.0000001"); // 0.0000001 * 1e6 = 0.1 → rounds to 0
+    mockDexResponse("0.0000001", "MINT_B8_1"); // 0.0000001 * 1e6 = 0.1 → rounds to 0
     const p = await svc.fetchDexScreenerPrice("MINT_B8_1");
     expect(p).toBeNull();
   });
 
   it("DexScreener: cached-hit branch also rejects 0n prices", async () => {
     // first call fills cache (sub-precision)
-    mockDexResponse("0.0000004");
+    mockDexResponse("0.0000004", "MINT_B8_2");
     const first = await svc.fetchDexScreenerPrice("MINT_B8_2");
     expect(first).toBeNull();
 
@@ -107,7 +107,7 @@ describe("oracle B-fixes — B8 priceE6===0n short-circuit", () => {
   });
 
   it("DexScreener: still returns the price for legit values", async () => {
-    mockDexResponse("0.5"); // 500_000
+    mockDexResponse("0.5", "MINT_B8_4"); // 500_000
     const p = await svc.fetchDexScreenerPrice("MINT_B8_4");
     expect(p).toBe(500_000n);
   });

--- a/tests/services/oracle.test.ts
+++ b/tests/services/oracle.test.ts
@@ -64,6 +64,7 @@ describe('OracleService', () => {
           {
             priceUsd: '1.23',
             liquidity: { usd: 100000 },
+            baseToken: { address: 'MINT_UNIQUE_1' },
           },
         ],
       };
@@ -96,6 +97,7 @@ describe('OracleService', () => {
           {
             priceUsd: 'invalid',
             liquidity: { usd: 100000 },
+            baseToken: { address: 'MINT_INVALID' },
           },
         ],
       };
@@ -132,6 +134,7 @@ describe('OracleService', () => {
           {
             priceUsd: '2.50',
             liquidity: { usd: 200000 },
+            baseToken: { address: 'MINT_CACHE_TEST' },
           },
         ],
       };
@@ -154,10 +157,10 @@ describe('OracleService', () => {
 
     it('should refetch after cache TTL expires', async () => {
       const mockResponse1 = {
-        pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }],
+        pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 }, baseToken: { address: 'MINT_TTL_TEST' } }],
       };
       const mockResponse2 = {
-        pairs: [{ priceUsd: '2.00', liquidity: { usd: 200000 } }],
+        pairs: [{ priceUsd: '2.00', liquidity: { usd: 200000 }, baseToken: { address: 'MINT_TTL_TEST' } }],
       };
 
       let callCount = 0;
@@ -219,7 +222,7 @@ describe('OracleService', () => {
     it('should reject prices with >10% divergence between sources', async () => {
       // DexScreener: $1.00
       const dexResponse = {
-        pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }],
+        pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 }, baseToken: { address: 'MINT999' } }],
       };
 
       // Jupiter: $1.50 (50% divergence)
@@ -241,7 +244,7 @@ describe('OracleService', () => {
     it('should accept prices with <10% divergence', async () => {
       // DexScreener: $1.00
       const dexResponse = {
-        pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }],
+        pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 }, baseToken: { address: 'MINT888' } }],
       };
 
       // Jupiter: $1.05 (5% divergence)
@@ -267,7 +270,7 @@ describe('OracleService', () => {
       // Seed history with $1.00 for SLAB_HISTDEV
       vi.mocked(fetch)
         .mockResolvedValueOnce({
-          ok: true, json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }] }),
+          ok: true, json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 }, baseToken: { address: 'MINT_HISTDEV_A' } }] }),
         } as any)
         .mockResolvedValueOnce({
           ok: true, json: async () => ({ data: { MINT_HISTDEV_A: { price: '1.00' } } }),
@@ -282,7 +285,7 @@ describe('OracleService', () => {
       // but fails the >30% historical deviation check.
       vi.mocked(fetch)
         .mockResolvedValueOnce({
-          ok: true, json: async () => ({ pairs: [{ priceUsd: '1.50', liquidity: { usd: 100000 } }] }),
+          ok: true, json: async () => ({ pairs: [{ priceUsd: '1.50', liquidity: { usd: 100000 }, baseToken: { address: 'MINT_HISTDEV_B' } }] }),
         } as any)
         .mockResolvedValueOnce({
           ok: true, json: async () => ({ data: { MINT_HISTDEV_B: { price: '1.50' } } }),
@@ -296,7 +299,7 @@ describe('OracleService', () => {
       // Seed history with $1.00 for SLAB_HISTDEV2
       vi.mocked(fetch)
         .mockResolvedValueOnce({
-          ok: true, json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }] }),
+          ok: true, json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 }, baseToken: { address: 'MINT_HISTDEV2_A' } }] }),
         } as any)
         .mockResolvedValueOnce({
           ok: true, json: async () => ({ data: { MINT_HISTDEV2_A: { price: '1.00' } } }),
@@ -308,7 +311,7 @@ describe('OracleService', () => {
       // New price = $1.20 (20% above history) — within 30% threshold → accepted
       vi.mocked(fetch)
         .mockResolvedValueOnce({
-          ok: true, json: async () => ({ pairs: [{ priceUsd: '1.20', liquidity: { usd: 100000 } }] }),
+          ok: true, json: async () => ({ pairs: [{ priceUsd: '1.20', liquidity: { usd: 100000 }, baseToken: { address: 'MINT_HISTDEV2_B' } }] }),
         } as any)
         .mockResolvedValueOnce({
           ok: true, json: async () => ({ data: { MINT_HISTDEV2_B: { price: '1.20' } } }),
@@ -323,7 +326,7 @@ describe('OracleService', () => {
       // First call for a brand-new slab → no history → no deviation check → accepted
       vi.mocked(fetch)
         .mockResolvedValueOnce({
-          ok: true, json: async () => ({ pairs: [{ priceUsd: '9999.00', liquidity: { usd: 100000 } }] }),
+          ok: true, json: async () => ({ pairs: [{ priceUsd: '9999.00', liquidity: { usd: 100000 }, baseToken: { address: 'MINT_HISTDEV3' } }] }),
         } as any)
         .mockResolvedValueOnce({
           ok: true, json: async () => ({ data: { MINT_HISTDEV3: { price: '9999.00' } } }),
@@ -351,7 +354,10 @@ describe('OracleService', () => {
       vi.mocked(fetch).mockImplementation(async (url) => {
         const u = typeof url === 'string' ? url : (url as Request).toString();
         if (u.includes('dexscreener')) {
-          return { ok: true, json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }] }) } as any;
+          // Thread the queried mint out of the request URL so the fixture's
+          // baseToken always matches whichever mint is being fetched.
+          const dexMint = decodeURIComponent(u.split('/tokens/')[1] ?? 'UNKNOWN');
+          return { ok: true, json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 }, baseToken: { address: dexMint } }] }) } as any;
         }
         const m = u.match(/ids=([^&]+)/);
         const mint = m ? decodeURIComponent(m[1]!) : 'UNKNOWN';
@@ -426,7 +432,7 @@ describe('OracleService', () => {
   describe('price history tracking', () => {
     it('should track price history up to max entries per market', async () => {
       const mockResponse = {
-        pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }],
+        pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 }, baseToken: { address: 'MINT_HISTORY' } }],
       };
 
       vi.mocked(fetch).mockResolvedValue({
@@ -447,14 +453,17 @@ describe('OracleService', () => {
     });
 
     it('should track up to max markets (500)', async () => {
-      const mockResponse = {
-        pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 } }],
-      };
-
-      vi.mocked(fetch).mockResolvedValue({
-        ok: true,
-        json: async () => mockResponse,
-      } as any);
+      // Different mints are fetched across this loop (MINT0..MINT500), so the
+      // fixture must thread the actual queried mint out of the request URL
+      // rather than hardcoding a single baseToken address.
+      vi.mocked(fetch).mockImplementation(async (url) => {
+        const u = typeof url === 'string' ? url : (url as Request).toString();
+        const mint = decodeURIComponent(u.split('/tokens/')[1] ?? 'UNKNOWN');
+        return {
+          ok: true,
+          json: async () => ({ pairs: [{ priceUsd: '1.00', liquidity: { usd: 100000 }, baseToken: { address: mint } }] }),
+        } as any;
+      });
 
       // Add first market
       await oracleService.fetchPrice('MINT0', 'SLAB0');
@@ -479,7 +488,7 @@ describe('OracleService', () => {
   describe('in-flight request deduplication', () => {
     it('should deduplicate concurrent DexScreener requests', async () => {
       const mockResponse = {
-        pairs: [{ priceUsd: '3.14', liquidity: { usd: 100000 } }],
+        pairs: [{ priceUsd: '3.14', liquidity: { usd: 100000 }, baseToken: { address: 'MINT_DEDUP' } }],
       };
 
       let fetchCount = 0;
@@ -539,7 +548,7 @@ describe('OracleService', () => {
   describe('getCurrentPrice', () => {
     it('should return latest price from history', async () => {
       const mockResponse = {
-        pairs: [{ priceUsd: '4.56', liquidity: { usd: 100000 } }],
+        pairs: [{ priceUsd: '4.56', liquidity: { usd: 100000 }, baseToken: { address: 'MINT_CURRENT' } }],
       };
 
       vi.mocked(fetch).mockResolvedValue({


### PR DESCRIPTION
Closes #380 — `[SECURITY][HIGH]` DexScreener quote-side pairs can inject another asset's price.

## What changed

`src/services/oracle.ts` discarded pair identity when parsing DexScreener responses:

```ts
interface DexScreenerResponse {
  pairs?: Array<{ priceUsd?: string; liquidity?: { usd?: number } }>;
}
const pair = sortPairsByLiquidity(json.pairs)?.[0];
```

DexScreener's `/latest/dex/tokens/<mint>` endpoint returns **every** pair the mint appears in, including pairs where it is the *quote* token — but `priceUsd` always describes the pair's **base** token. Nothing referenced the queried `mint`.

`sortPairsByLiquidity()` is replaced by `selectPairForMint(pairs, mint)`, which filters to pairs whose `baseToken.address` exactly equals the queried mint before ranking by liquidity. Applied on **both** the fresh-fetch and cache-hit paths (the original bug was present in both).

## Why it matters

`fetchPrice()` accepts DexScreener as a single source whenever Jupiter returns null. During a Jupiter outage, a high-liquidity `SOL/USDC` pair returned for a USDC query would make the keeper treat **SOL's** price as USDC's — feeding a wildly wrong price into cranks and liquidations.

## Design decisions

- **Fail-closed.** A pair with no `baseToken` is rejected rather than trusted. The real API always returns it, so its absence means a malformed or changed upstream response — better to fall back to Jupiter / on-chain than to publish a price we cannot attribute.
- **Exact match, not case-insensitive.** Solana mint addresses are base58 and case-significant; a loose compare could conflate distinct mints.

## Testing

New `tests/services/oracle-quote-token.test.ts` (6 tests): quote-side rejection, base-side preference over a 200x-higher-liquidity quote pair, liquidity ranking still intact, missing-`baseToken` rejection, case-sensitivity, and the cached path.

**Verified non-vacuous:** with the source fix reverted, 5 of the 6 fail. The 6th (liquidity ranking) passes either way by design — it is the no-regression guard.

- `npx vitest run tests/services/` → **230 passed, 11 skipped, 0 failed** (19 files)
- Pre-existing fixtures mocked pairs without `baseToken`, so they were correctly rejected by the new filter and needed updating to match what the real API returns. Where a single mock backs several mints, the mint is threaded from the request URL so each pair gets its own correct `baseToken` and no test passes vacuously. No assertions or expected values were changed.

## Note for reviewers

`npx tsc --noEmit` reports 3 errors (`closeQ` / `PermissionlessCrankArgs` in `crank.ts` and `liquidation.ts`). These are **pre-existing and unrelated** — byte-identical on `origin/main` before this branch. Flagging separately; likely SDK type drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price selection from market data by ensuring the queried token is the pair’s base token.
  * Prevented incorrect prices from quote-token pairs and unsupported or incomplete responses.
  * Improved cache recency handling and added warnings when price retrieval fails.

* **Tests**
  * Added regression coverage for token matching, caching, malformed responses, and price-selection edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->