### PR TITLE
fix(docker): copy pnpm-workspace.yaml so overrides match the lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,12 @@ RUN corepack enable && corepack prepare pnpm@10 --activate
 
 WORKDIR /app
 
-# Copy package files
-COPY package.json pnpm-lock.yaml ./
+# Copy package files. pnpm-workspace.yaml is required: it is where pnpm.overrides
+# now live (moved out of package.json in 989d893), and --frozen-lockfile compares
+# the resolved overrides against the ones recorded in pnpm-lock.yaml. Without this
+# file pnpm sees no overrides, disagrees with the lockfile, and fails the build
+# with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # SDK is now on npm (@percolatorct/sdk) — no vendor directory needed
 
@@ -32,8 +36,9 @@ RUN corepack enable && corepack prepare pnpm@10 --activate
 
 WORKDIR /app
 
-# Copy package files for prod-only install
-COPY package.json pnpm-lock.yaml ./
+# Copy package files for prod-only install. pnpm-workspace.yaml carries the
+# overrides the lockfile was resolved with — see the builder stage above.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # K-NEW-1: install production deps only — excludes vitest, vite, tsx, @types/*
 # and their associated CVEs from the final image. (pnpm install --prod is deprecated;


### PR DESCRIPTION
Fixes the `docker` job, which has failed on **every push to main since 2026-06-22** (~4 weeks).

## Symptom

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

## Root cause

`989d893` moved `pnpm.overrides` out of `package.json` and into `pnpm-workspace.yaml`. The Dockerfile only ever copied `package.json` and `pnpm-lock.yaml`, so inside the image pnpm resolved **zero** overrides while `pnpm-lock.yaml` still recorded `overrides: vite: 8.0.8`. `--frozen-lockfile` refuses to proceed on that disagreement.

The tell that makes this easy to misdiagnose: CI's `build-and-test` job runs **the same pnpm 10** and **the same `--frozen-lockfile`**, and passes. It passes only because `actions/checkout` gives it the entire repo, `pnpm-workspace.yaml` included. Just the docker build, with its narrower `COPY` context, was missing the file. So this is *not* a pnpm-version problem, despite the `10.34.5 → 11.14.0` upgrade notice in the failing log.

## Fix

Copy `pnpm-workspace.yaml` in both the builder and runner stages.

## Why not just regenerate the lockfile

The obvious-looking fix — `pnpm install --no-frozen-lockfile` to make the lockfile agree with an empty override set — would have **silently dropped a security pin**. That override is the `K-1` HIGH CVE mitigation from `192d1b5`: vite pinned to 8.0.8, closing GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583, and GHSA-4w7w-66w2-5vf9. The correct direction is to give pnpm the overrides file, not to relax the lockfile.

## Verification

Docker daemon isn't available in this environment, so I replicated **each stage's exact COPY context** into a scratch directory against pnpm 10.33.0 (same major as both CI and the image):

| Stage context | Command | Result |
|---|---|---|
| `package.json` + `pnpm-lock.yaml` (current) | `pnpm install --frozen-lockfile` | ❌ exit 1, reproduces the exact CI error |
| \+ `pnpm-workspace.yaml` (this PR) | `pnpm install --frozen-lockfile` | ✅ exit 0 |
| \+ `pnpm-workspace.yaml` (this PR) | `pnpm install --frozen-lockfile --prod` | ✅ exit 0 |

`pnpm why vite` in the fixed builder context resolves to **`vite@8.0.8`**, confirming the K-1 pin is actually applied rather than merely unblocked.

Also confirmed there is no `.dockerignore` that would exclude the file, and that `pnpm-workspace.yaml` is git-tracked and therefore present in the build context.

## Reviewer note

PR #371 adds a second override (`ws` → 8.21.0). Whichever of these two lands second should confirm the new override is declared in `pnpm-workspace.yaml` (not `package.json`) and is reflected in `pnpm-lock.yaml`, or the same mismatch returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)