### PR TITLE
ci(sdk-smoke): drop invalid --no-frozen-lockfile from `pnpm add`

### DIFF
--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -74,17 +74,19 @@ jobs:
 
       # Install dependencies from the *existing* lockfile first so all other
       # packages (vitest, @solana/web3.js …) are present, then override
-      # only the SDK dep to the target npm version.  --no-frozen-lockfile is
-      # intentional: we are mutating one dep, not reproducing a build.
+      # only the SDK dep to the target npm version.
       - name: Install dependencies (frozen lockfile for non-SDK packages)
         run: pnpm install --frozen-lockfile
 
+      # `pnpm add` rewrites the lockfile by design and does NOT accept
+      # --no-frozen-lockfile (that flag belongs to `pnpm install`). Passing it
+      # made pnpm 10 abort with `Unknown option: 'frozen-lockfile'`, failing
+      # this job on every nightly run.
       - name: Override SDK dep with published npm version
         env:
           TARGET_VER: ${{ steps.sdk_ver.outputs.version }}
         run: |
-          pnpm add "@percolatorct/sdk@${TARGET_VER}" \
-            --no-frozen-lockfile
+          pnpm add "@percolatorct/sdk@${TARGET_VER}"
 
       - name: Verify installed SDK version
         env:


### PR DESCRIPTION
## Problem

The nightly **SDK publish smoke** job has been failing on every scheduled run (e.g. [29731320027](https://github.com/dcccrypto/percolator-keeper/actions/runs/29731320027), and the 2026-07-19 run before it):

```
ERROR  Unknown option: 'frozen-lockfile'
Process completed with exit code 1
```

## Root cause

`--no-frozen-lockfile` is an option of **`pnpm install`**, not **`pnpm add`**. pnpm 10 rejects unknown options outright, so the *Override SDK dep* step aborted before installing the target SDK version.

This matters beyond the red X: the job **never actually smoke-tested the published SDK**. It failed at dependency setup, so a genuine publish regression would have looked identical to this flag bug.

The flag was also unnecessary — `pnpm add` rewrites the lockfile by design, which is exactly the "mutate one dep, not reproduce a build" behaviour the original comment described.

## Verification

Against pnpm 10.33.0 (the version this workflow pins):

| command | result |
|---|---|
| `pnpm add is-odd@3.0.1 --no-frozen-lockfile` | `ERROR Unknown option: 'frozen-lockfile'` |
| `pnpm add is-odd@3.0.1` | `+ is-odd 3.0.1` |
| `CI=true pnpm add is-even@1.0.0` | `+ is-even 1.0.0` |

`CI=true` matters because pnpm defaults `frozen-lockfile` to true for `install` under CI — but that default does not apply to `add`. Neither repo has an `.npmrc` pinning it, so no override is needed.

## Related

percolator-indexer has the identical bug — companion PR filed there. Its copy of this workflow was also missing the `env:` hardening this repo already has, so that PR carries an injection fix too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)