### PR TITLE
fix(liquidation): v17 pre-submit re-verification must fail closed (#373)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -1107,6 +1107,25 @@ export class LiquidationService {
       if (v17PortfolioPubkey) {
         // v17 verification: re-fetch portfolio and confirm still undercollateralized.
         // Skip the slab bitmap path (parseUsedIndices/parseAccount) which doesn't apply.
+        //
+        // #373: the try below wraps ONLY the fetch/parse of re-verification data,
+        // and fails CLOSED. It previously wrapped the drift guard and the margin
+        // recheck too, with an empty catch — so any throw (a malformed wrapper
+        // blob in parseWrapperConfigV17, a fetchClusterUnixTimeSec error, the
+        // M-6 owner-check failure in fetchSlabWithRetry) fell straight through to
+        // the send with NO checks applied.
+        //
+        // That mattered most for the oracle-drift guard, which has no on-chain
+        // counterpart: "The on-chain Liquidate instruction carries no price bound,
+        // so keeper-side drift detection is the only available mitigation." Losing
+        // it means submitting at unbounded drift with no backstop anywhere.
+        //
+        // The v12.x path below is unwrapped and already fails closed; this makes
+        // the live v17 mainnet path match it.
+        let pf: ReturnType<typeof parsePortfolioV17>;
+        let freshMarketData: Uint8Array;
+        let freshPrice: bigint;
+        let freshRiskParams: { maintenanceMarginBps: bigint; minNonzeroMmReq: bigint } | null = null;
         try {
           const pfInfo = await withTimeout(
             connection.getAccountInfo(v17PortfolioPubkey),
@@ -1120,7 +1139,7 @@ export class LiquidationService {
             });
             return null;
           }
-          const pf = parsePortfolioV17(new Uint8Array(pfInfo.data));
+          pf = parsePortfolioV17(new Uint8Array(pfInfo.data));
           // Check there's still an active position
           const hasActive = pf.legs.some(l => l.active && l.basisPosQ !== 0n);
           if (!hasActive) {
@@ -1136,7 +1155,7 @@ export class LiquidationService {
           // equity as the scanner (#230). scanPriceE6 is the scan-time price; if it's
           // unavailable (0) we keep the leg-active check + rely on the on-chain program.
           // #287 (M-6): pass programId so fetchSlab enforces the on-chain owner check.
-          const freshMarketData = await fetchSlabWithRetry(slabAddress, programId);
+          freshMarketData = await fetchSlabWithRetry(slabAddress, programId);
           // H-8: isolate this call from the outer "proceed cautiously" catch --
           // that catch's fail-open posture is meant for transient RPC failures
           // preventing re-verification entirely, not for "we got data back but
@@ -1144,7 +1163,6 @@ export class LiquidationService {
           // (which would fall through to submitting the liquidation
           // unconditionally) -- degrade to relying on the equity<=0n signal
           // alone instead.
-          let freshRiskParams: { maintenanceMarginBps: bigint; minNonzeroMmReq: bigint } | null = null;
           try {
             const parsed = parseV17RiskParams(freshMarketData);
             freshRiskParams = {
@@ -1160,7 +1178,23 @@ export class LiquidationService {
             }
           }
           const freshNowSec = await fetchClusterUnixTimeSec(connection);
-          const freshPrice = resolveV17WrapperPrice(parseWrapperConfigV17(freshMarketData), freshNowSec);
+          freshPrice = resolveV17WrapperPrice(parseWrapperConfigV17(freshMarketData), freshNowSec);
+        } catch (err) {
+          // #373: FAIL CLOSED. We could not obtain the data the drift guard and
+          // margin recheck depend on, so we cannot assert either. Skipping this
+          // submit costs one liquidation attempt (the next scan cycle retries);
+          // proceeding would submit at unbounded drift with no on-chain bound.
+          logger.warn("v17 liquidate: pre-submit re-verification failed, aborting (fail closed)", {
+            portfolio: v17PortfolioPubkey.toBase58().slice(0, 8),
+            slabAddress: slabAddress.toBase58().slice(0, 8),
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return null;
+        }
+
+        // ── Checks below run OUTSIDE the try: a throw here must abort the
+        //    submit, never be swallowed into proceeding. ──────────────────────
+        {
           if (freshPrice === 0n) {
             logger.warn("v17 liquidate: no fresh price available for pre-submit recheck, aborting", {
               portfolio: v17PortfolioPubkey.toBase58().slice(0, 8),
@@ -1241,9 +1275,6 @@ export class LiquidationService {
               instructions[0] = buildIx({ programId, keys: crankKeys, data: updatedCrankData });
             }
           }
-        } catch {
-          // If we can't re-verify, proceed cautiously — the on-chain program
-          // will reject if the portfolio is already closed.
         }
       } else {
       // Bug 3: Re-read slab data and verify account before submitting (v12.x path)

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -165,6 +165,7 @@ import { LiquidationService } from '../../src/services/liquidation.js';
 import * as core from '@percolatorct/sdk';
 import * as shared from '@percolatorct/shared';
 import * as keeperSendModule from '../../src/lib/keeper-send.js';
+import * as v17risk from '../../src/lib/v17-risk.js';
 
 // Zero key (all zeros) - used for Pyth-pinned oracleAuthority and Hyperp indexFeedId
 const ZERO_KEY = (() => {
@@ -684,6 +685,156 @@ describe('LiquidationService', () => {
   });
 
   describe('liquidate', () => {
+    // #373: the v17 pre-submit re-verification used to wrap the drift guard and
+    // the margin recheck in `try { … } catch { /* proceed cautiously */ }`. Any
+    // throw inside it fell through to the send with NO checks applied — and the
+    // oracle-drift guard has no on-chain counterpart, so a drifted liquidation
+    // had no backstop anywhere. It must fail CLOSED instead.
+    describe('#373: pre-submit re-verification fails closed', () => {
+      function v17Fixture() {
+        const nowSec = BigInt(Math.floor(Date.now() / 1000));
+        const clockData = Buffer.alloc(40);
+        clockData.writeBigInt64LE(nowSec, 32);
+        const slabAddress = new PublicKey('11111111111111111111111111111111');
+        const portfolioPubkey = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+        const connection = {
+          getSlot: vi.fn(async () => 200),
+          getAccountInfo: vi.fn(async (pubkey: PublicKey) => {
+            if (pubkey.toBase58() === portfolioPubkey.toBase58()) {
+              return { data: new Uint8Array([1, 2, 3]) };
+            }
+            return { data: clockData };
+          }),
+        };
+
+        vi.mocked(shared.getConnection)
+          .mockReturnValueOnce(connection as any)
+          .mockReturnValueOnce(connection as any);
+        vi.mocked(core.fetchSlab).mockResolvedValueOnce(new Uint8Array(512));
+        vi.mocked(core.parsePortfolioV17).mockReturnValueOnce({
+          owner: new PublicKey('So11111111111111111111111111111111111111112'),
+          capital: 1_000_000n,
+          pnl: 0n,
+          feeCredits: 0n,
+          legs: [{ active: true, basisPosQ: 100_000_000_000n, assetIndex: 0 }],
+        } as any);
+
+        const market = {
+          slabAddress,
+          programId: slabAddress,
+          config: {
+            collateralMint: slabAddress,
+            oracleAuthority: mockNonZeroKey(),
+            indexFeedId: mockZeroKey(),
+          },
+          params: { maintenanceMarginBps: 500n },
+          header: { admin: mockZeroKey() },
+        };
+
+        return { market, portfolioPubkey, nowSec };
+      }
+
+      it('does NOT submit when parseWrapperConfigV17 throws on malformed wrapper bytes', async () => {
+        const { market, portfolioPubkey } = v17Fixture();
+
+        // The exact trigger from the report: malformed/edge wrapper bytes. The
+        // throw lands before the drift guard, the freshPrice===0 abort and the
+        // margin recheck have run.
+        vi.mocked(core.parseWrapperConfigV17).mockImplementationOnce(() => {
+          throw new RangeError('offset is out of bounds');
+        });
+
+        const sig = await liquidationService.liquidate(
+          market as any,
+          0,
+          portfolioPubkey,
+          1_000_000n,
+          100_000_000_000n,
+        );
+
+        expect(sig).toBeNull();
+        expect(keeperSendModule.keeperSend).not.toHaveBeenCalled();
+      });
+
+      it('does NOT submit when the slab re-fetch throws (M-6 owner-check failure)', async () => {
+        const { market, portfolioPubkey } = v17Fixture();
+
+        // fetchSlabWithRetry surfaces the on-chain owner-check failure as a
+        // throw; swallowing it would submit against an unverified slab.
+        vi.mocked(core.fetchSlab).mockReset();
+        vi.mocked(core.fetchSlab).mockRejectedValue(
+          new Error('slab account not owned by expected program'),
+        );
+
+        const sig = await liquidationService.liquidate(
+          market as any,
+          0,
+          portfolioPubkey,
+          1_000_000n,
+          100_000_000_000n,
+        );
+
+        expect(sig).toBeNull();
+        expect(keeperSendModule.keeperSend).not.toHaveBeenCalled();
+      });
+
+      it('still RUNS the drift + margin checks when re-verification succeeds', async () => {
+        // The contrast case. Without it, "fail closed" could be implemented as
+        // "always return null" and the two tests above would still pass.
+        //
+        // Asserted via readRawOracleTargetPriceForAsset, which
+        // evaluateV17PortfolioHealth reads (#335) — it is only reachable once
+        // execution gets PAST the fetch/parse block into the margin recheck.
+        // (Asserting an actual submit would need a realistic v17 slab buffer;
+        // no test in this suite has one, and a fake would prove nothing.)
+        const { market, portfolioPubkey, nowSec } = v17Fixture();
+
+        vi.mocked(core.parseWrapperConfigV17).mockReturnValueOnce({
+          oracleMode: 2, // EWMA_MARK
+          maxStalenessSecs: 60n,
+          oracleTargetPriceE6: 0n,
+          // Must be fresh: resolveV17WrapperPrice returns 0n for a stale EWMA,
+          // which would abort on the freshPrice===0 guard before the drift and
+          // margin checks — i.e. this test would pass for the wrong reason.
+          oracleTargetPublishTime: nowSec,
+          markEwmaE6: 1_000_000n, // == scanPriceE6 → zero drift, so the guard passes
+        } as any);
+        vi.mocked(v17risk.readRawOracleTargetPriceForAsset).mockClear();
+
+        await liquidationService.liquidate(
+          market as any,
+          0,
+          portfolioPubkey,
+          1_000_000n,
+          100_000_000_000n,
+        );
+
+        expect(v17risk.readRawOracleTargetPriceForAsset).toHaveBeenCalled();
+      });
+
+      it('never reaches the margin recheck when re-verification throws', async () => {
+        // Mirror of the assertion above — proves the fail-closed path really
+        // does skip the downstream work, rather than the two just differing by
+        // return value.
+        const { market, portfolioPubkey } = v17Fixture();
+
+        vi.mocked(core.parseWrapperConfigV17).mockImplementationOnce(() => {
+          throw new RangeError('offset is out of bounds');
+        });
+        vi.mocked(v17risk.readRawOracleTargetPriceForAsset).mockClear();
+
+        await liquidationService.liquidate(
+          market as any,
+          0,
+          portfolioPubkey,
+          1_000_000n,
+          100_000_000_000n,
+        );
+
+        expect(v17risk.readRawOracleTargetPriceForAsset).not.toHaveBeenCalled();
+      });
+    });
+
     it('aborts v17 liquidation when fresh wrapper price drifts beyond the configured limit', async () => {
       const nowSec = BigInt(Math.floor(Date.now() / 1000));
       const clockData = Buffer.alloc(40);
@@ -721,7 +872,12 @@ describe('LiquidationService', () => {
         oracleMode: 2, // EWMA_MARK
         maxStalenessSecs: 60n,
         oracleTargetPriceE6: 0n,
-        oracleTargetPublishTime: 0n,
+        // Was 0n, which makes resolveV17WrapperPrice treat the EWMA as stale and
+        // return 0n — so this test aborted on the freshPrice===0 guard and never
+        // reached the drift check. It passed with the drift guard entirely
+        // disabled. A fresh publish time makes the price resolve so the 100%
+        // drift below (1.0 -> 2.0 vs a 150bps limit) is what actually aborts.
+        oracleTargetPublishTime: nowSec,
         markEwmaE6: 2_000_000n,
       } as any);
 


### PR DESCRIPTION
Closes #373.

## The bug

The v17 pre-submit re-verification wrapped its **entire** block — the still-undercollateralized margin recheck, the maintenance-margin re-parse, and the oracle-drift guard — in `try { … } catch { /* proceed cautiously */ }` with an empty catch. Any throw fell straight through to the send with **no checks applied**.

The v12.x path directly below is unwrapped and already fails closed. v17 is the live mainnet layout, so the asymmetry ran the wrong way.

The "proceed cautiously — the on-chain program will reject" justification covers the closed/topped-up case. It does **not** cover the drift guard, which the code itself documents as having no on-chain counterpart:

> The on-chain Liquidate instruction carries no price bound, so keeper-side drift detection is the only available mitigation.

So on a throw, a liquidation could be submitted at unbounded drift with no backstop anywhere — keeper-side skipped, on-chain nonexistent. Triggers aren't attacker-controlled (malformed wrapper bytes in `parseWrapperConfigV17`, a cluster-time RPC error, the M-6 owner-check failure in `fetchSlabWithRetry`) but they're reachable.

## The fix

Narrow the `try` to the fetch/parse of re-verification data and `return null` on failure. The drift and margin checks now run **outside** it, so their failure aborts the submit. Matches the H-8 pattern already applied to the inner `reMmBps` parse.

**Trade-off, stated plainly:** during RPC instability the keeper now *skips* these liquidations instead of submitting them blind. That's the intended posture and the one v12.x already had — the next scan cycle retries. It trades some liquidation coverage under RPC flakiness for never submitting an unverified liquidation.

## Verification

The issue asked for a test where `parseWrapperConfigV17` throws and `keeperSend` is never called. Added that, plus the slab-re-fetch throw, plus two contrast tests proving the checks still *run* on the healthy path (otherwise "fail closed" could be implemented as "always return null" and the first two would still pass).

I verified these against the **original code**, not a hand-rolled mutation — my first mutation attempt produced a broken hybrid that passed and would have let a useless test through:

```
ORIGINAL fail-open liquidation.ts + new tests  → 2 failed   ✅ they catch the bug
fixed liquidation.ts + new tests               → 4 passed
```

## Second finding: the existing drift test was vacuous

While building the contrast case I found the pre-existing test — `aborts v17 liquidation when fresh wrapper price drifts beyond the configured limit` — **passes with the drift guard entirely commented out.**

Its wrapper config had `oracleTargetPublishTime: 0n`, so `resolveV17WrapperPrice` treated the EWMA as stale and returned `0n`. The test aborted on the `freshPrice === 0n` guard and never reached the drift check.

So the mitigation this whole issue exists to protect had **no working test coverage**. Fixed by giving it a fresh publish time; the 100% drift (1.0 → 2.0 against a 150bps limit) is now what actually aborts. Mutation-verified: disabling the guard fails it.

## Checks

- Full keeper suite: **979 passed, 0 failures**
- `npx tsc --noEmit` clean

Touches liquidation safety logic on the live mainnet path — **wants a security review before merge**, not just a functional one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved liquidation safety by aborting submissions when pre-submit verification data is missing, invalid, or cannot be refreshed.
  * Prevented liquidations from proceeding when market data, pricing, or risk information cannot be reliably verified.
  * Ensured drift and margin safeguards run only with validated, up-to-date inputs.
* **Tests**
  * Added coverage for malformed data, failed market refreshes, successful re-verification, and price drift scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->