### PR TITLE
ci: build the Docker image on pull requests, and assert what it ships (#384)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,44 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: build-and-test
-    if: github.ref == 'refs/heads/main'
+    # #384: this was gated to `refs/heads/main`, so the image was only built
+    # AFTER merge and image-build breakage passed PR review invisibly. It then
+    # failed on every push to main from 2026-06-22 to 2026-07-18 (~4 weeks) with
+    # ERR_PNPM_LOCKFILE_CONFIG_MISMATCH, and the PR that introduced it could not
+    # have caught it: build-and-test passes there, because actions/checkout
+    # supplies the whole repo while the docker build context is narrower. The
+    # two jobs disagree on exactly the thing that broke, and only the invisible
+    # one failed.
+    #
+    # The job only builds — it never pushes to a registry — so running it on
+    # pull requests needs no push-gating.
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build Docker image
         run: docker build -t percolator-keeper .
+
+      # K-NEW-1 in the Dockerfile installs production deps only, to keep vitest,
+      # tsx, @types/* and their CVEs out of the runtime image. Nothing verified
+      # that. A regression to a full install would still build green, so assert
+      # the outcome rather than the exit code.
+      - name: Assert devDependencies are absent from the runtime image
+        run: |
+          set -euo pipefail
+          for pkg in vitest tsx typescript fast-check; do
+            if docker run --rm --entrypoint sh percolator-keeper -c "test -e /app/node_modules/$pkg"; then
+              echo "::error::devDependency '$pkg' is present in the runtime image (K-NEW-1 regression)"
+              exit 1
+            fi
+          done
+          echo "OK: vitest, tsx, typescript and fast-check are absent from the runtime image"
+
+      - name: Assert production dependencies survived
+        run: |
+          set -euo pipefail
+          # Mirror check: an install that dropped real dependencies would also
+          # satisfy the assertion above, so it has to be paired with this one.
+          for pkg in @solana/web3.js @upstash/redis p-queue lru-cache; do
+            docker run --rm --entrypoint sh percolator-keeper -c "test -e /app/node_modules/$pkg" \
+              || { echo "::error::production dependency '$pkg' missing from the runtime image"; exit 1; }
+          done
+          echo "OK: production dependencies are present"


### PR DESCRIPTION
Closes #384.

## The gap

```yaml
docker:
  needs: build-and-test
  if: github.ref == 'refs/heads/main'
```

The image was only built **after** merge, so image-build breakage passed PR review invisibly and landed on a red main.

**Not theoretical** — as the issue documents, the job failed on every push to main from **2026-06-22 to 2026-07-18 (~4 weeks)** with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. The PR that introduced it *could not* have caught it: `build-and-test` passes in that scenario because `actions/checkout` supplies the whole repo while the docker build context is narrower. The two jobs disagree on exactly the thing that broke, and only the invisible one ran.

## On the suggested fix

The issue proposes `push: ${{ github.ref == 'refs/heads/main' }}` to keep the registry push main-only. **There is no push step** — the job only runs `docker build`. So ungating it is sufficient and nothing needs push-gating.

## Also: assert what the image actually ships

The Dockerfile's `K-NEW-1` comment claims the runtime image excludes vitest, tsx, `@types/*` and their CVEs:

```dockerfile
# K-NEW-1: install production deps only — excludes vitest, vite, tsx, @types/*
# and their associated CVEs from the final image.
RUN pnpm install --frozen-lockfile --prod
```

**Nothing verified that.** A regression to a full install would still build green — the same "green job proves nothing" trap that let the 4-week breakage hide. So the job now asserts the outcome:

- `vitest` / `tsx` / `typescript` / `fast-check` **absent** from `/app/node_modules`
- `@solana/web3.js` / `@upstash/redis` / `p-queue` / `lru-cache` **present**

The second is the mirror check: an install that dropped real dependencies would satisfy the first on its own.

## Verification

Same fix and assertion pattern as [percolator-indexer#185](https://github.com/dcccrypto/percolator-indexer/pull/185), where it is already green and I confirmed from the job log that the assertion steps actually executed rather than being skipped.

This PR is self-verifying the same way: for a same-repo `pull_request` GitHub uses the workflow from the PR branch, so **if a `docker` check appears below and passes, the change works** — and the assertions tell you the image contents are right, not merely that it built.

**Note for reviewers:** this touches only `.github/workflows/ci.yml`, so it doesn't collide with any of the open PRs on `liquidation.ts` / `oracle.ts` / `crank.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)