### PR TITLE
fix(monitor): stop reporting v17 markets as a passing conservation check (#347)

### DIFF
--- a/src/services/monitor.ts
+++ b/src/services/monitor.ts
@@ -54,13 +54,24 @@ const ALERT_COOLDOWN_MS = 5 * 60_000;
 
 export interface MarketInvariantResult {
   slabAddress: string;
-  ok: boolean;
-  /** Actual SPL token balance in the vault token account */
-  vaultTokenBalance: string;
-  /** engine.vault — what the program believes is in the vault */
-  engineVault: string;
-  /** Shortfall: engineVault - vaultTokenBalance (0n when ok) */
-  shortfall: string;
+  /**
+   * true  = invariant evaluated and holds
+   * false = invariant evaluated and VIOLATED (funds may have leaked)
+   * null  = NOT EVALUATED — no conclusion available
+   *
+   * #347: `null` exists because this used to report `true` for v17 markets
+   * without checking anything. Since the v17 cutover that is every production
+   * market, so the only fund-conservation tripwire in the codebase was emitting
+   * a green signal it had never computed. An unevaluated check must never be
+   * indistinguishable from a passing one.
+   */
+  ok: boolean | null;
+  /** Actual SPL token balance in the vault token account. null when unevaluated. */
+  vaultTokenBalance: string | null;
+  /** engine.vault — what the program believes is in the vault. null when unevaluated. */
+  engineVault: string | null;
+  /** Shortfall: engineVault - vaultTokenBalance (0n when ok). null when unevaluated. */
+  shortfall: string | null;
   checkedAt: number;
   skippedReason?: string;
 }
@@ -196,14 +207,25 @@ export class MonitorService {
           `fetchSlab(${slabAddress.slice(0, 8)})`,
         );
         if (isV17Account(data)) {
+          // #347: report UNCHECKED, not healthy. The legacy formula reads
+          // engine.vault, a v12 field, so it genuinely cannot run here — but
+          // "the old formula doesn't apply" is not "the vault is fine". The
+          // zeroed balances were just as misleading as ok:true: a dashboard
+          // showing shortfall "0" reads as "checked, nothing missing".
+          //
+          // A real v17 invariant (sum insurance fund + Σ portfolio capital/pnl
+          // backing vs getTokenAccountBalance) still needs building — see #347.
+          // Until then this surfaces the gap instead of masking it.
           this._invariantResults.set(slabAddress, {
             slabAddress,
-            ok: true,
-            vaultTokenBalance: "0",
-            engineVault: "0",
-            shortfall: "0",
+            ok: null,
+            vaultTokenBalance: null,
+            engineVault: null,
+            shortfall: null,
             checkedAt: now,
-            skippedReason: "v17 market account: legacy engine.vault invariant is not applicable",
+            skippedReason:
+              "UNCHECKED — v17 market account: the legacy engine.vault invariant does not apply " +
+              "and no v17 equivalent is implemented yet (#347). This is NOT a passing check.",
           });
           this._adlStalenessResults.set(slabAddress, {
             slabAddress,

--- a/tests/services/monitor.test.ts
+++ b/tests/services/monitor.test.ts
@@ -54,11 +54,14 @@ describe("MonitorService", () => {
     const status = service.getStatus();
     expect(sdk.parseEngine).not.toHaveBeenCalled();
     expect(sdk.parseConfig).not.toHaveBeenCalled();
+    // #347: this previously asserted `ok: true`, codifying the bug — a v17
+    // market was reported healthy without the conservation invariant ever
+    // running. `null` means "not evaluated" and is the whole point.
     expect(status.invariants).toEqual([
       expect.objectContaining({
         slabAddress,
-        ok: true,
-        skippedReason: expect.stringContaining("v17 market account"),
+        ok: null,
+        skippedReason: expect.stringContaining("UNCHECKED"),
       }),
     ]);
     expect(status.adlStaleness).toEqual([
@@ -69,6 +72,49 @@ describe("MonitorService", () => {
         skippedReason: expect.stringContaining("v17 removed ExecuteAdl"),
       }),
     ]);
+  });
+
+  it("#347: never reports a v17 market as ok:true — an unevaluated check is not a passing one", async () => {
+    // The load-bearing assertion. Since the v17 cutover every production market
+    // takes this branch, so `ok: true` here meant the only fund-conservation
+    // tripwire in the codebase emitted green across the entire live market set
+    // without ever computing anything.
+    const service = new MonitorService();
+    const slabAddress = "11111111111111111111111111111111";
+    const markets = new Map([
+      [slabAddress, { market: { slabAddress: new PublicKey(slabAddress) } }],
+    ]);
+
+    vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array([1, 2, 3]));
+    vi.mocked(sdk.isV17Account).mockReturnValue(true);
+
+    service.setMarketSource(() => markets as any);
+    await (service as any)._runChecks();
+
+    const [invariant] = service.getStatus().invariants;
+    expect(invariant.ok).not.toBe(true);
+    expect(invariant.ok).toBeNull();
+  });
+
+  it("#347: does not fabricate zeroed balances for an unevaluated v17 market", async () => {
+    // shortfall "0" reads as "checked, nothing missing" on a dashboard, which is
+    // the same false-green in a different field. Unevaluated must be null.
+    const service = new MonitorService();
+    const slabAddress = "11111111111111111111111111111111";
+    const markets = new Map([
+      [slabAddress, { market: { slabAddress: new PublicKey(slabAddress) } }],
+    ]);
+
+    vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array([1, 2, 3]));
+    vi.mocked(sdk.isV17Account).mockReturnValue(true);
+
+    service.setMarketSource(() => markets as any);
+    await (service as any)._runChecks();
+
+    const [invariant] = service.getStatus().invariants;
+    expect(invariant.shortfall).toBeNull();
+    expect(invariant.vaultTokenBalance).toBeNull();
+    expect(invariant.engineVault).toBeNull();
   });
 
   it("M-6: passes the market's programId to fetchSlab as expectedOwner", async () => {


### PR DESCRIPTION
Addresses #347 — **the false signal**. Deliberately does *not* claim to implement the v17 invariant; see Scope below.

## The bug

`MonitorService` is the keeper's **only** off-chain fund-conservation tripwire. Its own header states the purpose: if the on-chain SPL balance falls below what the program thinks is in the vault, funds have leaked and we alert immediately.

For v17 markets it bailed out **before** that check and recorded:

```ts
ok: true,                 // reports HEALTHY without checking anything
vaultTokenBalance: "0",
engineVault: "0",
shortfall: "0",
```

Since the v17 cutover **every production market is v17**, so the invariant never ran anywhere — and `/health`'s `invariants` block actively showed green for a check that was never computed.

The ADL-staleness skip beside it is legitimate (`ExecuteAdl` was removed in v17). This one isn't: v17 vaults still hold SPL tokens and the program still tracks accounting; only the *source field* changed. The code answered *"the old formula doesn't apply"* with *"report healthy"*.

## The change

Makes "unevaluated" representable, and reports it:

```ts
ok: boolean | null   // null = NOT EVALUATED, no conclusion available
```

Balances become `null` rather than `"0"` — a dashboard reading `shortfall: "0"` concludes *"checked, nothing missing"*, which is the same false green wearing a different hat.

## Scope — what this does NOT do

**It does not implement the v17 invariant.** Deriving it (insurance fund + Σ portfolio capital/pnl backing vs `getTokenAccountBalance`) needs the v17 accounting model, and getting it subtly wrong would emit **false shortfall alerts on a fund-leak detector** — which trains on-call to ignore it, arguably worse than silence.

That work stays open on #347 and wants someone with the v17 accounting model (anchor/SDK side). What this PR fixes is the part that is unambiguously wrong today: **a monitor claiming a result it never computed.**

## Why it's safe to change the type

`/health` embeds `monitorService.getStatus()` verbatim and **does not gate its status code** on `invariants[].ok` — I checked before touching it, since flipping every v17 market to non-`true` could otherwise have turned the endpoint red fleet-wide. `src/index.ts` is the only consumer outside this file.

## Verification

The existing v17 test asserted `ok: true`, **codifying the bug** — updated, with a comment saying so. Added the two regressions the issue asks for.

Checked against the **original** `monitor.ts`, not a hand-rolled mutation:

```
ORIGINAL false-green code + tests → 3 of 4 FAILED  ✅
fixed code + tests                → 4 passed
```

- Full keeper suite: **977 passed, 0 failures**
- `npx tsc --noEmit` clean

Touches only `src/services/monitor.ts` + its test — no collision with the open PRs on `liquidation.ts` / `oracle.ts` / `crank.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Market monitoring now clearly reports when v17 conservation checks have not been evaluated.
  * Unevaluated v17 checks no longer appear as successful or display fabricated zero-balance values.
  * Monitoring results include clearer information when a conservation check is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->