### PR TITLE
keeper: v17 config offset, crank wire, fee split + bucket recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,3 +148,42 @@ SHADOW_HARNESS_ENABLED=false
 # SHADOW_HARNESS_COMPARE_WINDOW_MS=300000        # comparison window (5 min default)
 # SHADOW_HARNESS_DIVERGENCE_THRESHOLD_PCT=1.0    # alert threshold (1% default)
 # SHADOW_HARNESS_DECISION_LOG_PATH=/tmp/keeper-decisions.jsonl  # JSONL log path
+
+# ─── v17 fee-split + backing-bucket recovery crank (tags 89/78/87/84) ─────────
+# One threshold-gated loop that empties the pots the v17 fee split accrues into,
+# and recovers backing domains whose buckets have lapsed.
+#
+# OFF by default. Three of the four legs move real collateral, and tag 89
+# forfeits lapsed principal to the junior pool (the engine's documented expiry
+# semantics), so enabling is an operator decision, not a deploy side effect.
+KEEPER_FEE_CRANK_ENABLED=false
+
+# Minimum outstanding claim (in COLLATERAL ATOMS) before a leg is worth sending.
+# Defaults assume a 6-decimal collateral mint, so 1_000_000 atoms = 1.0 token.
+# Set these ABOVE the landed transaction cost or a sweep is value-destroying.
+# KEEPER_PROTOCOL_FEE_SWEEP_MIN_ATOMS=1000000   # tag 84 (authority-gated)
+# KEEPER_LP_FEE_CRANK_MIN_ATOMS=100000          # tag 78 (permissionless)
+# KEEPER_STAKE_FEE_SWEEP_MIN_ATOMS=100000       # tag 87 (permissionless)
+#
+# ⚠ Tag 89 (ExpireBackingBucket) has NO economic threshold, deliberately. A
+# lapsed bucket permanently bricks its domain — settling a loss fails Custom(21),
+# settling a gain fails Custom(19), and topping up to re-fund it fails Custom(21)
+# as well, so it cannot even be paid to come back. Tag 89 is the only exit.
+# Every backed market lapses eventually (the expiry is fixed when the bucket
+# opens and is never extended), so this is routine maintenance. Skipping it to
+# save a fee trades lamports against unrecoverable user funds.
+#
+# Observability horizon for the "buckets lapsing soon" gauge — a leading
+# indicator for whether the crank cadence is fast enough.
+# KEEPER_BUCKET_LAPSE_WARN_SLOTS=5000
+
+# Tag 84 is NOT permissionless: it requires the market's protocol_fee_authority
+# as signer. The keeper skips the leg entirely unless CRANK_KEYPAIR IS that
+# authority. Destination token account for the swept protocol fees:
+# KEEPER_PROTOCOL_FEE_DESTINATION=
+
+# ⚠ REQUIRED for tags 84 and 87 — the market's collateral vault token account.
+# Not yet derived automatically (see keeper-crank-report.md): until the ATA
+# derivation lands, tags 84/87 skip when this is unset. Tag 89, the
+# liveness-critical leg, does NOT need it — it moves no tokens.
+# KEEPER_MARKET_VAULT_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -182,8 +182,9 @@ KEEPER_FEE_CRANK_ENABLED=false
 # authority. Destination token account for the swept protocol fees:
 # KEEPER_PROTOCOL_FEE_DESTINATION=
 
-# ⚠ REQUIRED for tags 84 and 87 — the market's collateral vault token account.
-# Not yet derived automatically (see keeper-crank-report.md): until the ATA
-# derivation lands, tags 84/87 skip when this is unset. Tag 89, the
-# liveness-critical leg, does NOT need it — it moves no tokens.
-# KEEPER_MARKET_VAULT_TOKEN=
+# (removed) KEEPER_MARKET_VAULT_TOKEN — no longer read, and must not come back.
+# The market's collateral vault token account is now DERIVED per market via the
+# SDK's deriveCanonicalVault(), matching the program's own canonical_vault_address
+# (ATA of the ["vault", market] authority PDA for the collateral mint). A single
+# process-wide env var could only ever be right for one market, and the wrapper's
+# F-VAULT-FRAG pin rejects any other address as InvalidVaultAccount (12).

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@percolatorct/sdk": "file:../percolator-sdk",
+    "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#ac68ac3f45fb3a069866308727c0fd40e8293d2e",
     "@percolatorct/shared": "github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f",
     "@solana/web3.js": "^1.98.0",
     "@upstash/redis": "^1.38.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#59441ff3",
+    "@percolatorct/sdk": "file:../percolator-sdk",
     "@percolatorct/shared": "github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f",
     "@solana/web3.js": "^1.98.0",
     "@upstash/redis": "^1.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
   .:
     dependencies:
       '@percolatorct/sdk':
-        specifier: file:../percolator-sdk
-        version: file:../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        specifier: github:dcccrypto/percolator-sdk#ac68ac3f45fb3a069866308727c0fd40e8293d2e
+        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@percolatorct/shared':
         specifier: github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f
-        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@file:../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -461,8 +461,9 @@ packages:
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
-  '@percolatorct/sdk@file:../percolator-sdk':
-    resolution: {directory: ../percolator-sdk, type: directory}
+  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e':
+    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e}
+    version: 4.2.0
     engines: {node: '>=20.0.0'}
 
   '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f':
@@ -1879,7 +1880,7 @@ snapshots:
 
   '@oxc-project/types@0.124.0': {}
 
-  '@percolatorct/sdk@file:../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1890,9 +1891,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@file:../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@percolatorct/sdk': file:../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@percolatorct/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@sentry/node': 10.46.0
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@supabase/supabase-js': 2.100.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
   .:
     dependencies:
       '@percolatorct/sdk':
-        specifier: github:dcccrypto/percolator-sdk#59441ff3
-        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        specifier: file:../percolator-sdk
+        version: file:../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@percolatorct/shared':
         specifier: github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f
-        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@file:../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -461,9 +461,8 @@ packages:
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
-  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e}
-    version: 3.0.0
+  '@percolatorct/sdk@file:../percolator-sdk':
+    resolution: {directory: ../percolator-sdk, type: directory}
     engines: {node: '>=20.0.0'}
 
   '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f':
@@ -1880,7 +1879,7 @@ snapshots:
 
   '@oxc-project/types@0.124.0': {}
 
-  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/sdk@file:../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1891,9 +1890,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@file:../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@percolatorct/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/59441ff301ba5e09b91784e7ec1d272c287de01e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@percolatorct/sdk': file:../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@sentry/node': 10.46.0
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@supabase/supabase-js': 2.100.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)

--- a/railway.toml
+++ b/railway.toml
@@ -9,7 +9,7 @@ dockerfilePath = "Dockerfile"
 # fixed, rather than worked around by removing platform-level health gating
 # entirely (see commit e6b5d2a).
 healthcheckPath = "/health"
-healthcheckTimeout = 120
+healthcheckTimeout = 300
 startCommand = "node dist/index.js"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { validateKeeperEnvGuards } from "./env-guards.js";
 import { isMainnet } from "./config/network.js";
 import { CURRENT_NETWORK } from "./network.js";
 import { assertMainnetProgramId, assertProgramIdAllowList } from "./lib/boot-assertions.js";
+import { assertV17LayoutGeneration } from "./lib/v17-layout.js";
 import { snapshotMetrics as snapshotSenderMetrics } from "./lib/sender-metrics.js";
 import { walletBalanceSol, activeMarketsCount, registerDefaultMetrics } from "./lib/metrics.js";
 import * as metricsServer from "./lib/metrics-server.js";
@@ -83,6 +84,13 @@ assertMainnetProgramId({ isMainnet: isMainnet(), programId: config.programId });
 // Validate the full discovery/signing program set (config.allProgramIds), not
 // just the single config.programId — discovery scans and signs against every entry.
 assertProgramIdAllowList({ isMainnet: isMainnet(), allProgramIds: config.allProgramIds });
+// Refuse to start against an SDK whose v17 account layout does not match the
+// deployed wrapper. The keeper reads market accounts by raw byte offset — there
+// is no discriminator and no error return on a wrong-offset read, it just
+// yields plausible garbage. A stale SDK pin is exactly how the keeper ended up
+// reading every v17 market at the 432-byte (two generations old) layout, so a
+// mismatch has to be a startup crash rather than a silent misparse.
+assertV17LayoutGeneration();
 if (isMainnet()) {
   logger.info("Running in MAINNET mode", { programId: config.programId });
 }

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -216,20 +216,26 @@ export async function keeperSend(
 
   // v17 cutover (issue #176): the wrapper program installs a custom 128KB heap
   // allocator and aborts ("Access violation in heap section") on its first heap
-  // allocation unless the transaction requests the matching heap frame. Every
-  // keeper send path (crank InitUser/CrankLpVaultFees/RestartAssetOracle/
-  // PermissionlessCrank + liquidation Liquidate) carries a wrapper instruction,
-  // so prepend the request here as the FIRST instruction. 131072 = 128*1024 ==
-  // the program's V16_HEAP_FRAME_BYTES. The CU limit is left to estimateCost /
-  // simulatedCu, so no setComputeUnitLimit is added here.
-  instructions = [
+  // allocation unless the transaction requests the matching heap frame.
+  // 131072 = 128*1024 == the program's V16_HEAP_FRAME_BYTES.
+  //
+  // This is prepended for SIMULATION ONLY. `sendWithRetryKeeper` builds its own
+  // transaction and already prepends the heap frame itself — unconditionally, as
+  // `DEFAULT_KEEPER_OPTS.heapFrameBytes` is always set — plus setComputeUnitLimit
+  // and setComputeUnitPrice. Prepending a second copy into the array handed to it
+  // produced TWO identical requestHeapFrame instructions and the runtime rejected
+  // the whole transaction: "Transaction contains a duplicate instruction (3)"
+  // ([0] heapFrame, [1] cuLimit, [2] cuPrice, [3] the duplicate). That aborted
+  // every keeperSend path, all four fee-crank legs included, before it ever
+  // reached the program.
+  const simulationInstructions = [
     ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }),
     ...instructions,
   ];
 
   const { estimatedCost, simulatedCu, provenToFail, simError } = await estimateCost(
     connection,
-    instructions,
+    simulationInstructions,
     signers,
     txType,
     extraLamports,

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -308,6 +308,84 @@ export const shadowDivergencePct = new Gauge({
   registers: [registry],
 });
 
+// ─── v17 fee-split + backing-bucket-recovery crank ────────────────────────────
+// These are what the runbook reads to answer "is the crank actually working?".
+// The key pairing is attempts vs. atoms_moved (revenue legs) and lapsed vs.
+// expired (the liveness leg): a leg attempting work but moving nothing, or a
+// lapsed gauge that never returns to zero, is the failure mode that otherwise
+// looks exactly like a healthy idle keeper.
+
+export const feeCrankLegAttemptsTotal = new Counter({
+  name: "keeper_fee_crank_leg_attempts_total",
+  help: "Fee-crank transactions attempted, partitioned by leg (tags 78/84/87/89)",
+  labelNames: ["leg"] as const,
+  registers: [registry],
+});
+
+export const feeCrankLegSkippedTotal = new Counter({
+  name: "keeper_fee_crank_leg_skipped_total",
+  help: "Fee-crank legs that found no pending work (never sent a transaction), by leg",
+  labelNames: ["leg"] as const,
+  registers: [registry],
+});
+
+// Benign rejections are counted SEPARATELY from errors on purpose. Custom(19),
+// Custom(21), Custom(27), Custom(38), Custom(41), Custom(53) and Custom(61) are
+// by-design outcomes of a permissionless crank racing another keeper or hitting
+// a mode gate. Folding them into the error counter would make a healthy keeper
+// look like it was failing constantly and make the error rate useless as an alarm.
+export const feeCrankLegBenignRejectsTotal = new Counter({
+  name: "keeper_fee_crank_leg_benign_rejects_total",
+  help: "Fee-crank sends rejected by design (mode gates, nothing-to-do, lost races), by leg and program error code",
+  labelNames: ["leg", "code"] as const,
+  registers: [registry],
+});
+
+export const feeCrankLegErrorsTotal = new Counter({
+  name: "keeper_fee_crank_leg_errors_total",
+  help: "Fee-crank genuine failures (unrecognised program errors, RPC faults), by leg and phase",
+  labelNames: ["leg", "phase"] as const,
+  registers: [registry],
+});
+
+export const feeCrankAtomsMovedTotal = new Counter({
+  name: "keeper_fee_crank_atoms_moved_total",
+  help: "Collateral atoms swept per fee leg per market (expected amount at send time; the program clamps and may partial-fill)",
+  labelNames: ["leg", "market"] as const,
+  registers: [registry],
+});
+
+export const feeCrankPendingClaimAtoms = new Gauge({
+  name: "keeper_fee_crank_pending_claim_atoms",
+  help: "Outstanding (accrued - withdrawn) atoms per fee leg per market. A monotonically rising value means the leg is not being cranked",
+  labelNames: ["market", "leg"] as const,
+  registers: [registry],
+});
+
+export const feeCrankBucketsExpiredTotal = new Counter({
+  name: "keeper_fee_crank_buckets_expired_total",
+  help: "Backing buckets recovered via tag 89 ExpireBackingBucket, by market",
+  labelNames: ["market"] as const,
+  registers: [registry],
+});
+
+// ⚠ ALARM ON THIS. A non-zero lapsed gauge that persists across cycles means
+// domains are bricked right now: settling a loss fails Custom(21), settling a
+// gain fails Custom(19), and top-up fails Custom(21). Losing accounts strand.
+export const feeCrankBucketsLapsedGauge = new Gauge({
+  name: "keeper_fee_crank_buckets_lapsed",
+  help: "Backing buckets currently Fresh-and-lapsed (bricked domains awaiting tag 89), by market",
+  labelNames: ["market"] as const,
+  registers: [registry],
+});
+
+export const feeCrankBucketsLapsingSoonGauge = new Gauge({
+  name: "keeper_fee_crank_buckets_lapsing_soon",
+  help: "Backing buckets that will lapse within the warning horizon, by market. Leading indicator for tag 89 cadence",
+  labelNames: ["market"] as const,
+  registers: [registry],
+});
+
 export function registerDefaultMetrics(): void {
   collectDefaultMetrics({ register: registry, prefix: "nodejs_" });
 }

--- a/src/lib/v17-fee-state.ts
+++ b/src/lib/v17-fee-state.ts
@@ -1,0 +1,337 @@
+/**
+ * Pure readers over a v17 market account's raw bytes, for the fee/recovery cranks.
+ *
+ * Everything here is a total function from `Uint8Array` to plain data — no RPC,
+ * no clock, no keypairs. That is deliberate: the decision "is there anything to
+ * do on this market?" is the part that must be right, and it is the part that is
+ * cheapest to test exhaustively if it never touches the network. The crank
+ * service composes these; it does not re-derive any offset itself.
+ *
+ * All offsets come from `v17-layout.ts`, which derives them from the SDK. See
+ * that file for why the keeper no longer hardcodes any of this.
+ */
+
+import { parseWrapperConfigV17 } from "@percolatorct/sdk";
+import {
+  BACKING_BUCKET_LEN,
+  BUCKET_EXPIRY_SLOT_OFF,
+  BUCKET_FRESH_UNLIENED_OFF,
+  BUCKET_IMPAIRED_LIENED_OFF,
+  BUCKET_STATUS_FRESH,
+  BUCKET_STATUS_OFF,
+  BUCKET_VALID_LIENED_OFF,
+  MARKET_MODE_LIVE,
+  MG_C_TOT_OFF,
+  MG_CURRENT_SLOT_OFF,
+  MG_INSURANCE_DOMAIN_BUDGET_REMAINING_TOTAL_OFF,
+  MG_INSURANCE_OFF,
+  MG_MATERIALIZED_PORTFOLIO_COUNT_OFF,
+  MG_MODE_OFF,
+  MG_SOURCE_INSURANCE_CREDIT_RESERVED_ATOMS_OFF,
+  V16_CFG_MAX_MARKET_SLOTS_OFF,
+  V17_ASSET_SLOTS_BASE_OFF,
+  V17_MARKET_ASSET_SLOT_LEN,
+  backingBucketOff,
+  engineConfigFieldOff,
+  marketGroupFieldOff,
+} from "./v17-layout.js";
+
+// ─── Primitive little-endian readers ──────────────────────────────────────────
+
+export function readU8(data: Uint8Array, offset: number): number {
+  if (offset < 0 || offset + 1 > data.length) {
+    throw new RangeError(`readU8 out of bounds at ${offset} (len ${data.length})`);
+  }
+  return data[offset]!;
+}
+
+export function readU32LE(data: Uint8Array, offset: number): number {
+  if (offset < 0 || offset + 4 > data.length) {
+    throw new RangeError(`readU32LE out of bounds at ${offset} (len ${data.length})`);
+  }
+  return (
+    data[offset]! |
+    (data[offset + 1]! << 8) |
+    (data[offset + 2]! << 16) |
+    (data[offset + 3]! << 24)
+  ) >>> 0;
+}
+
+export function readU64LE(data: Uint8Array, offset: number): bigint {
+  if (offset < 0 || offset + 8 > data.length) {
+    throw new RangeError(`readU64LE out of bounds at ${offset} (len ${data.length})`);
+  }
+  let value = 0n;
+  for (let i = 0; i < 8; i++) {
+    value |= BigInt(data[offset + i]!) << (8n * BigInt(i));
+  }
+  return value;
+}
+
+export function readU128LE(data: Uint8Array, offset: number): bigint {
+  const lo = readU64LE(data, offset);
+  const hi = readU64LE(data, offset + 8);
+  return lo | (hi << 64n);
+}
+
+// ─── Market group header ──────────────────────────────────────────────────────
+
+/**
+ * Minimum bytes needed before any market-group field read is in bounds.
+ * Callers should check this once and skip the market rather than let individual
+ * reads throw.
+ */
+export const V17_MARKET_GROUP_MIN_LEN = V17_ASSET_SLOTS_BASE_OFF;
+
+export interface V17MarketGroupState {
+  /** 0 = Live, 1 = Resolved, 2 = Recovery. */
+  mode: number;
+  /** The engine's own advancing slot counter (`header.current_slot`). */
+  currentSlot: bigint;
+  insurance: bigint;
+  cTot: bigint;
+  materializedPortfolioCount: bigint;
+  sourceInsuranceCreditReservedTotalAtoms: bigint;
+  insuranceDomainBudgetRemainingTotal: bigint;
+  /** `config.max_market_slots` — domain count is exactly 2× this. */
+  maxMarketSlots: number;
+  /** Asset slots physically present in the account, from its length. */
+  assetSlotCount: number;
+}
+
+export function readMarketGroupState(data: Uint8Array): V17MarketGroupState {
+  if (data.length < V17_MARKET_GROUP_MIN_LEN) {
+    throw new RangeError(
+      `readMarketGroupState: account too short — need >= ${V17_MARKET_GROUP_MIN_LEN} bytes, got ${data.length}`,
+    );
+  }
+  return {
+    mode: readU8(data, marketGroupFieldOff(MG_MODE_OFF)),
+    currentSlot: readU64LE(data, marketGroupFieldOff(MG_CURRENT_SLOT_OFF)),
+    insurance: readU128LE(data, marketGroupFieldOff(MG_INSURANCE_OFF)),
+    cTot: readU128LE(data, marketGroupFieldOff(MG_C_TOT_OFF)),
+    materializedPortfolioCount: readU64LE(
+      data,
+      marketGroupFieldOff(MG_MATERIALIZED_PORTFOLIO_COUNT_OFF),
+    ),
+    sourceInsuranceCreditReservedTotalAtoms: readU128LE(
+      data,
+      marketGroupFieldOff(MG_SOURCE_INSURANCE_CREDIT_RESERVED_ATOMS_OFF),
+    ),
+    insuranceDomainBudgetRemainingTotal: readU128LE(
+      data,
+      marketGroupFieldOff(MG_INSURANCE_DOMAIN_BUDGET_REMAINING_TOTAL_OFF),
+    ),
+    maxMarketSlots: readU32LE(data, engineConfigFieldOff(V16_CFG_MAX_MARKET_SLOTS_OFF)),
+    assetSlotCount: Math.floor(
+      (data.length - V17_ASSET_SLOTS_BASE_OFF) / V17_MARKET_ASSET_SLOT_LEN,
+    ),
+  };
+}
+
+/**
+ * The shared withdrawable pool that tags 78, 84 and 87 all clamp against
+ * (`handle_withdraw_protocol_fee`'s §1.3/N2 clamp and its two mirrors):
+ *
+ *     insurance − source_insurance_credit_reserved_total_atoms
+ *               − insurance_domain_budget_remaining_total
+ *
+ * Saturating, exactly as the program does it. A leg whose wrapper-side claim
+ * exceeds this does not fail — it partial-fills and leaves the remainder
+ * claimable — so the keeper uses this to report expected vs. actual movement
+ * rather than to gate the send.
+ */
+export function engineAvailableAtoms(group: V17MarketGroupState): bigint {
+  const afterReserved =
+    group.insurance > group.sourceInsuranceCreditReservedTotalAtoms
+      ? group.insurance - group.sourceInsuranceCreditReservedTotalAtoms
+      : 0n;
+  return afterReserved > group.insuranceDomainBudgetRemainingTotal
+    ? afterReserved - group.insuranceDomainBudgetRemainingTotal
+    : 0n;
+}
+
+// ─── Fee legs ─────────────────────────────────────────────────────────────────
+
+export type FeeLeg = "lp" | "insuranceReserve" | "protocol";
+
+export interface V17FeeLegClaims {
+  /** Tag 78 `LpVaultCrankFees`. */
+  lp: bigint;
+  /** Tag 87 `WithdrawInsuranceReserveToStake`. */
+  insuranceReserve: bigint;
+  /** Tag 84 `WithdrawProtocolFee`. */
+  protocol: bigint;
+}
+
+/**
+ * Outstanding (accrued − withdrawn) claim per fee leg, read from the wrapper
+ * config's fee-split tail. These counters are what make "is there anything to
+ * do?" answerable WITHOUT sending a transaction — the whole reason the crank
+ * does not fire blindly.
+ *
+ * Each counter pair is monotonic with withdrawn <= accrued (enforced program
+ * side), but this subtracts saturatingly anyway: a negative claim from a
+ * misread would otherwise become an enormous unsigned number and look like a
+ * huge pending sweep.
+ */
+export function readFeeLegClaims(data: Uint8Array): V17FeeLegClaims {
+  const cfg = parseWrapperConfigV17(data);
+  const sat = (accrued: bigint, withdrawn: bigint): bigint =>
+    accrued > withdrawn ? accrued - withdrawn : 0n;
+  return {
+    lp: sat(cfg.lpFeeAccruedAtoms, cfg.lpFeeWithdrawnAtoms),
+    insuranceReserve: sat(
+      cfg.insuranceReserveAccruedAtoms,
+      cfg.insuranceReserveWithdrawnAtoms,
+    ),
+    protocol: sat(cfg.protocolFeeAccruedAtoms, cfg.protocolFeeWithdrawnAtoms),
+  };
+}
+
+// ─── Backing buckets (tag 89) ─────────────────────────────────────────────────
+
+export interface V17BackingBucket {
+  /** Engine domain index. `asset = domain / 2`, `side = domain % 2` (0 long). */
+  domain: number;
+  assetIndex: number;
+  side: "long" | "short";
+  status: number;
+  expirySlot: bigint;
+  freshUnlienedBackingNum: bigint;
+  validLienedBackingNum: bigint;
+  impairedLienedBackingNum: bigint;
+}
+
+/**
+ * Read every configured backing bucket.
+ *
+ * Domain count is `config.max_market_slots × 2` (the program's own bound in
+ * `handle_expire_backing_bucket`), but the account only physically contains
+ * `assetSlotCount` slots — a market can be configured for more slots than its
+ * account was sized for. Iterating on the configured count alone would read
+ * past the buffer; iterating on the physical count alone could address a domain
+ * the program rejects as `InvalidInstruction`. So this takes the min.
+ */
+export function readBackingBuckets(
+  data: Uint8Array,
+  group: V17MarketGroupState,
+): V17BackingBucket[] {
+  const configuredAssets = group.maxMarketSlots;
+  const assetCount = Math.min(configuredAssets, group.assetSlotCount);
+  const buckets: V17BackingBucket[] = [];
+
+  for (let assetIndex = 0; assetIndex < assetCount; assetIndex++) {
+    for (const side of [0, 1] as const) {
+      const domain = assetIndex * 2 + side;
+      const base = backingBucketOff(domain);
+      if (base + BACKING_BUCKET_LEN > data.length) continue;
+      buckets.push({
+        domain,
+        assetIndex,
+        side: side === 0 ? "long" : "short",
+        status: readU8(data, base + BUCKET_STATUS_OFF),
+        expirySlot: readU64LE(data, base + BUCKET_EXPIRY_SLOT_OFF),
+        freshUnlienedBackingNum: readU128LE(data, base + BUCKET_FRESH_UNLIENED_OFF),
+        validLienedBackingNum: readU128LE(data, base + BUCKET_VALID_LIENED_OFF),
+        impairedLienedBackingNum: readU128LE(data, base + BUCKET_IMPAIRED_LIENED_OFF),
+      });
+    }
+  }
+  return buckets;
+}
+
+/**
+ * Buckets that tag 89 `ExpireBackingBucket` would accept right now.
+ *
+ * The engine's `expire_source_backing_bucket_not_atomic` accepts exactly
+ * `status == Fresh && now_slot >= expiry_slot`, and rejects everything else
+ * with `Stale`. `now_slot` is
+ * `max(Clock::get().slot, header.current_slot)` — never caller-supplied — so a
+ * bucket is expirable iff EITHER clock reaches the expiry or the engine's own
+ * counter already has.
+ *
+ * Using the max here (rather than just the chain slot) matters in the direction
+ * that costs money: `header.current_slot` can legitimately run AHEAD of the
+ * chain slot the keeper last observed, and a bucket that the program would
+ * accept but the keeper skips is a domain that stays bricked. It cannot produce
+ * a false positive, because the program recomputes the same max itself and a
+ * caller cannot lower it.
+ *
+ * WHY THIS IS ROUTINE, NOT AN EDGE CASE. A bucket's `expiry_slot` is fixed when
+ * the bucket opens and is NEVER extended while it stays `Fresh`
+ * (`fresh_counterparty_backing_expiry_slot` returns the stored value unchanged
+ * on a live bucket). Every backed market therefore lapses eventually — a longer
+ * horizon defers the lapse, it does not avoid it. Once lapsed the domain is a
+ * dead end in all three directions: settling a gain returns `EngineStale`
+ * (Custom 19), reserving a further loss returns `EngineLockActive` (Custom 21),
+ * and `TopUpBackingBucket` to re-fund it returns 21 as well — it cannot even be
+ * paid to come back. Tag 89 is the only exit.
+ */
+export function findExpirableBuckets(
+  buckets: readonly V17BackingBucket[],
+  chainSlot: bigint,
+  engineCurrentSlot: bigint,
+): V17BackingBucket[] {
+  const nowSlot = chainSlot > engineCurrentSlot ? chainSlot : engineCurrentSlot;
+  return buckets.filter(
+    (b) => b.status === BUCKET_STATUS_FRESH && nowSlot >= b.expirySlot,
+  );
+}
+
+/**
+ * Buckets that are `Fresh` and will lapse within `horizonSlots`. Purely
+ * observational — surfaced as a metric so an operator can see the lapse coming
+ * and size the crank cadence, rather than discovering it when an account fails
+ * to settle.
+ */
+export function findLapsingSoonBuckets(
+  buckets: readonly V17BackingBucket[],
+  chainSlot: bigint,
+  engineCurrentSlot: bigint,
+  horizonSlots: bigint,
+): V17BackingBucket[] {
+  const nowSlot = chainSlot > engineCurrentSlot ? chainSlot : engineCurrentSlot;
+  return buckets.filter(
+    (b) =>
+      b.status === BUCKET_STATUS_FRESH &&
+      b.expirySlot > nowSlot &&
+      b.expirySlot - nowSlot <= horizonSlots,
+  );
+}
+
+// ─── Mode gates ───────────────────────────────────────────────────────────────
+
+/**
+ * Tags 78 and 87 are Live-only by design, and additionally refuse on a
+ * "matured Live" market (one past its permissionless-resolve horizon, via
+ * `reject_permissionless_resolve_matured_live_view`). The keeper cannot cheaply
+ * evaluate the matured-Live predicate off-chain, so it gates on mode only and
+ * treats the program's rejection of a matured market as a by-design outcome.
+ */
+export function isLiveOnlyLegEligible(group: V17MarketGroupState): boolean {
+  return group.mode === MARKET_MODE_LIVE;
+}
+
+/**
+ * Tag 84 is Live OR fully-wound-down Resolved — `handle_withdraw_protocol_fee`
+ * permits Resolved only when `materialized_portfolio_count == 0 && c_tot == 0`.
+ * W12: `ResolveMarket` is one-way and tag 84 is the protocol claim's ONLY exit,
+ * which is why it gets the wider gate that tag 87 deliberately does not.
+ */
+export function isProtocolFeeLegEligible(group: V17MarketGroupState): boolean {
+  if (group.mode === MARKET_MODE_LIVE) return true;
+  if (group.mode !== 1) return false;
+  return group.materializedPortfolioCount === 0n && group.cTot === 0n;
+}
+
+/**
+ * Tag 89 is Live-only: a resolved/wound-down market already reaches the same
+ * transition through the engine's own resolved-close sweep
+ * (`realize_source_backed_claims_for_resolved_close_not_atomic`), so
+ * re-entering it from outside would be a second unsequenced mutation of a
+ * terminal ledger. The program returns `EngineLockActive` (Custom 21) otherwise.
+ */
+export function isBucketExpiryEligible(group: V17MarketGroupState): boolean {
+  return group.mode === MARKET_MODE_LIVE;
+}

--- a/src/lib/v17-layout.ts
+++ b/src/lib/v17-layout.ts
@@ -1,0 +1,344 @@
+/**
+ * v17 account layout — the ONE place the keeper learns where things live.
+ *
+ * ══ WHY THIS FILE EXISTS ═════════════════════════════════════════════════════
+ *
+ * `v17-risk.ts` hardcoded `V17_WRAPPER_CONFIG_LEN = 432`. That constant has been
+ * wrong for two generations of the wrapper:
+ *
+ *     432  →  496   (protocol-fee program change: +protocol_fee_authority,
+ *                    +protocol_fee_accrued_atoms, +protocol_fee_withdrawn_atoms)
+ *     496  →  576   (fee-collection split: +4×u128 fee counters, +3×u16 shares,
+ *                    +10B explicit padding)
+ *
+ * Because `WrapperConfigV16` sits between the 16-byte account header and the
+ * market-group header, EVERY derived offset past it moves when it grows. At 432
+ * the keeper was reading the market-group header 144 bytes too early — so
+ * `maintenance_margin_bps`, `h_min`, `h_max`, `liquidation_fee_bps` and
+ * `min_nonzero_mm_req` were all being read out of the middle of the wrapper
+ * config's oracle-leg arrays. The keeper is misreading live market accounts
+ * today, entirely independent of the fee-split work.
+ *
+ * The fix is not "change 432 to 576" — that is how we got here. The fix is that
+ * the keeper stops owning this number at all. `@percolatorct/sdk` derives it
+ * from the program's own `WRAPPER_CONFIG_LEN`, which the program pins with a
+ * compile-time `assert!(size_of::<WrapperConfigV16>() == WRAPPER_CONFIG_LEN)`
+ * (v16_program.rs). The indexer already imports these constants
+ * (`percolator-indexer/src/v17/discovery.ts`); this module converges the keeper
+ * onto the same source of truth.
+ *
+ * ══ THE TRIPWIRE ═════════════════════════════════════════════════════════════
+ *
+ * Importing from the SDK is necessary but NOT sufficient: an SDK pinned to a
+ * stale commit exports a stale constant, and the keeper would go on misreading
+ * accounts just as silently as it does now. `assertV17LayoutGeneration()` below
+ * refuses to start against an SDK whose layout generation does not match the
+ * deployed wrapper. A wrong offset must be a loud startup crash, never a quiet
+ * misread. See its doc comment for why the expected value is written down here
+ * even though the offsets are not.
+ *
+ * ══ SUB-STRUCT OFFSETS ═══════════════════════════════════════════════════════
+ *
+ * The SDK exports the OUTER layout (header → wrapper config → market group →
+ * asset slots) but not the engine sub-struct field offsets, so those are
+ * derived here from the engine's `#[repr(C)]` struct definitions
+ * (`percolator/src/v16.rs`). Every `V16PodU*` field is an align-1 `[u8; N]`
+ * byte array and every struct derives `bytemuck::Pod` (which forbids implicit
+ * padding), so field offsets are the running sum of field sizes with no
+ * alignment gaps anywhere.
+ *
+ * Each derived block below ends with a total that is asserted against an
+ * INDEPENDENTLY-SOURCED length (the SDK's `V17_MARKET_GROUP_LEN` /
+ * `V17_MARKET_ASSET_SLOT_LEN`). That is a real check, not decoration: it is how
+ * the offsets in this file were verified in the first place, and it is what
+ * would have caught the 432 bug. If a struct gains a field upstream, the sum
+ * stops matching and `assertV17LayoutGeneration()` throws at boot.
+ */
+
+import {
+  V17_HEADER_LEN,
+  V17_WRAPPER_CONFIG_LEN,
+  V17_MARKET_GROUP_OFF,
+  V17_MARKET_GROUP_LEN,
+  V17_MARKET_ASSET_SLOT_LEN,
+} from "@percolatorct/sdk";
+
+// ─── Re-exports: SDK is the source of truth, this module is the front door ────
+// Callers import from here rather than reaching into the SDK directly, so that
+// the tripwire below is unavoidable and there is exactly one import site to
+// audit when the layout moves again.
+
+export {
+  V17_HEADER_LEN,
+  V17_WRAPPER_CONFIG_LEN,
+  V17_MARKET_GROUP_OFF,
+  V17_MARKET_GROUP_LEN,
+  V17_MARKET_ASSET_SLOT_LEN,
+};
+
+/**
+ * Expected `WRAPPER_CONFIG_LEN` for the currently-deployed wrapper
+ * `DhSkE7uTb8HBUYYWF1xkxMYBGtLYJEoDq1tfBD7SnHcj`
+ * (sha256 6b2fda2363352aba0ef88abde0d398f9dd477b1208507e7e8393586ed5458931).
+ *
+ * ⚠ THIS IS A TRIPWIRE, NOT A DATA SOURCE. Nothing in this file — or anywhere
+ * else in the keeper — computes an offset from this number. It exists only so
+ * that a keeper running against an SDK from the wrong generation FAILS TO BOOT
+ * instead of silently reading the wrong bytes. That distinction is the whole
+ * lesson of the 432 bug: the old code used its stale constant as an offset
+ * source, so being wrong was invisible.
+ *
+ * When the wrapper's config legitimately grows again, this bumps in the same
+ * commit that repins the SDK, and the mismatch until then is the point.
+ */
+export const V17_EXPECTED_WRAPPER_CONFIG_LEN = 576;
+
+// ─── MarketGroupV16HeaderAccount ──────────────────────────────────────────────
+// Offsets are RELATIVE to V17_MARKET_GROUP_OFF. Derived from
+// `percolator/src/v16.rs` `MarketGroupV16HeaderAccount`.
+
+/** `market_group_id: [u8; 32]` */
+export const MG_MARKET_GROUP_ID_OFF = 0;
+export const MG_MARKET_GROUP_ID_LEN = 32;
+
+/** `config: V16ConfigAccount` — see the V16_CFG_* offsets below. */
+export const MG_CONFIG_OFF = MG_MARKET_GROUP_ID_OFF + MG_MARKET_GROUP_ID_LEN; // 32
+
+// V16ConfigAccount field offsets, relative to MG_CONFIG_OFF.
+export const V16_CFG_MAX_PORTFOLIO_ASSETS_OFF = 0; // u16
+export const V16_CFG_MAX_MARKET_SLOTS_OFF = 2; // u32
+export const V16_CFG_MIN_NONZERO_MM_REQ_OFF = 6; // u128
+export const V16_CFG_MIN_NONZERO_IM_REQ_OFF = 22; // u128
+export const V16_CFG_H_MIN_OFF = 38; // u64
+export const V16_CFG_H_MAX_OFF = 46; // u64
+export const V16_CFG_MAINTENANCE_MARGIN_BPS_OFF = 54; // u64
+export const V16_CFG_INITIAL_MARGIN_BPS_OFF = 62; // u64
+export const V16_CFG_MAX_TRADING_FEE_BPS_OFF = 70; // u64
+export const V16_CFG_LIQUIDATION_FEE_BPS_OFF = 78; // u64
+/**
+ * `V16ConfigAccount` total size. Continues past liquidation_fee_bps with
+ * liquidation_fee_cap(16) + min_liquidation_abs(16) + 8×u64(64) +
+ * public_b_chunk_atoms(16) + 5×u64(40) + 11×u8(11) = 249.
+ */
+export const V16_CFG_LEN = 249;
+
+export const MG_ASSET_SLOT_CAPACITY_OFF = MG_CONFIG_OFF + V16_CFG_LEN; // 281, u32
+export const MG_VAULT_OFF = MG_ASSET_SLOT_CAPACITY_OFF + 4; // 285, u128
+export const MG_INSURANCE_OFF = MG_VAULT_OFF + 16; // 301, u128
+export const MG_C_TOT_OFF = MG_INSURANCE_OFF + 16; // 317, u128
+
+// Seven u128 aggregates sit between c_tot and the two clamp operands:
+// pnl_pos_tot(333) pnl_pos_bound_tot_num(349) pnl_pos_bound_tot(365)
+// pnl_matured_pos_tot(381) backing_provider_earnings_total(397)
+// source_claim_bound_total_num(413) source_fresh_backing_total_num(429).
+
+// The two clamp operands every fee-withdraw leg (tags 78/84/87) draws against.
+// All three legs share one pool:
+//   insurance − source_insurance_credit_reserved_total_atoms
+//             − insurance_domain_budget_remaining_total
+// and each clamps its own claim to it, so a leg can partial-fill.
+export const MG_SOURCE_INSURANCE_CREDIT_RESERVED_ATOMS_OFF = 445; // u128
+export const MG_INSURANCE_DOMAIN_BUDGET_REMAINING_TOTAL_OFF = 461; // u128
+
+export const MG_RESOLVED_PAYOUT_BLOCKER_COUNT_OFF = 477; // u64
+export const MG_STRESS_CONSUMPTION_OFF = 485; // u128
+export const MG_STRESS_ENVELOPE_START_SLOT_OFF = 501; // u64
+export const MG_STRESS_ENVELOPE_START_CREDIT_EPOCH_OFF = 509; // u64
+export const MG_MATERIALIZED_PORTFOLIO_COUNT_OFF = 517; // u64
+// stale_certificate_count(525) b_stale_account_count(533)
+// negative_pnl_account_count(541) risk_epoch(549) asset_set_epoch(557)
+// asset_activation_count(565) last_asset_activation_slot(573)
+// next_market_id(581) oracle_epoch(589) funding_epoch(597) slot_last(605)
+export const MG_CURRENT_SLOT_OFF = 613; // u64
+// bankruptcy_hlock_active(621) threshold_stress_active(622) loss_stale_active(623)
+// recovery_reason: V16OptionalRecoveryReasonAccount { present: u8, value: u8 } (624..626)
+/** `mode`: 0 = Live, 1 = Resolved, 2 = Recovery. */
+export const MG_MODE_OFF = 626; // u8
+// resolved_slot(627) payout_snapshot(635) payout_snapshot_pnl_pos_tot(651)
+// payout_snapshot_captured(667)
+// resolved_payout_ledger: ResolvedPayoutLedgerV16Account = 5×u128 + u64 + 2×u8 = 90
+export const MG_RESOLVED_PAYOUT_LEDGER_OFF = 668;
+export const MG_RESOLVED_PAYOUT_LEDGER_LEN = 90;
+
+/** Independently-derived total, asserted against the SDK's V17_MARKET_GROUP_LEN. */
+export const MG_DERIVED_LEN = MG_RESOLVED_PAYOUT_LEDGER_OFF + MG_RESOLVED_PAYOUT_LEDGER_LEN; // 758
+
+// ─── Per-asset slot ───────────────────────────────────────────────────────────
+// Each asset slot in the market account is a 512-byte wrapper oracle-wrapper
+// prefix followed by the engine's EngineAssetSlotV16Account.
+
+/** Wrapper-side oracle prefix that precedes each `EngineAssetSlotV16Account`. */
+export const ASSET_SLOT_WRAPPER_PREFIX_LEN = 512;
+
+// AssetStateV16Account field offsets (relative to the engine asset slot start).
+export const ASSET_MARKET_ID_OFF = 0; // u64
+export const ASSET_RETIRED_SLOT_OFF = 8; // u64
+export const ASSET_LIFECYCLE_OFF = 16; // u8
+export const ASSET_RAW_ORACLE_TARGET_PRICE_OFF = 17; // u64
+export const ASSET_EFFECTIVE_PRICE_OFF = 25; // u64
+export const ASSET_FUND_PX_LAST_OFF = 33; // u64
+export const ASSET_SLOT_LAST_OFF = 41; // u64
+// a_long(49) a_short(65) k_long(81) k_short(97) f_long_num(113) f_short_num(129)
+// k_epoch_start_long(145) k_epoch_start_short(161) f_epoch_start_long_num(177)
+// f_epoch_start_short_num(193) b_long_num(209) b_short_num(225)
+// b_epoch_start_long_num(241) b_epoch_start_short_num(257)
+export const ASSET_OI_EFF_LONG_Q_OFF = 273; // u128
+export const ASSET_OI_EFF_SHORT_Q_OFF = 289; // u128
+// stored_pos_count_long(305) .. pending_obligation_count_short(345)
+// loss_weight_sum_*(353,369) social_loss_remainder_*(385,401)
+// social_loss_dust_*(417,433) explicit_unallocated_loss_*(449,465)
+// epoch_long(481) epoch_short(489) mode_long(497) mode_short(498)
+/** `AssetStateV16Account` total size. */
+export const ASSET_STATE_LEN = 499;
+
+// EngineAssetSlotV16Account field offsets (relative to the engine asset slot start).
+export const SLOT_ASSET_OFF = 0;
+export const SLOT_INSURANCE_DOMAIN_BUDGET_LONG_OFF = ASSET_STATE_LEN; // 499, u128
+export const SLOT_INSURANCE_DOMAIN_BUDGET_SHORT_OFF = 515; // u128
+export const SLOT_INSURANCE_DOMAIN_SPENT_LONG_OFF = 531; // u128
+export const SLOT_INSURANCE_DOMAIN_SPENT_SHORT_OFF = 547; // u128
+export const SLOT_PENDING_DOMAIN_LOSS_BARRIER_LONG_OFF = 563; // u64
+export const SLOT_PENDING_DOMAIN_LOSS_BARRIER_SHORT_OFF = 571; // u64
+/** `SourceCreditStateV16Account` = 11×u128 + u64 = 184. */
+export const SOURCE_CREDIT_LEN = 184;
+export const SLOT_SOURCE_CREDIT_LONG_OFF = 579;
+export const SLOT_SOURCE_CREDIT_SHORT_OFF = SLOT_SOURCE_CREDIT_LONG_OFF + SOURCE_CREDIT_LEN; // 763
+
+/**
+ * `BackingBucketV16Account` = market_id(u64) + 5×u128 + expiry_slot(u64) +
+ * status(u8) = 8 + 80 + 8 + 1 = 97.
+ */
+export const BACKING_BUCKET_LEN = 97;
+export const SLOT_BACKING_LONG_OFF = SLOT_SOURCE_CREDIT_SHORT_OFF + SOURCE_CREDIT_LEN; // 947
+export const SLOT_BACKING_SHORT_OFF = SLOT_BACKING_LONG_OFF + BACKING_BUCKET_LEN; // 1044
+
+/** `InsuranceCreditReservationV16Account` = 4×u128 + u64 = 72. */
+export const INSURANCE_RESERVATION_LEN = 72;
+export const SLOT_INSURANCE_RESERVATION_LONG_OFF = SLOT_BACKING_SHORT_OFF + BACKING_BUCKET_LEN; // 1141
+export const SLOT_INSURANCE_RESERVATION_SHORT_OFF =
+  SLOT_INSURANCE_RESERVATION_LONG_OFF + INSURANCE_RESERVATION_LEN; // 1213
+
+/** Independently-derived `EngineAssetSlotV16Account` size. */
+export const ENGINE_ASSET_SLOT_DERIVED_LEN =
+  SLOT_INSURANCE_RESERVATION_SHORT_OFF + INSURANCE_RESERVATION_LEN; // 1285
+
+/** Independently-derived per-asset stride within the market account. */
+export const ASSET_SLOT_DERIVED_STRIDE =
+  ASSET_SLOT_WRAPPER_PREFIX_LEN + ENGINE_ASSET_SLOT_DERIVED_LEN; // 1797
+
+// BackingBucketV16Account field offsets (relative to the bucket start).
+export const BUCKET_MARKET_ID_OFF = 0; // u64
+export const BUCKET_FRESH_UNLIENED_OFF = 8; // u128
+export const BUCKET_VALID_LIENED_OFF = 24; // u128
+export const BUCKET_CONSUMED_LIENED_OFF = 40; // u128
+export const BUCKET_IMPAIRED_LIENED_OFF = 56; // u128
+export const BUCKET_UTILIZATION_FEE_EARNINGS_OFF = 72; // u128
+export const BUCKET_EXPIRY_SLOT_OFF = 88; // u64
+export const BUCKET_STATUS_OFF = 96; // u8
+
+/**
+ * `BackingBucketStatusV16` discriminants, from `encode_backing_bucket_status`
+ * (percolator/src/v16.rs).
+ */
+export const BUCKET_STATUS_EMPTY = 0;
+export const BUCKET_STATUS_FRESH = 1;
+export const BUCKET_STATUS_EXPIRED = 2;
+export const BUCKET_STATUS_IMPAIRED = 3;
+
+/** Market group `mode` discriminants. */
+export const MARKET_MODE_LIVE = 0;
+export const MARKET_MODE_RESOLVED = 1;
+export const MARKET_MODE_RECOVERY = 2;
+
+// ─── Derived absolute offsets ─────────────────────────────────────────────────
+
+/** Absolute byte offset of the first asset slot in the market account. */
+export const V17_ASSET_SLOTS_BASE_OFF = V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_LEN;
+
+/** Absolute byte offset of a market-group header field. */
+export function marketGroupFieldOff(relativeOff: number): number {
+  return V17_MARKET_GROUP_OFF + relativeOff;
+}
+
+/** Absolute byte offset of a `V16ConfigAccount` field. */
+export function engineConfigFieldOff(relativeOff: number): number {
+  return V17_MARKET_GROUP_OFF + MG_CONFIG_OFF + relativeOff;
+}
+
+/** Absolute byte offset of the `EngineAssetSlotV16Account` for `assetIndex`. */
+export function engineAssetSlotOff(assetIndex: number): number {
+  return (
+    V17_ASSET_SLOTS_BASE_OFF +
+    assetIndex * V17_MARKET_ASSET_SLOT_LEN +
+    ASSET_SLOT_WRAPPER_PREFIX_LEN
+  );
+}
+
+/**
+ * Absolute byte offset of a backing bucket, addressed by DOMAIN index.
+ *
+ * The engine's `domain_asset_side` (v16.rs) maps domain → (asset, side) as
+ * `asset_index = domain / 2` and `side = domain % 2 == 0 ? Long : Short`.
+ * Tag 89 takes a domain, not an (asset, side) pair, so the keeper must speak
+ * the same dialect or it will expire the wrong bucket.
+ */
+export function backingBucketOff(domain: number): number {
+  const assetIndex = Math.floor(domain / 2);
+  const sideOff = domain % 2 === 0 ? SLOT_BACKING_LONG_OFF : SLOT_BACKING_SHORT_OFF;
+  return engineAssetSlotOff(assetIndex) + sideOff;
+}
+
+/**
+ * Boot tripwire. Throws unless the SDK's layout matches the deployed wrapper
+ * generation AND this module's independently-derived struct sizes agree with
+ * the SDK's.
+ *
+ * Called from boot assertions so a stale/mismatched SDK is a startup crash.
+ * The keeper reads market accounts by raw byte offset; there is no checksum,
+ * no discriminator and no error return on a wrong-offset read — it just gets
+ * plausible-looking garbage. Failing closed at boot is the only place this is
+ * catchable.
+ */
+export function assertV17LayoutGeneration(): void {
+  const problems: string[] = [];
+
+  if (V17_WRAPPER_CONFIG_LEN !== V17_EXPECTED_WRAPPER_CONFIG_LEN) {
+    problems.push(
+      `@percolatorct/sdk exports V17_WRAPPER_CONFIG_LEN=${V17_WRAPPER_CONFIG_LEN} but the ` +
+        `deployed wrapper uses ${V17_EXPECTED_WRAPPER_CONFIG_LEN}. The SDK pin is from the ` +
+        `wrong generation (432 = pre-protocol-fee, 496 = pre-fee-split, 576 = current). ` +
+        `Every offset past the wrapper config would be wrong by ` +
+        `${V17_EXPECTED_WRAPPER_CONFIG_LEN - V17_WRAPPER_CONFIG_LEN} bytes.`,
+    );
+  }
+
+  if (MG_DERIVED_LEN !== V17_MARKET_GROUP_LEN) {
+    problems.push(
+      `MarketGroupV16HeaderAccount field offsets sum to ${MG_DERIVED_LEN} but the SDK reports ` +
+        `V17_MARKET_GROUP_LEN=${V17_MARKET_GROUP_LEN}. A field was added/removed/resized upstream ` +
+        `and the offsets in v17-layout.ts are stale.`,
+    );
+  }
+
+  if (ASSET_SLOT_DERIVED_STRIDE !== V17_MARKET_ASSET_SLOT_LEN) {
+    problems.push(
+      `EngineAssetSlotV16Account field offsets sum to a stride of ${ASSET_SLOT_DERIVED_STRIDE} ` +
+        `but the SDK reports V17_MARKET_ASSET_SLOT_LEN=${V17_MARKET_ASSET_SLOT_LEN}. ` +
+        `Per-asset reads (prices, backing buckets) would be misaligned.`,
+    );
+  }
+
+  if (V17_MARKET_GROUP_OFF !== V17_HEADER_LEN + V17_WRAPPER_CONFIG_LEN) {
+    problems.push(
+      `SDK V17_MARKET_GROUP_OFF=${V17_MARKET_GROUP_OFF} != V17_HEADER_LEN(${V17_HEADER_LEN}) + ` +
+        `V17_WRAPPER_CONFIG_LEN(${V17_WRAPPER_CONFIG_LEN}). The SDK's own constants disagree.`,
+    );
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `v17 layout mismatch — refusing to start rather than misread market accounts:\n  - ` +
+        problems.join("\n  - "),
+    );
+  }
+}

--- a/src/lib/v17-risk.ts
+++ b/src/lib/v17-risk.ts
@@ -1,18 +1,44 @@
-const V17_HEADER_LEN = 16;
-const V17_WRAPPER_CONFIG_LEN = 432;
-// V17_MARKET_GROUP_OFF is exported below for use by callers (per-asset price reading).
-const V17_MARKET_GROUP_ID_LEN = 32;
+/**
+ * ⚠ LAYOUT CONSTANTS COME FROM `v17-layout.ts` (which imports them from
+ * `@percolatorct/sdk`). They used to be hardcoded here, and
+ * `V17_WRAPPER_CONFIG_LEN` was stuck at 432 while the deployed wrapper moved to
+ * 496 and then 576. Since the wrapper config sits between the account header and
+ * the market-group header, every constant below it was 144 bytes off, and this
+ * module was silently parsing risk params out of the wrapper config's oracle-leg
+ * arrays instead of the engine config.
+ *
+ * Do not reintroduce a literal here. If an offset is missing, add it to
+ * `v17-layout.ts` where the boot-time structural assertions can police it.
+ */
+import {
+  ASSET_EFFECTIVE_PRICE_OFF,
+  ASSET_RAW_ORACLE_TARGET_PRICE_OFF,
+  ASSET_SLOT_WRAPPER_PREFIX_LEN,
+  ENGINE_ASSET_SLOT_DERIVED_LEN,
+  MG_CONFIG_OFF,
+  V16_CFG_H_MAX_OFF,
+  V16_CFG_H_MIN_OFF,
+  V16_CFG_LIQUIDATION_FEE_BPS_OFF,
+  V16_CFG_MAINTENANCE_MARGIN_BPS_OFF,
+  V16_CFG_MIN_NONZERO_MM_REQ_OFF,
+  V17_HEADER_LEN,
+  V17_MARKET_ASSET_SLOT_LEN,
+  V17_MARKET_GROUP_LEN,
+  V17_MARKET_GROUP_OFF,
+  engineConfigFieldOff,
+} from "./v17-layout.js";
 
-// ─── Exported layout constants ────────────────────────────────────────────────
+// ─── Exported layout constants (re-derived from the SDK, not hardcoded) ───────
 
-export const V17_MARKET_GROUP_OFF = V17_HEADER_LEN + V17_WRAPPER_CONFIG_LEN; // 448
-export const V17_MARKET_GROUP_LEN = 758; // MarketGroupV16HeaderAccount size
-export const V17_ENGINE_ASSET_SLOT_LEN = 1285; // EngineAssetSlotV16Account size
-export const V17_ASSET_ORACLE_WRAPPER_LEN = 512; // ASSET_ORACLE_WRAPPER_LEN constant
-export const V17_ASSET_SLOT_STRIDE = 1797; // ASSET_ORACLE_WRAPPER_LEN + ENGINE_ASSET_SLOT_LEN
-// offset of effective_price within EngineAssetSlotV16Account (after the ORACLE_WRAPPER prefix)
-// = 8 (market_id) + 8 (retired_slot) + 1 (lifecycle) + 8 (raw_oracle_target_price) = 25
-export const V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT = 25;
+export { V17_MARKET_GROUP_OFF, V17_MARKET_GROUP_LEN };
+/** `EngineAssetSlotV16Account` size. */
+export const V17_ENGINE_ASSET_SLOT_LEN = ENGINE_ASSET_SLOT_DERIVED_LEN;
+/** Wrapper-side oracle prefix preceding each engine asset slot. */
+export const V17_ASSET_ORACLE_WRAPPER_LEN = ASSET_SLOT_WRAPPER_PREFIX_LEN;
+/** Per-asset stride = oracle wrapper prefix + engine asset slot. */
+export const V17_ASSET_SLOT_STRIDE = V17_MARKET_ASSET_SLOT_LEN;
+/** Offset of `effective_price` within `EngineAssetSlotV16Account`. */
+export const V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT = ASSET_EFFECTIVE_PRICE_OFF;
 // #335: offset of raw_oracle_target_price within EngineAssetSlotV16Account (after the
 // ORACLE_WRAPPER prefix). It is the field immediately BEFORE effective_price:
 // = 8 (market_id) + 8 (retired_slot) + 1 (lifecycle) = 17.
@@ -20,18 +46,26 @@ export const V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT = 25;
 // struct is #[repr(C)] over alignment-1 byte-array fields (V16PodU64 = [u8;8], no
 // padding), so raw_oracle_target_price (V16PodU64) sits at byte 17 and effective_price
 // at byte 25. (src/v16.rs:1168 target_effective_lag_adverse_delta consumes both.)
-export const V17_RAW_ORACLE_TARGET_PRICE_OFF_IN_ASSET_SLOT = 17;
-// absolute offset of min_nonzero_mm_req in the market account data
-// = V17_ENGINE_CONFIG_OFF + V16PodU16(2) + V16PodU32(4) = 480 + 6 = 486
-export const V17_MIN_NONZERO_MM_REQ_OFF = 486;
+export const V17_RAW_ORACLE_TARGET_PRICE_OFF_IN_ASSET_SLOT = ASSET_RAW_ORACLE_TARGET_PRICE_OFF;
+/**
+ * Absolute offset of `min_nonzero_mm_req` in the market account data.
+ * = market group + V16ConfigAccount + max_portfolio_assets(u16) + max_market_slots(u32).
+ */
+export const V17_MIN_NONZERO_MM_REQ_OFF = engineConfigFieldOff(V16_CFG_MIN_NONZERO_MM_REQ_OFF);
 
-const V17_ENGINE_CONFIG_OFF = V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_ID_LEN;
+const V17_ENGINE_CONFIG_OFF = V17_MARKET_GROUP_OFF + MG_CONFIG_OFF;
 
-const V17_ENGINE_CONFIG_H_MIN_OFF = 38;
-const V17_ENGINE_CONFIG_H_MAX_OFF = 46;
-const V17_ENGINE_CONFIG_MAINTENANCE_MARGIN_BPS_OFF = 54;
-const V17_ENGINE_CONFIG_LIQUIDATION_FEE_BPS_OFF = 78;
+const V17_ENGINE_CONFIG_H_MIN_OFF = V16_CFG_H_MIN_OFF;
+const V17_ENGINE_CONFIG_H_MAX_OFF = V16_CFG_H_MAX_OFF;
+const V17_ENGINE_CONFIG_MAINTENANCE_MARGIN_BPS_OFF = V16_CFG_MAINTENANCE_MARGIN_BPS_OFF;
+const V17_ENGINE_CONFIG_LIQUIDATION_FEE_BPS_OFF = V16_CFG_LIQUIDATION_FEE_BPS_OFF;
 
+/**
+ * `maintenance_fee_per_slot` within the WRAPPER config (not the engine config),
+ * so this offset is relative to the account header and does NOT move when the
+ * wrapper config grows at its tail — all fee-split/protocol-fee additions were
+ * appended after this field.
+ */
 const V17_WRAPPER_MAINTENANCE_FEE_PER_SLOT_OFF = V17_HEADER_LEN + 96;
 
 export const V17_RISK_PARAMS_MIN_DATA_LEN = Math.max(

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -37,6 +37,7 @@ import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
 import { parseV17RiskParams, V17_RISK_PARAMS_MIN_DATA_LEN } from "../lib/v17-risk.js";
 import { resolveV17OracleTail } from "../lib/v17-oracle-tail.js";
+import { isFeeCrankEnabled, runFeeCrankPass } from "./fee-crank.js";
 
 export type CrankResult = "success" | "skipped" | "failed";
 
@@ -246,7 +247,10 @@ async function discoverV17Markets(
       const data = new Uint8Array(account.data);
       if (!isV17Account(data)) continue;
 
-      // Parse the v17 wrapper config (starts at offset 16, 432 bytes)
+      // Parse the v17 wrapper config (starts at V17_HEADER_LEN, spans
+      // V17_WRAPPER_CONFIG_LEN bytes — currently 576, was 496 pre-fee-split and
+      // 432 before the protocol-fee change; the SDK owns the number, see
+      // lib/v17-layout.ts).
       const wrapperCfg = parseWrapperConfigV17(data);
       const marketConfig = wrapperConfigV17ToMarketConfig(wrapperCfg);
 
@@ -1488,12 +1492,14 @@ export class CrankService {
         return "skipped";
       }
 
+      // ABI: close_q/fee_bps were REMOVED from the PermissionlessCrank wire
+      // upstream (#206) — the program derives the close size itself and rejects
+      // a nonzero funding rate. Passing them was a no-op at best; the SDK now
+      // rejects them at compile time.
       const crankData = encodePermissionlessCrank({
         action: CrankAction.FeeSweep,
         assetIndex: 0,
         nowSlot,
-        closeQ: 0n,
-        feeBps: 0n,
         recoveryReason: 0,
       });
 
@@ -1795,7 +1801,34 @@ export class CrankService {
     // of toCrank, which includes markets whose own crank failed this batch).
     // Uses Promise.allSettled so failures don't block the cycle but work IS
     // tracked so shutdown can complete before new enqueues race the drain.
-    if (succeededSlabs.size > 0 && this._isRunning) {
+    // ─── v17 fee-split + backing-bucket recovery (tags 89/78/87/84) ──────────
+    // Supersedes the blind per-market crankLpVault() call below for v17 markets:
+    // that one fired tag 78 at every market every cycle without reading state,
+    // paying for a guaranteed revert whenever there were no fees and logging
+    // every rejection — including genuine faults — as "no fees to crank".
+    // runFeeCrankPass reads each market once and only sends where there is
+    // pending work. OFF unless KEEPER_FEE_CRANK_ENABLED=true.
+    if (succeededSlabs.size > 0 && this._isRunning && isFeeCrankEnabled()) {
+      const feeCrankMarkets: { address: PublicKey; programId: PublicKey }[] = [];
+      for (const slabAddress of succeededSlabs) {
+        const state = this.markets.get(slabAddress);
+        if (!state) continue;
+        feeCrankMarkets.push({
+          address: state.market.slabAddress,
+          programId: state.market.programId,
+        });
+      }
+      try {
+        await runFeeCrankPass(getConnection(), this._keypair, feeCrankMarkets);
+      } catch (err) {
+        // Whole-pass failure must never abort the crank cycle.
+        logger.warn("fee-crank pass threw (isolated)", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    if (succeededSlabs.size > 0 && this._isRunning && !isFeeCrankEnabled()) {
       const connection = getConnection();
       const keypair = this._keypair;
       const lpVaultTasks: Promise<void | string | null>[] = [];

--- a/src/services/fee-crank.ts
+++ b/src/services/fee-crank.ts
@@ -1,0 +1,969 @@
+/**
+ * v17 fee-split + backing-bucket-recovery crank.
+ *
+ * ══ WHAT THIS SERVICE IS FOR ═════════════════════════════════════════════════
+ *
+ * The v17 fee split routes every trade fee four ways, and the backing engine
+ * parks counterparty capital in per-domain buckets. Both mechanisms accrue into
+ * pots that only a permissionless crank can empty, and until this service
+ * existed nothing cranked them:
+ *
+ *   tag 89  ExpireBackingBucket             — lapsed bucket recovery  (LIVENESS)
+ *   tag 78  LpVaultCrankFees                — LP fee leg              (REVENUE)
+ *   tag 87  WithdrawInsuranceReserveToStake — staker fee leg          (REVENUE)
+ *   tag 84  WithdrawProtocolFee             — protocol fee leg        (REVENUE)
+ *
+ * Tag 89 is the one that is not optional. The other three leak revenue if they
+ * never run; tag 89 STRANDS USER FUNDS. See `describeBucketExpiryUrgency()`.
+ *
+ * ══ WHY ONE LOOP AND NOT FOUR ════════════════════════════════════════════════
+ *
+ * All four cranks have the same shape: read some counter out of the market
+ * account, compare it to a threshold, send one instruction if it clears. They
+ * differ only in which counter, which threshold, which accounts, and which
+ * mode gate. Four separate loops would mean four copies of the
+ * failure-isolation, rejection-classification, metrics and backoff logic —
+ * four places for them to drift apart, and four independent account fetches of
+ * the same market per cycle.
+ *
+ * So there is one `CrankLeg` description per tag and one driver
+ * (`runFeeCrankCycle`) that fetches each market ONCE and evaluates every leg
+ * against that single snapshot.
+ *
+ * ══ NEVER CRANK BLIND ════════════════════════════════════════════════════════
+ *
+ * Every leg's `detect()` reads on-chain state and returns `null` when there is
+ * nothing to do. A transaction is only ever built for a leg that reported
+ * pending work. This is a correction to the previous `crankLpVault()` in
+ * `crank.ts`, which fired tag 78 at every market every cycle and classified the
+ * resulting failure as "no fees to crank" — burning SOL on a guaranteed-revert
+ * transaction each time, and swallowing genuine faults (authority mismatch,
+ * zero LP shares, wrong mode) under the same debug line.
+ *
+ * ══ FAILURE ISOLATION ════════════════════════════════════════════════════════
+ *
+ * Isolation is per (market, leg), not per market: a market whose LP leg throws
+ * still gets its tag-89 bucket sweep in the same cycle. Every leg body is
+ * wrapped, results are collected via `Promise.allSettled`, and no leg can
+ * abort the cycle for any other market or any other leg.
+ */
+
+import { PublicKey } from "@solana/web3.js";
+import type { Connection, Keypair, TransactionInstruction } from "@solana/web3.js";
+import {
+  buildIx,
+  decodeStakePool,
+  deriveLpBackingLedger,
+  deriveLpVaultRegistry,
+  deriveStakePool,
+  deriveVaultAuthority,
+  encodeExpireBackingBucket,
+  encodeLpVaultCrankFees,
+  encodeWithdrawInsuranceReserveToStake,
+  encodeWithdrawProtocolFee,
+  parseLpVaultRegistry,
+  parseWrapperConfigV17,
+} from "@percolatorct/sdk";
+import { createLogger } from "@percolatorct/shared";
+import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
+import { sharedTxQueue } from "../lib/tx-queue.js";
+import {
+  engineAvailableAtoms,
+  findExpirableBuckets,
+  findLapsingSoonBuckets,
+  isBucketExpiryEligible,
+  isLiveOnlyLegEligible,
+  isProtocolFeeLegEligible,
+  readBackingBuckets,
+  readFeeLegClaims,
+  readMarketGroupState,
+  V17_MARKET_GROUP_MIN_LEN,
+  type V17BackingBucket,
+  type V17MarketGroupState,
+} from "../lib/v17-fee-state.js";
+import {
+  feeCrankLegAttemptsTotal,
+  feeCrankLegBenignRejectsTotal,
+  feeCrankLegErrorsTotal,
+  feeCrankLegSkippedTotal,
+  feeCrankAtomsMovedTotal,
+  feeCrankPendingClaimAtoms,
+  feeCrankBucketsExpiredTotal,
+  feeCrankBucketsLapsedGauge,
+  feeCrankBucketsLapsingSoonGauge,
+} from "../lib/metrics.js";
+
+const logger = createLogger("keeper:fee-crank");
+
+// ─── Tunables ─────────────────────────────────────────────────────────────────
+
+/**
+ * A sweep must be worth more than it costs to send. Base fee is 5,000 lamports
+ * and priority fees push a realistic landed cost toward ~50k lamports; at that
+ * price a sweep of a few hundred atoms is strictly value-destroying.
+ *
+ * Thresholds are in COLLATERAL ATOMS, so the right value depends on the
+ * collateral mint's decimals. The defaults assume a 6-decimal stablecoin
+ * (1 atom = 1e-6 units), making the default protocol threshold 1.0 token.
+ */
+function envBigint(name: string, fallback: bigint): bigint {
+  const raw = (process.env[name] ?? "").trim();
+  if (raw === "") return fallback;
+  try {
+    const parsed = BigInt(raw);
+    if (parsed < 0n) {
+      logger.warn("negative fee-crank threshold ignored, using default", {
+        name,
+        raw,
+        fallback: fallback.toString(),
+      });
+      return fallback;
+    }
+    return parsed;
+  } catch {
+    logger.warn("unparseable fee-crank threshold, using default", {
+      name,
+      raw,
+      fallback: fallback.toString(),
+    });
+    return fallback;
+  }
+}
+
+export interface FeeCrankThresholds {
+  /** Tag 84 — the leg the brief explicitly requires be threshold-gated. */
+  protocolAtoms: bigint;
+  /** Tag 78. */
+  lpAtoms: bigint;
+  /** Tag 87. */
+  insuranceReserveAtoms: bigint;
+  /**
+   * Tag 89 has NO economic threshold — see `describeBucketExpiryUrgency()`.
+   * This is only the observability horizon for the "lapsing soon" gauge.
+   */
+  bucketLapseWarnHorizonSlots: bigint;
+}
+
+export function loadFeeCrankThresholds(): FeeCrankThresholds {
+  return {
+    protocolAtoms: envBigint("KEEPER_PROTOCOL_FEE_SWEEP_MIN_ATOMS", 1_000_000n),
+    lpAtoms: envBigint("KEEPER_LP_FEE_CRANK_MIN_ATOMS", 100_000n),
+    insuranceReserveAtoms: envBigint("KEEPER_STAKE_FEE_SWEEP_MIN_ATOMS", 100_000n),
+    bucketLapseWarnHorizonSlots: envBigint("KEEPER_BUCKET_LAPSE_WARN_SLOTS", 5_000n),
+  };
+}
+
+// ─── By-design rejections vs. real errors ─────────────────────────────────────
+
+/**
+ * Custom program error codes this crank expects to see and must NOT alarm on.
+ *
+ * Detection reads a snapshot; the chain moves. A leg can be genuinely pending
+ * when we look and genuinely satisfied by the time the transaction lands —
+ * another keeper cranked it, the market resolved, a bucket got expired by
+ * someone else. Those are races the design anticipates, not faults.
+ *
+ * Treating them as errors would be actively harmful: a permissionless crank
+ * that pages on "someone else did the work first" trains operators to ignore
+ * its alerts, and the one time the alert is real it gets ignored too.
+ */
+export const BENIGN_PROGRAM_ERRORS: ReadonlyMap<number, string> = new Map([
+  [
+    19,
+    "EngineStale — bucket/domain ledger not current (tag 89 raced, or bucket not yet lapsed)",
+  ],
+  [
+    21,
+    "EngineLockActive — market mode gate (tags 78/87/89 are Live-only; 84 needs Live or wound-down Resolved)",
+  ],
+  [27, "mode gate — market not in an eligible mode for this leg"],
+  [38, "LpVaultNoFeesToCrank — LP leg already drained (tag 78)"],
+  [41, "LpVaultZeroSharesMinted — no LP shares outstanding to claim the fees (tag 78)"],
+  [53, "no insurance reserve available (tag 87)"],
+  [61, "backing bucket not Fresh-and-lapsed — already expired or not yet due (tag 89)"],
+]);
+
+/** Extract a Solana `Custom(N)` / `custom program error: 0xN` code, if present. */
+export function extractCustomErrorCode(err: unknown): number | null {
+  const msg = err instanceof Error ? err.message : String(err);
+  const decimal = /Custom(?:\s*[:(]\s*|\s+)(\d+)/i.exec(msg);
+  if (decimal?.[1] !== undefined) return Number.parseInt(decimal[1], 10);
+  const hex = /custom program error:\s*0x([0-9a-f]+)/i.exec(msg);
+  if (hex?.[1] !== undefined) return Number.parseInt(hex[1], 16);
+  return null;
+}
+
+export interface RejectionClassification {
+  benign: boolean;
+  code: number | null;
+  reason: string;
+}
+
+/**
+ * Classify a send failure as a by-design rejection (log at debug) or a real
+ * error (log at warn and count toward the error metric).
+ *
+ * Deliberately conservative: only a RECOGNISED custom code is benign. An
+ * unrecognised custom code, an RPC failure, a signature error or a thrown
+ * exception all classify as real. The previous LP-vault crank did the
+ * opposite — any message containing "Custom" was written off as "no fees to
+ * crank" — which meant a market misconfigured badly enough to reject every
+ * crank looked identical to a market with nothing to do.
+ */
+export function classifyRejection(err: unknown): RejectionClassification {
+  const code = extractCustomErrorCode(err);
+  if (code === null) {
+    return {
+      benign: false,
+      code: null,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+  const benignReason = BENIGN_PROGRAM_ERRORS.get(code);
+  if (benignReason !== undefined) {
+    return { benign: true, code, reason: benignReason };
+  }
+  return { benign: false, code, reason: `unexpected program error Custom(${code})` };
+}
+
+// ─── Leg model ────────────────────────────────────────────────────────────────
+
+export type LegName = "expireBackingBucket" | "lpVaultCrankFees" | "insuranceReserveToStake" | "protocolFee";
+
+/** One unit of pending work discovered by a leg's detector. */
+export interface PendingWork {
+  /** Human-readable reason, for the log line and the runbook. */
+  reason: string;
+  /**
+   * Atoms this send is expected to move, when the leg moves atoms.
+   * `null` for tag 89, which moves no tokens at all — it only advances a
+   * bucket's status so settlement can proceed.
+   */
+  expectedAtoms: bigint | null;
+  /** Instructions to send as one transaction. */
+  instructions: TransactionInstruction[];
+  /** Extra structured detail for logs/metrics (e.g. the domain for tag 89). */
+  detail?: Record<string, string | number>;
+}
+
+export interface MarketSnapshot {
+  address: PublicKey;
+  programId: PublicKey;
+  data: Uint8Array;
+  group: V17MarketGroupState;
+  chainSlot: bigint;
+}
+
+export interface LegContext {
+  connection: Connection;
+  keypair: Keypair;
+  thresholds: FeeCrankThresholds;
+}
+
+export interface CrankLeg {
+  name: LegName;
+  tag: number;
+  /**
+   * Read state and return every unit of work that should be sent right now.
+   * MUST return an empty array when there is nothing to do — the driver never
+   * sends speculatively.
+   */
+  detect(snapshot: MarketSnapshot, ctx: LegContext): Promise<PendingWork[]>;
+}
+
+// ─── Tag 89: ExpireBackingBucket ──────────────────────────────────────────────
+
+/**
+ * Why tag 89 has no economic threshold and runs on every cycle.
+ *
+ * A backing bucket's `expiry_slot` is fixed when the bucket opens and is never
+ * extended while it stays `Fresh`. EVERY backed market therefore lapses — a
+ * longer horizon defers the lapse, it does not avoid it. This is routine
+ * maintenance, not an edge case.
+ *
+ * Once lapsed, the domain is a dead end in all three directions, permanently:
+ *   - settling a LOSS against it    -> EngineLockActive (Custom 21)
+ *   - settling a GAIN against it    -> EngineStale      (Custom 19)
+ *   - TopUpBackingBucket to re-fund -> EngineLockActive (Custom 21)
+ * It cannot even be paid to come back. Tag 89 is the only exit, and it is
+ * permissionless precisely so that any keeper can perform the repair.
+ *
+ * So the "threshold" for tag 89 is simply: the bucket is Fresh and lapsed.
+ * Skipping it to save a transaction fee would be trading a few thousand
+ * lamports against user funds that cannot be recovered by any other means.
+ */
+export function describeBucketExpiryUrgency(): string {
+  return (
+    "tag 89 is liveness-critical: a lapsed bucket permanently bricks its domain " +
+    "(loss->Custom21, gain->Custom19, top-up->Custom21) and tag 89 is the only exit"
+  );
+}
+
+export const expireBackingBucketLeg: CrankLeg = {
+  name: "expireBackingBucket",
+  tag: 89,
+  async detect(snapshot, ctx) {
+    const { group, data, address, programId, chainSlot } = snapshot;
+
+    if (!isBucketExpiryEligible(group)) {
+      // Live-only. On a Resolved market the engine's own resolved-close sweep
+      // reaches the same transition, so there is nothing for us to repair.
+      return [];
+    }
+
+    const buckets = readBackingBuckets(data, group);
+    const expirable = findExpirableBuckets(buckets, chainSlot, group.currentSlot);
+    const lapsingSoon = findLapsingSoonBuckets(
+      buckets,
+      chainSlot,
+      group.currentSlot,
+      ctx.thresholds.bucketLapseWarnHorizonSlots,
+    );
+
+    const marketLabel = address.toBase58().slice(0, 8);
+    feeCrankBucketsLapsedGauge.set({ market: marketLabel }, expirable.length);
+    feeCrankBucketsLapsingSoonGauge.set({ market: marketLabel }, lapsingSoon.length);
+
+    if (lapsingSoon.length > 0) {
+      logger.info("backing buckets approaching lapse", {
+        market: marketLabel,
+        count: lapsingSoon.length,
+        horizonSlots: ctx.thresholds.bucketLapseWarnHorizonSlots.toString(),
+        domains: lapsingSoon.map((b) => b.domain).join(","),
+      });
+    }
+
+    // One instruction per domain, sent as separate transactions so that a
+    // domain the program refuses cannot block the others in the same market.
+    return expirable.map((bucket) => buildExpireBucketWork(programId, address, bucket));
+  },
+};
+
+function buildExpireBucketWork(
+  programId: PublicKey,
+  market: PublicKey,
+  bucket: V17BackingBucket,
+): PendingWork {
+  const data = encodeExpireBackingBucket({ domain: bucket.domain });
+  const ix = buildIx({
+    programId,
+    // handle_expire_backing_bucket takes exactly one account: the market,
+    // writable, owned by the program. No signer beyond the fee payer, no
+    // token accounts — it moves no tokens.
+    keys: [{ pubkey: market, isSigner: false, isWritable: true }],
+    data,
+  });
+  return {
+    reason:
+      `backing bucket domain ${bucket.domain} (asset ${bucket.assetIndex} ${bucket.side}) ` +
+      `is Fresh and lapsed at slot ${bucket.expirySlot}`,
+    // Tag 89 moves NO tokens. It forfeits the lapsed principal to the junior
+    // pool as the engine's documented expiry semantics — the alternative being
+    // that the account never settles at all.
+    expectedAtoms: null,
+    instructions: [ix],
+    detail: {
+      domain: bucket.domain,
+      assetIndex: bucket.assetIndex,
+      side: bucket.side,
+      expirySlot: bucket.expirySlot.toString(),
+      freshUnliened: bucket.freshUnlienedBackingNum.toString(),
+      validLiened: bucket.validLienedBackingNum.toString(),
+    },
+  };
+}
+
+// ─── Tag 78: LpVaultCrankFees ─────────────────────────────────────────────────
+
+export const lpVaultCrankFeesLeg: CrankLeg = {
+  name: "lpVaultCrankFees",
+  tag: 78,
+  async detect(snapshot, ctx) {
+    const { group, data, address, programId } = snapshot;
+
+    // Live-only by design (stricter than tag 84): this crank CONVERTS senior
+    // insurance into a junior LP claim that must still be paid out later, so
+    // "safe to drain now" does not transfer to Resolved/Recovery.
+    if (!isLiveOnlyLegEligible(group)) return [];
+
+    const claims = readFeeLegClaims(data);
+    feeCrankPendingClaimAtoms.set(
+      { market: address.toBase58().slice(0, 8), leg: "lp" },
+      Number(claims.lp),
+    );
+    if (claims.lp < ctx.thresholds.lpAtoms) return [];
+
+    // The vault registry must exist AND still hold real shares. The program
+    // rejects with LpVaultZeroSharesMinted (41) when outstanding shares are at
+    // or below the dead-share floor, because crediting principal that no share
+    // can claim strands the atoms. Check it here so we don't pay for a revert.
+    const [registryPda] = deriveLpVaultRegistry(programId, address);
+    const registryInfo = await ctx.connection.getAccountInfo(registryPda);
+    if (registryInfo === null) return [];
+
+    let domainIdx: number;
+    let sharesOutstanding: bigint;
+    try {
+      const registry = parseLpVaultRegistry(new Uint8Array(registryInfo.data));
+      domainIdx = Number(registry.domain);
+      sharesOutstanding = BigInt(registry.totalLpSharesOutstanding);
+    } catch (err) {
+      logger.debug("LP vault registry unparseable, skipping tag 78", {
+        market: address.toBase58().slice(0, 8),
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+    }
+
+    if (sharesOutstanding <= LP_VAULT_MINIMUM_LIQUIDITY) {
+      logger.debug("LP vault has no real shares outstanding, skipping tag 78", {
+        market: address.toBase58().slice(0, 8),
+        sharesOutstanding: sharesOutstanding.toString(),
+      });
+      return [];
+    }
+
+    const [ledgerPda] = deriveLpBackingLedger(programId, address, domainIdx);
+    const ix = buildIx({
+      programId,
+      keys: [
+        { pubkey: ctx.keypair.publicKey, isSigner: true, isWritable: false },
+        { pubkey: address, isSigner: false, isWritable: true },
+        { pubkey: registryPda, isSigner: false, isWritable: true },
+        { pubkey: ledgerPda, isSigner: false, isWritable: true },
+      ],
+      data: encodeLpVaultCrankFees(),
+    });
+
+    return [
+      {
+        reason: `LP fee leg has ${claims.lp} atoms outstanding`,
+        expectedAtoms: claims.lp,
+        instructions: [ix],
+        detail: { domain: domainIdx, sharesOutstanding: sharesOutstanding.toString() },
+      },
+    ];
+  },
+};
+
+/**
+ * `LP_VAULT_MINIMUM_LIQUIDITY` — the irreducible dead-share floor that is never
+ * minted and never redeemable. The program compares
+ * `total_lp_shares_outstanding <= LP_VAULT_MINIMUM_LIQUIDITY` and rejects.
+ *
+ * ⚠ Mirrored from `percolator-prog` `constants::LP_VAULT_MINIMUM_LIQUIDITY`
+ * because the SDK does not export it. If the SDK gains an export, import it
+ * instead of this literal. Being wrong here is benign in one direction only:
+ * too LOW and we pay for an occasional revert that classifies as benign
+ * Custom(41); too HIGH and we silently skip legitimate LP fee cranks.
+ */
+const LP_VAULT_MINIMUM_LIQUIDITY = 1_000n;
+
+// ─── Tag 87: WithdrawInsuranceReserveToStake ──────────────────────────────────
+
+export const insuranceReserveToStakeLeg: CrankLeg = {
+  name: "insuranceReserveToStake",
+  tag: 87,
+  async detect(snapshot, ctx) {
+    const { group, data, address, programId } = snapshot;
+
+    // Live-only, and deliberately stricter than tag 84 — this leg carries no
+    // authority signature at all, so allowing it in a terminal state would
+    // hand a permissionless drain to anyone. See the runbook warning below.
+    if (!isLiveOnlyLegEligible(group)) return [];
+
+    const claims = readFeeLegClaims(data);
+    feeCrankPendingClaimAtoms.set(
+      { market: address.toBase58().slice(0, 8), leg: "insuranceReserve" },
+      Number(claims.insuranceReserve),
+    );
+    if (claims.insuranceReserve < ctx.thresholds.insuranceReserveAtoms) return [];
+
+    // Destination is derived, never caller-chosen: the pool at
+    // ["stake_pool", market] under the pinned stake program, and `pool.vault`
+    // out of that pool's own bytes. We re-derive it here only to know whether
+    // the market has a bound pool at all — an unbound market can never satisfy
+    // this instruction and sending would be a guaranteed revert.
+    const [stakePoolPda] = deriveStakePool(address);
+    const poolInfo = await ctx.connection.getAccountInfo(stakePoolPda);
+    if (poolInfo === null) {
+      logger.debug("no stake pool bound to market, skipping tag 87", {
+        market: address.toBase58().slice(0, 8),
+      });
+      return [];
+    }
+
+    let stakeVault: PublicKey;
+    try {
+      stakeVault = decodeStakePool(new Uint8Array(poolInfo.data)).vault;
+    } catch (err) {
+      logger.debug("stake pool unparseable, skipping tag 87", {
+        market: address.toBase58().slice(0, 8),
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+    }
+
+    const cfg = parseWrapperConfigV17(data);
+    const [vaultAuthority] = deriveVaultAuthority(programId, address);
+    const marketVaultToken = resolveMarketVaultToken(cfg);
+    if (marketVaultToken === null) {
+      logger.debug("market vault token account unresolved, skipping tag 87", {
+        market: address.toBase58().slice(0, 8),
+      });
+      return [];
+    }
+
+    const ix = buildIx({
+      programId,
+      keys: [
+        { pubkey: ctx.keypair.publicKey, isSigner: true, isWritable: false },
+        { pubkey: address, isSigner: false, isWritable: true },
+        { pubkey: stakePoolPda, isSigner: false, isWritable: false },
+        { pubkey: stakeVault, isSigner: false, isWritable: true },
+        { pubkey: marketVaultToken, isSigner: false, isWritable: true },
+        { pubkey: vaultAuthority, isSigner: false, isWritable: false },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      ],
+      data: encodeWithdrawInsuranceReserveToStake(),
+    });
+
+    return [
+      {
+        reason: `staker fee leg has ${claims.insuranceReserve} atoms outstanding`,
+        expectedAtoms: claims.insuranceReserve,
+        instructions: [ix],
+        detail: { stakePool: stakePoolPda.toBase58().slice(0, 8) },
+      },
+    ];
+  },
+};
+
+// ─── Tag 84: WithdrawProtocolFee ──────────────────────────────────────────────
+
+export const protocolFeeLeg: CrankLeg = {
+  name: "protocolFee",
+  tag: 84,
+  async detect(snapshot, ctx) {
+    const { group, data, address, programId } = snapshot;
+
+    // Live OR fully-wound-down Resolved. Wider than tags 78/87 because tag 84
+    // is signer-gated AND is the protocol claim's only exit (W12).
+    if (!isProtocolFeeLegEligible(group)) return [];
+
+    const cfg = parseWrapperConfigV17(data);
+
+    // NOT permissionless: requires the protocol fee authority's signature.
+    // If this keeper does not hold that key, there is nothing to do — sending
+    // would revert with Unauthorized, which is NOT in the benign set and would
+    // (correctly) alarm every cycle.
+    if (!cfg.protocolFeeAuthority.equals(ctx.keypair.publicKey)) {
+      return [];
+    }
+
+    const claims = readFeeLegClaims(data);
+    feeCrankPendingClaimAtoms.set(
+      { market: address.toBase58().slice(0, 8), leg: "protocol" },
+      Number(claims.protocol),
+    );
+
+    // Threshold-gated so a sweep is never net-negative against transaction cost.
+    if (claims.protocol < ctx.thresholds.protocolAtoms) return [];
+
+    const destination = resolveProtocolFeeDestination();
+    if (destination === null) {
+      logger.warn(
+        "protocol fee sweep pending but KEEPER_PROTOCOL_FEE_DESTINATION is unset — skipping",
+        { market: address.toBase58().slice(0, 8), pendingAtoms: claims.protocol.toString() },
+      );
+      return [];
+    }
+
+    const marketVaultToken = resolveMarketVaultToken(cfg);
+    if (marketVaultToken === null) return [];
+    const [vaultAuthority] = deriveVaultAuthority(programId, address);
+
+    const ix = buildIx({
+      programId,
+      keys: [
+        { pubkey: ctx.keypair.publicKey, isSigner: true, isWritable: false },
+        { pubkey: address, isSigner: false, isWritable: true },
+        { pubkey: destination, isSigner: false, isWritable: true },
+        { pubkey: marketVaultToken, isSigner: false, isWritable: true },
+        { pubkey: vaultAuthority, isSigner: false, isWritable: false },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      ],
+      // amount 0 = "withdraw all currently-available capacity". The program
+      // clamps to what is actually available and marks only the ACTUALLY
+      // transferred amount as withdrawn, so a partial fill leaves the
+      // remainder claimable next cycle rather than marking it paid.
+      data: encodeWithdrawProtocolFee({ amount: 0n }),
+    });
+
+    return [
+      {
+        reason: `protocol fee leg has ${claims.protocol} atoms outstanding (threshold ${ctx.thresholds.protocolAtoms})`,
+        expectedAtoms: claims.protocol,
+        instructions: [ix],
+        detail: { destination: destination.toBase58().slice(0, 8) },
+      },
+    ];
+  },
+};
+
+const TOKEN_PROGRAM_ID = new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+
+function resolveProtocolFeeDestination(): PublicKey | null {
+  const raw = (process.env.KEEPER_PROTOCOL_FEE_DESTINATION ?? "").trim();
+  if (raw === "") return null;
+  try {
+    return new PublicKey(raw);
+  } catch {
+    logger.warn("KEEPER_PROTOCOL_FEE_DESTINATION is not a valid pubkey", { raw });
+    return null;
+  }
+}
+
+/**
+ * The market's collateral vault token account.
+ *
+ * ⚠ DEPENDENCY. The v17 wrapper config does not carry the vault token account
+ * pubkey directly — the program derives/validates it via
+ * `verify_withdrawable_token_accounts` against the vault authority PDA and the
+ * collateral mint. Resolving it correctly means computing the canonical ATA of
+ * `collateralMint` under the vault-authority PDA. Rather than reimplement ATA
+ * derivation (and its Token-2022 branch) here, this reads an operator-provided
+ * override and returns null otherwise, which makes the affected legs skip
+ * rather than send a malformed transaction.
+ *
+ * See the report: this is the one remaining piece that must be wired before
+ * tags 84/87 can run for real. Tag 89 — the liveness-critical one — does not
+ * need it, because it touches no token accounts.
+ */
+function resolveMarketVaultToken(
+  _cfg: ReturnType<typeof parseWrapperConfigV17>,
+): PublicKey | null {
+  const raw = (process.env.KEEPER_MARKET_VAULT_TOKEN ?? "").trim();
+  if (raw === "") return null;
+  try {
+    return new PublicKey(raw);
+  } catch {
+    return null;
+  }
+}
+
+// ─── The driver ───────────────────────────────────────────────────────────────
+
+export const ALL_LEGS: readonly CrankLeg[] = [
+  // Liveness first: a bricked domain is worse than an unswept fee pot, and if
+  // the cycle is going to run out of budget it should run out on revenue, not
+  // on user funds.
+  expireBackingBucketLeg,
+  lpVaultCrankFeesLeg,
+  insuranceReserveToStakeLeg,
+  protocolFeeLeg,
+];
+
+export interface LegOutcome {
+  market: string;
+  leg: LegName;
+  tag: number;
+  status: "sent" | "benign-reject" | "error" | "idle";
+  signature?: string;
+  atomsMoved?: bigint;
+  reason?: string;
+}
+
+/**
+ * Evaluate every leg against one market snapshot and send whatever is pending.
+ *
+ * Each (market, leg) is isolated: a throw anywhere inside a leg is caught,
+ * classified, counted and logged, and the next leg still runs.
+ */
+export async function runLegsForMarket(
+  snapshot: MarketSnapshot,
+  ctx: LegContext,
+  legs: readonly CrankLeg[] = ALL_LEGS,
+): Promise<LegOutcome[]> {
+  const marketLabel = snapshot.address.toBase58().slice(0, 8);
+  const outcomes: LegOutcome[] = [];
+
+  for (const leg of legs) {
+    let pending: PendingWork[];
+    try {
+      pending = await leg.detect(snapshot, ctx);
+    } catch (err) {
+      // A detector that throws must not take down the other legs. This is a
+      // real error — detection reads local bytes and derives PDAs, so a throw
+      // here means a layout or RPC problem worth surfacing.
+      feeCrankLegErrorsTotal.inc({ leg: leg.name, phase: "detect" });
+      logger.warn("fee-crank leg detection failed", {
+        market: marketLabel,
+        leg: leg.name,
+        tag: leg.tag,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      outcomes.push({
+        market: marketLabel,
+        leg: leg.name,
+        tag: leg.tag,
+        status: "error",
+        reason: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    if (pending.length === 0) {
+      feeCrankLegSkippedTotal.inc({ leg: leg.name });
+      outcomes.push({ market: marketLabel, leg: leg.name, tag: leg.tag, status: "idle" });
+      continue;
+    }
+
+    for (const work of pending) {
+      outcomes.push(await sendPendingWork(snapshot, ctx, leg, work, marketLabel));
+    }
+  }
+
+  return outcomes;
+}
+
+async function sendPendingWork(
+  snapshot: MarketSnapshot,
+  ctx: LegContext,
+  leg: CrankLeg,
+  work: PendingWork,
+  marketLabel: string,
+): Promise<LegOutcome> {
+  feeCrankLegAttemptsTotal.inc({ leg: leg.name });
+  logger.info("fee-crank leg has pending work", {
+    market: marketLabel,
+    leg: leg.name,
+    tag: leg.tag,
+    reason: work.reason,
+    expectedAtoms: work.expectedAtoms?.toString() ?? "n/a (moves no tokens)",
+    ...work.detail,
+  });
+
+  try {
+    // Reuses the repo's existing send hardening: budget gating, priority-fee
+    // estimation, retry/backoff and the shared queue from the recovery-cranker
+    // work. maxRetries=2 — these cranks are idempotent-ish (a re-send after the
+    // work is done reverts benignly), so a couple of retries is cheap, but they
+    // are not urgent enough to justify aggressive rebroadcast.
+    const result = await sharedTxQueue.enqueue("crank", () =>
+      keeperSend(ctx.connection, work.instructions, [ctx.keypair], "crank", sharedBudget, 2, {
+        // Preflight is worth paying for here: it is exactly what turns a
+        // by-design rejection into a cheap simulated error instead of a landed
+        // failed transaction we paid fees for.
+        skipPreflight: false,
+        multiRpcBroadcast: false,
+        simulateForCU: true,
+      }),
+    );
+
+    if (result === null) {
+      // Budget gate declined the send — not an error, just deferred.
+      feeCrankLegSkippedTotal.inc({ leg: leg.name });
+      logger.debug("fee-crank leg deferred by budget gate", {
+        market: marketLabel,
+        leg: leg.name,
+      });
+      return { market: marketLabel, leg: leg.name, tag: leg.tag, status: "idle" };
+    }
+
+    if (work.expectedAtoms !== null) {
+      feeCrankAtomsMovedTotal.inc({ leg: leg.name, market: marketLabel }, Number(work.expectedAtoms));
+    }
+    if (leg.tag === 89) {
+      feeCrankBucketsExpiredTotal.inc({ market: marketLabel });
+    }
+
+    logger.info("fee-crank leg sent", {
+      market: marketLabel,
+      leg: leg.name,
+      tag: leg.tag,
+      signature: result.signature,
+      // "Expected" rather than "moved": the program clamps every fee leg to the
+      // shared available pool, so a partial fill is normal and the remainder
+      // stays claimable next cycle. Confirming the actual delta needs a
+      // post-send re-read, which the runbook does rather than the hot path.
+      expectedAtoms: work.expectedAtoms?.toString() ?? "0",
+      engineAvailableAtoms: engineAvailableAtoms(snapshot.group).toString(),
+      ...work.detail,
+    });
+
+    return {
+      market: marketLabel,
+      leg: leg.name,
+      tag: leg.tag,
+      status: "sent",
+      signature: result.signature,
+      ...(work.expectedAtoms !== null ? { atomsMoved: work.expectedAtoms } : {}),
+    };
+  } catch (err) {
+    const classification = classifyRejection(err);
+    if (classification.benign) {
+      feeCrankLegBenignRejectsTotal.inc({
+        leg: leg.name,
+        code: String(classification.code),
+      });
+      logger.debug("fee-crank leg rejected by design", {
+        market: marketLabel,
+        leg: leg.name,
+        tag: leg.tag,
+        code: classification.code,
+        reason: classification.reason,
+      });
+      return {
+        market: marketLabel,
+        leg: leg.name,
+        tag: leg.tag,
+        status: "benign-reject",
+        reason: classification.reason,
+      };
+    }
+
+    feeCrankLegErrorsTotal.inc({ leg: leg.name, phase: "send" });
+    logger.warn("fee-crank leg failed", {
+      market: marketLabel,
+      leg: leg.name,
+      tag: leg.tag,
+      code: classification.code,
+      error: classification.reason.slice(0, 200),
+    });
+    return {
+      market: marketLabel,
+      leg: leg.name,
+      tag: leg.tag,
+      status: "error",
+      reason: classification.reason,
+    };
+  }
+}
+
+/**
+ * Is the fee crank allowed to run?
+ *
+ * OFF unless explicitly enabled. This service moves real value (three of its
+ * four legs sweep collateral) and tag 89 forfeits lapsed principal to the
+ * junior pool as the engine's documented expiry semantics. Neither should
+ * begin the moment a keeper build ships; an operator turns it on deliberately,
+ * after the runbook checks. Defaulting to on would also mean the very first
+ * deploy of this code starts sweeping every market it can discover.
+ */
+export function isFeeCrankEnabled(): boolean {
+  return (process.env.KEEPER_FEE_CRANK_ENABLED ?? "").trim() === "true";
+}
+
+/**
+ * Fetch the given markets, build snapshots and run one full cycle.
+ *
+ * Fetches in one `getMultipleAccountsInfo` batch rather than per leg: all four
+ * legs read the same account, so the single-snapshot-per-market design costs
+ * one RPC round trip for the whole cycle instead of four per market.
+ */
+export async function runFeeCrankPass(
+  connection: Connection,
+  keypair: Keypair,
+  markets: readonly { address: PublicKey; programId: PublicKey }[],
+  thresholds: FeeCrankThresholds = loadFeeCrankThresholds(),
+): Promise<LegOutcome[]> {
+  if (markets.length === 0) return [];
+
+  let chainSlot: bigint;
+  let infos: (Awaited<ReturnType<Connection["getAccountInfo"]>>)[];
+  try {
+    [chainSlot, infos] = await Promise.all([
+      connection.getSlot().then((s) => BigInt(s)),
+      connection.getMultipleAccountsInfo(markets.map((m) => m.address)),
+    ]);
+  } catch (err) {
+    // A failed fetch is not a per-market failure — nothing was evaluated, so
+    // there is nothing to isolate. Report once and let the next cycle retry.
+    logger.warn("fee-crank pass could not load market accounts", {
+      markets: markets.length,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+
+  const snapshots: MarketSnapshot[] = [];
+  for (const [i, market] of markets.entries()) {
+    const info = infos[i];
+    if (!info) continue;
+    const snapshot = buildSnapshot(
+      market.address,
+      market.programId,
+      new Uint8Array(info.data),
+      chainSlot,
+    );
+    if (snapshot !== null) snapshots.push(snapshot);
+  }
+
+  return runFeeCrankCycle(snapshots, { connection, keypair, thresholds });
+}
+
+/**
+ * Build a snapshot from raw account bytes. Returns null when the account is not
+ * a usable v17 market (too short to contain the market group header), which the
+ * caller should treat as "skip", not "fail".
+ */
+export function buildSnapshot(
+  address: PublicKey,
+  programId: PublicKey,
+  data: Uint8Array,
+  chainSlot: bigint,
+): MarketSnapshot | null {
+  if (data.length < V17_MARKET_GROUP_MIN_LEN) return null;
+  try {
+    return { address, programId, data, group: readMarketGroupState(data), chainSlot };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One full cycle across many markets.
+ *
+ * Markets run concurrently but each market's legs run in sequence, so a single
+ * market never has four transactions in flight competing for the same account
+ * lock. `Promise.allSettled` guarantees one market's failure cannot abort the
+ * cycle for any other.
+ */
+export async function runFeeCrankCycle(
+  snapshots: readonly MarketSnapshot[],
+  ctx: LegContext,
+  legs: readonly CrankLeg[] = ALL_LEGS,
+): Promise<LegOutcome[]> {
+  const settled = await Promise.allSettled(
+    snapshots.map((snapshot) => runLegsForMarket(snapshot, ctx, legs)),
+  );
+
+  const outcomes: LegOutcome[] = [];
+  for (const [index, result] of settled.entries()) {
+    if (result.status === "fulfilled") {
+      outcomes.push(...result.value);
+      continue;
+    }
+    // runLegsForMarket already isolates per leg, so reaching here means
+    // something outside the per-leg try/catch failed. Still isolated per market.
+    const label = snapshots[index]?.address.toBase58().slice(0, 8) ?? "unknown";
+    feeCrankLegErrorsTotal.inc({ leg: "cycle", phase: "market" });
+    logger.warn("fee-crank market cycle failed", {
+      market: label,
+      error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+    });
+  }
+
+  const sent = outcomes.filter((o) => o.status === "sent").length;
+  const benign = outcomes.filter((o) => o.status === "benign-reject").length;
+  const errored = outcomes.filter((o) => o.status === "error").length;
+  logger.info("fee-crank cycle complete", {
+    markets: snapshots.length,
+    sent,
+    benignRejects: benign,
+    errors: errored,
+  });
+
+  return outcomes;
+}

--- a/src/services/fee-crank.ts
+++ b/src/services/fee-crank.ts
@@ -56,6 +56,7 @@ import {
   deriveLpBackingLedger,
   deriveLpVaultRegistry,
   deriveStakePool,
+  deriveCanonicalVault,
   deriveVaultAuthority,
   encodeExpireBackingBucket,
   encodeLpVaultCrankFees,
@@ -506,13 +507,7 @@ export const insuranceReserveToStakeLeg: CrankLeg = {
 
     const cfg = parseWrapperConfigV17(data);
     const [vaultAuthority] = deriveVaultAuthority(programId, address);
-    const marketVaultToken = resolveMarketVaultToken(cfg);
-    if (marketVaultToken === null) {
-      logger.debug("market vault token account unresolved, skipping tag 87", {
-        market: address.toBase58().slice(0, 8),
-      });
-      return [];
-    }
+    const marketVaultToken = resolveMarketVaultToken(programId, address, cfg);
 
     const ix = buildIx({
       programId,
@@ -579,8 +574,7 @@ export const protocolFeeLeg: CrankLeg = {
       return [];
     }
 
-    const marketVaultToken = resolveMarketVaultToken(cfg);
-    if (marketVaultToken === null) return [];
+    const marketVaultToken = resolveMarketVaultToken(programId, address, cfg);
     const [vaultAuthority] = deriveVaultAuthority(programId, address);
 
     const ix = buildIx({
@@ -625,31 +619,38 @@ function resolveProtocolFeeDestination(): PublicKey | null {
 }
 
 /**
- * The market's collateral vault token account.
+ * The market's collateral vault token account — DERIVED, per market.
  *
- * ⚠ DEPENDENCY. The v17 wrapper config does not carry the vault token account
- * pubkey directly — the program derives/validates it via
- * `verify_withdrawable_token_accounts` against the vault authority PDA and the
- * collateral mint. Resolving it correctly means computing the canonical ATA of
- * `collateralMint` under the vault-authority PDA. Rather than reimplement ATA
- * derivation (and its Token-2022 branch) here, this reads an operator-provided
- * override and returns null otherwise, which makes the affected legs skip
- * rather than send a malformed transaction.
+ * The v17 wrapper config does not store the vault token pubkey; the program
+ * computes it (`canonical_vault_address`, v16_program.rs) as the Associated
+ * Token Account of the market's `["vault", market]` authority PDA for the
+ * collateral mint, and pins the market to that single address (F-VAULT-FRAG) in
+ * `verify_withdrawable_token_accounts`. `deriveCanonicalVault` (SDK >= 4.2.0)
+ * reproduces that derivation seed-for-seed, so we derive it here rather than
+ * being told it.
  *
- * See the report: this is the one remaining piece that must be wired before
- * tags 84/87 can run for real. Tag 89 — the liveness-critical one — does not
- * need it, because it touches no token accounts.
+ * There is no Token-2022 branch to handle: `verify_token_program` rejects any
+ * token program that is not `spl_token::ID`, and `unpack_token_account` rejects
+ * any token account not OWNED by `spl_token::ID`, so the ATA's middle seed is
+ * always legacy SPL Token. The SDK pins the same constant.
+ *
+ * PREVIOUSLY this read a single global `KEEPER_MARKET_VAULT_TOKEN` env var and
+ * returned null when unset. That was wrong in two ways, both observed on the
+ * first real v17 market:
+ *   1. Unset (the default) silently disabled BOTH revenue legs — tags 84 and 87
+ *      no-opped forever while fees accrued, with only a debug line.
+ *   2. Set, it is a per-PROCESS constant standing in for a per-MARKET address.
+ *      With more than one market it would send some other market's vault, which
+ *      the F-VAULT-FRAG pin rejects as InvalidVaultAccount (12) — a guaranteed
+ *      revert on every market but one.
  */
 function resolveMarketVaultToken(
-  _cfg: ReturnType<typeof parseWrapperConfigV17>,
-): PublicKey | null {
-  const raw = (process.env.KEEPER_MARKET_VAULT_TOKEN ?? "").trim();
-  if (raw === "") return null;
-  try {
-    return new PublicKey(raw);
-  } catch {
-    return null;
-  }
+  programId: PublicKey,
+  market: PublicKey,
+  cfg: ReturnType<typeof parseWrapperConfigV17>,
+): PublicKey {
+  const [vaultToken] = deriveCanonicalVault(programId, market, cfg.collateralMint);
+  return vaultToken;
 }
 
 // ─── The driver ───────────────────────────────────────────────────────────────

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -1071,13 +1071,16 @@ export class LiquidationService {
       // for single-asset markets). For v12.x markets, accountIdx is the slab slot.
       // #329: use the scan-time closeQ; it will be re-derived from the fresh portfolio
       // in the pre-submit recheck below and the instruction data rebuilt if changed.
+      // ABI: close_q/fee_bps were REMOVED from the PermissionlessCrank wire
+      // upstream (#206) — the program derives the close size from on-chain
+      // portfolio state at execution time rather than trusting a caller-supplied
+      // quantity. `closeQ` is therefore still used for the keeper's OWN
+      // scan/eligibility decisions below, but it no longer reaches the chain.
       let effectiveCloseQ = closeQ;
       const crankData = encodePermissionlessCrank({
         action: CrankAction.Liquidate,
         assetIndex: accountIdx, // v17: leg.assetIndex; v12: slab slot
         nowSlot,
-        closeQ: effectiveCloseQ,
-        feeBps: 0n,
         recoveryReason: 0,
       });
 
@@ -1225,20 +1228,16 @@ export class LiquidationService {
               });
               return null;
             }
-            // #329: If the fresh closeQ differs from the scan-time value (position
-            // partially closed), rebuild the crank instruction with the updated value
-            // so the on-chain close_q matches the actual remaining position size.
+            // #329 (SUPERSEDED BY UPSTREAM #206): this used to rebuild the crank
+            // instruction when the position had partially closed between scan and
+            // submit, so the encoded close_q matched the remaining size. close_q
+            // is no longer part of the wire — the program reads the portfolio and
+            // derives the close size itself — so the rebuilt bytes would be
+            // identical to the original and the whole hazard #329 addressed is
+            // now handled on-chain. The fresh read is kept because the tracked
+            // value still feeds the keeper's post-submit accounting below.
             if (freshCloseQ > 0n && freshCloseQ !== effectiveCloseQ) {
               effectiveCloseQ = freshCloseQ;
-              const updatedCrankData = encodePermissionlessCrank({
-                action: CrankAction.Liquidate,
-                assetIndex: accountIdx,
-                nowSlot,
-                closeQ: effectiveCloseQ,
-                feeBps: 0n,
-                recoveryReason: 0,
-              });
-              instructions[0] = buildIx({ programId, keys: crankKeys, data: updatedCrankData });
             }
           }
         } catch {

--- a/src/services/monitor.ts
+++ b/src/services/monitor.ts
@@ -54,13 +54,24 @@ const ALERT_COOLDOWN_MS = 5 * 60_000;
 
 export interface MarketInvariantResult {
   slabAddress: string;
-  ok: boolean;
-  /** Actual SPL token balance in the vault token account */
-  vaultTokenBalance: string;
-  /** engine.vault — what the program believes is in the vault */
-  engineVault: string;
-  /** Shortfall: engineVault - vaultTokenBalance (0n when ok) */
-  shortfall: string;
+  /**
+   * true  = invariant evaluated and holds
+   * false = invariant evaluated and VIOLATED (funds may have leaked)
+   * null  = NOT EVALUATED — no conclusion available
+   *
+   * #347: `null` exists because this used to report `true` for v17 markets
+   * without checking anything. Since the v17 cutover that is every production
+   * market, so the only fund-conservation tripwire in the codebase was emitting
+   * a green signal it had never computed. An unevaluated check must never be
+   * indistinguishable from a passing one.
+   */
+  ok: boolean | null;
+  /** Actual SPL token balance in the vault token account. null when unevaluated. */
+  vaultTokenBalance: string | null;
+  /** engine.vault — what the program believes is in the vault. null when unevaluated. */
+  engineVault: string | null;
+  /** Shortfall: engineVault - vaultTokenBalance (0n when ok). null when unevaluated. */
+  shortfall: string | null;
   checkedAt: number;
   skippedReason?: string;
 }
@@ -196,14 +207,25 @@ export class MonitorService {
           `fetchSlab(${slabAddress.slice(0, 8)})`,
         );
         if (isV17Account(data)) {
+          // #347: report UNCHECKED, not healthy. The legacy formula reads
+          // engine.vault, a v12 field, so it genuinely cannot run here — but
+          // "the old formula doesn't apply" is not "the vault is fine". The
+          // zeroed balances were just as misleading as ok:true: a dashboard
+          // showing shortfall "0" reads as "checked, nothing missing".
+          //
+          // A real v17 invariant (sum insurance fund + Σ portfolio capital/pnl
+          // backing vs getTokenAccountBalance) still needs building — see #347.
+          // Until then this surfaces the gap instead of masking it.
           this._invariantResults.set(slabAddress, {
             slabAddress,
-            ok: true,
-            vaultTokenBalance: "0",
-            engineVault: "0",
-            shortfall: "0",
+            ok: null,
+            vaultTokenBalance: null,
+            engineVault: null,
+            shortfall: null,
             checkedAt: now,
-            skippedReason: "v17 market account: legacy engine.vault invariant is not applicable",
+            skippedReason:
+              "UNCHECKED — v17 market account: the legacy engine.vault invariant does not apply " +
+              "and no v17 equivalent is implemented yet (#347). This is NOT a passing check.",
           });
           this._adlStalenessResults.set(slabAddress, {
             slabAddress,

--- a/tests/lib/oracle-account.test.ts
+++ b/tests/lib/oracle-account.test.ts
@@ -3,7 +3,12 @@ import { PublicKey } from "@solana/web3.js";
 
 const PYTH_PDA = PublicKey.unique();
 
-vi.mock("@percolatorct/sdk", () => ({
+// Partial mock: real exports fill anything this factory does not override.
+// A full-replacement mock silently breaks whenever the source under test
+// imports a new SDK export (e.g. the v17 layout constants), and the failure
+// surfaces as an unrelated "no export defined on the mock" at import time.
+vi.mock("@percolatorct/sdk", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   derivePythPushOraclePDA: vi.fn(() => [PYTH_PDA, 0]),
 }));
 vi.mock("@percolatorct/shared", () => ({

--- a/tests/lib/v17-fee-state.test.ts
+++ b/tests/lib/v17-fee-state.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from "vitest";
+import {
+  BACKING_BUCKET_LEN,
+  BUCKET_EXPIRY_SLOT_OFF,
+  BUCKET_FRESH_UNLIENED_OFF,
+  BUCKET_STATUS_EMPTY,
+  BUCKET_STATUS_EXPIRED,
+  BUCKET_STATUS_FRESH,
+  BUCKET_STATUS_IMPAIRED,
+  BUCKET_STATUS_OFF,
+  MG_CURRENT_SLOT_OFF,
+  MG_C_TOT_OFF,
+  MG_INSURANCE_DOMAIN_BUDGET_REMAINING_TOTAL_OFF,
+  MG_INSURANCE_OFF,
+  MG_MATERIALIZED_PORTFOLIO_COUNT_OFF,
+  MG_MODE_OFF,
+  MG_SOURCE_INSURANCE_CREDIT_RESERVED_ATOMS_OFF,
+  V16_CFG_MAX_MARKET_SLOTS_OFF,
+  V17_ASSET_SLOTS_BASE_OFF,
+  V17_MARKET_ASSET_SLOT_LEN,
+  backingBucketOff,
+  engineConfigFieldOff,
+  marketGroupFieldOff,
+} from "../../src/lib/v17-layout.js";
+import {
+  engineAvailableAtoms,
+  findExpirableBuckets,
+  findLapsingSoonBuckets,
+  isBucketExpiryEligible,
+  isLiveOnlyLegEligible,
+  isProtocolFeeLegEligible,
+  readBackingBuckets,
+  readMarketGroupState,
+  readU128LE,
+  readU64LE,
+} from "../../src/lib/v17-fee-state.js";
+
+// ─── Synthetic v17 market account builder ─────────────────────────────────────
+// Writes real bytes at the real offsets so the readers are exercised against
+// the same layout they will see on chain. Nothing here duplicates an offset —
+// every position comes from v17-layout.ts.
+
+function writeU32LE(data: Uint8Array, off: number, value: number): void {
+  for (let i = 0; i < 4; i++) data[off + i] = (value >>> (8 * i)) & 0xff;
+}
+function writeU64LE(data: Uint8Array, off: number, value: bigint): void {
+  for (let i = 0; i < 8; i++) data[off + i] = Number((value >> (8n * BigInt(i))) & 0xffn);
+}
+function writeU128LE(data: Uint8Array, off: number, value: bigint): void {
+  writeU64LE(data, off, value & ((1n << 64n) - 1n));
+  writeU64LE(data, off + 8, value >> 64n);
+}
+
+interface BucketSpec {
+  domain: number;
+  status: number;
+  expirySlot: bigint;
+  freshUnliened?: bigint;
+}
+
+interface MarketSpec {
+  mode?: number;
+  currentSlot?: bigint;
+  insurance?: bigint;
+  cTot?: bigint;
+  materializedPortfolioCount?: bigint;
+  sourceInsuranceReserved?: bigint;
+  insuranceDomainBudgetRemaining?: bigint;
+  maxMarketSlots?: number;
+  assetSlots?: number;
+  buckets?: BucketSpec[];
+}
+
+function buildMarketAccount(spec: MarketSpec = {}): Uint8Array {
+  const assetSlots = spec.assetSlots ?? 2;
+  const data = new Uint8Array(V17_ASSET_SLOTS_BASE_OFF + assetSlots * V17_MARKET_ASSET_SLOT_LEN);
+
+  writeU32LE(
+    data,
+    engineConfigFieldOff(V16_CFG_MAX_MARKET_SLOTS_OFF),
+    spec.maxMarketSlots ?? assetSlots,
+  );
+  data[marketGroupFieldOff(MG_MODE_OFF)] = spec.mode ?? 0;
+  writeU64LE(data, marketGroupFieldOff(MG_CURRENT_SLOT_OFF), spec.currentSlot ?? 0n);
+  writeU128LE(data, marketGroupFieldOff(MG_INSURANCE_OFF), spec.insurance ?? 0n);
+  writeU128LE(data, marketGroupFieldOff(MG_C_TOT_OFF), spec.cTot ?? 0n);
+  writeU64LE(
+    data,
+    marketGroupFieldOff(MG_MATERIALIZED_PORTFOLIO_COUNT_OFF),
+    spec.materializedPortfolioCount ?? 0n,
+  );
+  writeU128LE(
+    data,
+    marketGroupFieldOff(MG_SOURCE_INSURANCE_CREDIT_RESERVED_ATOMS_OFF),
+    spec.sourceInsuranceReserved ?? 0n,
+  );
+  writeU128LE(
+    data,
+    marketGroupFieldOff(MG_INSURANCE_DOMAIN_BUDGET_REMAINING_TOTAL_OFF),
+    spec.insuranceDomainBudgetRemaining ?? 0n,
+  );
+
+  for (const bucket of spec.buckets ?? []) {
+    const base = backingBucketOff(bucket.domain);
+    data[base + BUCKET_STATUS_OFF] = bucket.status;
+    writeU64LE(data, base + BUCKET_EXPIRY_SLOT_OFF, bucket.expirySlot);
+    writeU128LE(data, base + BUCKET_FRESH_UNLIENED_OFF, bucket.freshUnliened ?? 0n);
+  }
+
+  return data;
+}
+
+describe("readMarketGroupState", () => {
+  it("reads header fields from the post-fee-split offsets", () => {
+    const data = buildMarketAccount({
+      mode: 2,
+      currentSlot: 123_456n,
+      insurance: 9_000n,
+      cTot: 77n,
+      materializedPortfolioCount: 5n,
+      maxMarketSlots: 4,
+      assetSlots: 3,
+    });
+    const group = readMarketGroupState(data);
+    expect(group.mode).toBe(2);
+    expect(group.currentSlot).toBe(123_456n);
+    expect(group.insurance).toBe(9_000n);
+    expect(group.cTot).toBe(77n);
+    expect(group.materializedPortfolioCount).toBe(5n);
+    expect(group.maxMarketSlots).toBe(4);
+    expect(group.assetSlotCount).toBe(3);
+  });
+
+  it("does not confuse adjacent u128 aggregates", () => {
+    // insurance / c_tot / the two clamp operands are all u128 and adjacent-ish;
+    // an off-by-16 read would silently swap them. Give each a unique value.
+    const data = buildMarketAccount({
+      insurance: 1n,
+      cTot: 2n,
+      sourceInsuranceReserved: 3n,
+      insuranceDomainBudgetRemaining: 4n,
+    });
+    const group = readMarketGroupState(data);
+    expect(group.insurance).toBe(1n);
+    expect(group.cTot).toBe(2n);
+    expect(group.sourceInsuranceCreditReservedTotalAtoms).toBe(3n);
+    expect(group.insuranceDomainBudgetRemainingTotal).toBe(4n);
+  });
+
+  it("refuses a buffer too short to hold the market group header", () => {
+    expect(() => readMarketGroupState(new Uint8Array(512))).toThrow(/too short/i);
+    // The stale-432 layout would have thought 1206 bytes was enough.
+    expect(() => readMarketGroupState(new Uint8Array(1206))).toThrow(/too short/i);
+  });
+});
+
+describe("engineAvailableAtoms — the shared clamp all three fee legs draw against", () => {
+  it("subtracts both reservations", () => {
+    const group = readMarketGroupState(
+      buildMarketAccount({
+        insurance: 1_000n,
+        sourceInsuranceReserved: 300n,
+        insuranceDomainBudgetRemaining: 200n,
+      }),
+    );
+    expect(engineAvailableAtoms(group)).toBe(500n);
+  });
+
+  it("saturates at zero rather than underflowing", () => {
+    // A bigint underflow here would produce a negative number that then reads as
+    // an enormous available pool — exactly the wrong direction to be wrong in.
+    const group = readMarketGroupState(
+      buildMarketAccount({
+        insurance: 100n,
+        sourceInsuranceReserved: 400n,
+        insuranceDomainBudgetRemaining: 900n,
+      }),
+    );
+    expect(engineAvailableAtoms(group)).toBe(0n);
+  });
+});
+
+describe("mode gates match the program's per-tag rules", () => {
+  const live = readMarketGroupState(buildMarketAccount({ mode: 0 }));
+  const recovery = readMarketGroupState(buildMarketAccount({ mode: 2 }));
+  const resolvedWoundDown = readMarketGroupState(
+    buildMarketAccount({ mode: 1, materializedPortfolioCount: 0n, cTot: 0n }),
+  );
+  const resolvedBusy = readMarketGroupState(
+    buildMarketAccount({ mode: 1, materializedPortfolioCount: 3n, cTot: 0n }),
+  );
+
+  it("tags 78/87 are Live-only", () => {
+    expect(isLiveOnlyLegEligible(live)).toBe(true);
+    expect(isLiveOnlyLegEligible(recovery)).toBe(false);
+    expect(isLiveOnlyLegEligible(resolvedWoundDown)).toBe(false);
+  });
+
+  it("tag 89 is Live-only", () => {
+    expect(isBucketExpiryEligible(live)).toBe(true);
+    expect(isBucketExpiryEligible(recovery)).toBe(false);
+    expect(isBucketExpiryEligible(resolvedWoundDown)).toBe(false);
+  });
+
+  it("tag 84 additionally allows fully-wound-down Resolved (W12)", () => {
+    expect(isProtocolFeeLegEligible(live)).toBe(true);
+    expect(isProtocolFeeLegEligible(resolvedWoundDown)).toBe(true);
+    // Resolved but still holding portfolios/capital: program returns EngineLockActive.
+    expect(isProtocolFeeLegEligible(resolvedBusy)).toBe(false);
+    // Recovery is never allowed for any leg.
+    expect(isProtocolFeeLegEligible(recovery)).toBe(false);
+  });
+
+  it("rejects a Resolved market with outstanding c_tot", () => {
+    const resolvedWithCapital = readMarketGroupState(
+      buildMarketAccount({ mode: 1, materializedPortfolioCount: 0n, cTot: 1n }),
+    );
+    expect(isProtocolFeeLegEligible(resolvedWithCapital)).toBe(false);
+  });
+});
+
+describe("readBackingBuckets — domain addressing", () => {
+  it("reads each domain's bucket independently", () => {
+    const data = buildMarketAccount({
+      assetSlots: 2,
+      maxMarketSlots: 2,
+      buckets: [
+        { domain: 0, status: BUCKET_STATUS_FRESH, expirySlot: 100n, freshUnliened: 11n },
+        { domain: 1, status: BUCKET_STATUS_EXPIRED, expirySlot: 200n, freshUnliened: 22n },
+        { domain: 2, status: BUCKET_STATUS_IMPAIRED, expirySlot: 300n, freshUnliened: 33n },
+        { domain: 3, status: BUCKET_STATUS_EMPTY, expirySlot: 400n, freshUnliened: 44n },
+      ],
+    });
+    const group = readMarketGroupState(data);
+    const buckets = readBackingBuckets(data, group);
+
+    expect(buckets).toHaveLength(4);
+    expect(buckets[0]).toMatchObject({
+      domain: 0, assetIndex: 0, side: "long",
+      status: BUCKET_STATUS_FRESH, expirySlot: 100n, freshUnlienedBackingNum: 11n,
+    });
+    expect(buckets[1]).toMatchObject({ domain: 1, assetIndex: 0, side: "short", expirySlot: 200n });
+    expect(buckets[2]).toMatchObject({ domain: 2, assetIndex: 1, side: "long", expirySlot: 300n });
+    expect(buckets[3]).toMatchObject({ domain: 3, assetIndex: 1, side: "short", expirySlot: 400n });
+  });
+
+  it("writing one bucket does not bleed into its neighbour", () => {
+    // Buckets are adjacent (long at +947, short at +1044, 97 bytes each). An
+    // off-by-one in BACKING_BUCKET_LEN would make these overlap.
+    const data = buildMarketAccount({
+      assetSlots: 1, maxMarketSlots: 1,
+      buckets: [{ domain: 0, status: BUCKET_STATUS_FRESH, expirySlot: 0xffff_ffffn, freshUnliened: (1n << 100n) }],
+    });
+    const group = readMarketGroupState(data);
+    const buckets = readBackingBuckets(data, group);
+    expect(buckets[0]!.expirySlot).toBe(0xffff_ffffn);
+    expect(buckets[0]!.freshUnlienedBackingNum).toBe(1n << 100n);
+    expect(buckets[1]!.status).toBe(BUCKET_STATUS_EMPTY);
+    expect(buckets[1]!.expirySlot).toBe(0n);
+  });
+
+  it("iterates min(configured domains, physically present slots)", () => {
+    // Configured for 8 assets but the account only holds 2 — reading on the
+    // configured count alone would run past the buffer.
+    const data = buildMarketAccount({ assetSlots: 2, maxMarketSlots: 8 });
+    const group = readMarketGroupState(data);
+    expect(readBackingBuckets(data, group)).toHaveLength(4); // 2 assets × 2 sides
+  });
+
+  it("stays in bounds when the account holds more slots than configured", () => {
+    const data = buildMarketAccount({ assetSlots: 4, maxMarketSlots: 1 });
+    const group = readMarketGroupState(data);
+    expect(readBackingBuckets(data, group)).toHaveLength(2); // 1 asset × 2 sides
+  });
+});
+
+describe("findExpirableBuckets — tag 89 detection", () => {
+  const mk = (specs: BucketSpec[]) => {
+    const data = buildMarketAccount({ assetSlots: 2, maxMarketSlots: 2, buckets: specs });
+    return readBackingBuckets(data, readMarketGroupState(data));
+  };
+
+  it("selects Fresh buckets at or past their expiry slot", () => {
+    const buckets = mk([
+      { domain: 0, status: BUCKET_STATUS_FRESH, expirySlot: 100n }, // lapsed
+      { domain: 1, status: BUCKET_STATUS_FRESH, expirySlot: 500n }, // not yet
+      { domain: 2, status: BUCKET_STATUS_FRESH, expirySlot: 200n }, // exactly at expiry
+    ]);
+    const found = findExpirableBuckets(buckets, 200n, 0n);
+    expect(found.map((b) => b.domain).sort()).toEqual([0, 2]);
+  });
+
+  it("ignores buckets that are not Fresh — the engine rejects those with Stale", () => {
+    const buckets = mk([
+      { domain: 0, status: BUCKET_STATUS_EMPTY, expirySlot: 1n },
+      { domain: 1, status: BUCKET_STATUS_EXPIRED, expirySlot: 1n },
+      { domain: 2, status: BUCKET_STATUS_IMPAIRED, expirySlot: 1n },
+      { domain: 3, status: BUCKET_STATUS_FRESH, expirySlot: 1n },
+    ]);
+    expect(findExpirableBuckets(buckets, 9_999n, 0n).map((b) => b.domain)).toEqual([3]);
+  });
+
+  it("uses max(chainSlot, engineCurrentSlot), matching the program's now_slot", () => {
+    const buckets = mk([{ domain: 0, status: BUCKET_STATUS_FRESH, expirySlot: 1_000n }]);
+    // Chain slot behind, engine ahead: the program WOULD accept, so we must too.
+    // Missing this means a bricked domain stays bricked.
+    expect(findExpirableBuckets(buckets, 500n, 2_000n)).toHaveLength(1);
+    // Engine behind, chain ahead: also accepted.
+    expect(findExpirableBuckets(buckets, 2_000n, 500n)).toHaveLength(1);
+    // Both behind: not yet due — sending would waste a fee on a Stale revert.
+    expect(findExpirableBuckets(buckets, 500n, 900n)).toHaveLength(0);
+  });
+
+  it("finds nothing on a market with no backing activity (never cranks blind)", () => {
+    const data = buildMarketAccount({ assetSlots: 2, maxMarketSlots: 2 });
+    const buckets = readBackingBuckets(data, readMarketGroupState(data));
+    expect(findExpirableBuckets(buckets, 10_000_000n, 10_000_000n)).toHaveLength(0);
+  });
+});
+
+describe("findLapsingSoonBuckets — leading indicator for cadence", () => {
+  it("flags Fresh buckets inside the horizon but not the already-lapsed ones", () => {
+    const data = buildMarketAccount({
+      assetSlots: 2, maxMarketSlots: 2,
+      buckets: [
+        { domain: 0, status: BUCKET_STATUS_FRESH, expirySlot: 900n },   // already lapsed
+        { domain: 1, status: BUCKET_STATUS_FRESH, expirySlot: 1_500n }, // within horizon
+        { domain: 2, status: BUCKET_STATUS_FRESH, expirySlot: 9_000n }, // beyond horizon
+      ],
+    });
+    const buckets = readBackingBuckets(data, readMarketGroupState(data));
+    const soon = findLapsingSoonBuckets(buckets, 1_000n, 0n, 1_000n);
+    expect(soon.map((b) => b.domain)).toEqual([1]);
+  });
+});
+
+describe("primitive readers", () => {
+  it("round-trips u64 and u128 little-endian", () => {
+    const data = new Uint8Array(64);
+    writeU64LE(data, 0, 0xdead_beef_cafe_baben);
+    writeU128LE(data, 16, (1n << 127n) - 1n);
+    expect(readU64LE(data, 0)).toBe(0xdead_beef_cafe_baben);
+    expect(readU128LE(data, 16)).toBe((1n << 127n) - 1n);
+  });
+
+  it("throws rather than returning garbage when out of bounds", () => {
+    const data = new Uint8Array(8);
+    expect(() => readU64LE(data, 4)).toThrow(/out of bounds/i);
+    expect(() => readU128LE(data, 0)).toThrow(/out of bounds/i);
+  });
+});
+
+describe("bucket layout constant", () => {
+  it("BACKING_BUCKET_LEN matches the engine struct", () => {
+    expect(BACKING_BUCKET_LEN).toBe(97);
+    expect(BUCKET_STATUS_OFF).toBe(96);
+    expect(BUCKET_EXPIRY_SLOT_OFF).toBe(88);
+  });
+});
+
+// ─── Cross-implementation check against the SDK's own parser ──────────────────
+// The strongest verification available without a live market: the SDK parses
+// the same market-group header independently (its own offset table, written by
+// a different author for a different purpose). If bytes written at MY offsets
+// read back correctly through ITS parser, both derivations agree — and this
+// module's readers are not merely self-consistent.
+
+describe("cross-check: bytes written at our offsets parse correctly via the SDK", () => {
+  it("SDK parseMarketGroupV17OI reads the insurance balance we wrote", async () => {
+    const { parseMarketGroupV17OI, isV17MarketAccount, V17_MAGIC, V17_KIND_OFF, V17_KIND_MARKET } =
+      await import("@percolatorct/sdk");
+
+    const data = buildMarketAccount({ assetSlots: 2, maxMarketSlots: 2, insurance: 424_242n });
+
+    // Stamp the v17 account header so the SDK accepts the buffer: magic u64 LE
+    // at 0, version at 8, kind at V17_KIND_OFF.
+    writeU64LE(data, 0, V17_MAGIC);
+    data[8] = 17;
+    data[V17_KIND_OFF] = V17_KIND_MARKET;
+    expect(isV17MarketAccount(data)).toBe(true);
+
+    const oi = parseMarketGroupV17OI(data);
+    expect(oi.insuranceBalance).toBe(424_242n);
+  });
+
+  it("SDK reads per-asset OI written at our engine-asset-slot offsets", async () => {
+    const { parseMarketGroupV17OI, V17_MAGIC, V17_KIND_OFF, V17_KIND_MARKET } =
+      await import("@percolatorct/sdk");
+    const { engineAssetSlotOff, ASSET_OI_EFF_LONG_Q_OFF, ASSET_OI_EFF_SHORT_Q_OFF } =
+      await import("../../src/lib/v17-layout.js");
+
+    const data = buildMarketAccount({ assetSlots: 2, maxMarketSlots: 2 });
+    writeU64LE(data, 0, V17_MAGIC);
+    data[8] = 17;
+    data[V17_KIND_OFF] = V17_KIND_MARKET;
+
+    // Asset 1's short OI is the most offset-sensitive field available: it needs
+    // the market-group offset, the header length, a full asset stride and the
+    // wrapper prefix to all be right simultaneously.
+    writeU128LE(data, engineAssetSlotOff(0) + ASSET_OI_EFF_LONG_Q_OFF, 111n);
+    writeU128LE(data, engineAssetSlotOff(1) + ASSET_OI_EFF_SHORT_Q_OFF, 999n);
+
+    const oi = parseMarketGroupV17OI(data);
+    expect(oi.totalLongOiQ).toBe(111n);
+    expect(oi.totalShortOiQ).toBe(999n);
+    expect(oi.assets).toEqual([
+      { assetIndex: 0, oiEffLongQ: 111n, oiEffShortQ: 0n },
+      { assetIndex: 1, oiEffLongQ: 0n, oiEffShortQ: 999n },
+    ]);
+  });
+});

--- a/tests/lib/v17-layout.test.ts
+++ b/tests/lib/v17-layout.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  V17_WRAPPER_CONFIG_LEN,
+  V17_MARKET_GROUP_OFF,
+  V17_MARKET_GROUP_LEN,
+  V17_MARKET_ASSET_SLOT_LEN,
+  V17_HEADER_LEN,
+  V17_EXPECTED_WRAPPER_CONFIG_LEN,
+  MG_DERIVED_LEN,
+  ENGINE_ASSET_SLOT_DERIVED_LEN,
+  ASSET_SLOT_DERIVED_STRIDE,
+  MG_CONFIG_OFF,
+  MG_VAULT_OFF,
+  MG_INSURANCE_OFF,
+  MG_C_TOT_OFF,
+  MG_MODE_OFF,
+  MG_CURRENT_SLOT_OFF,
+  V16_CFG_LEN,
+  V16_CFG_MAINTENANCE_MARGIN_BPS_OFF,
+  BACKING_BUCKET_LEN,
+  SOURCE_CREDIT_LEN,
+  INSURANCE_RESERVATION_LEN,
+  ASSET_STATE_LEN,
+  SLOT_BACKING_LONG_OFF,
+  SLOT_BACKING_SHORT_OFF,
+  V17_ASSET_SLOTS_BASE_OFF,
+  backingBucketOff,
+  engineAssetSlotOff,
+  assertV17LayoutGeneration,
+} from "../../src/lib/v17-layout.js";
+
+describe("v17 layout — SDK is the source of truth", () => {
+  it("takes the wrapper config length from the SDK, not a local literal", () => {
+    // The bug this whole module exists to prevent: the keeper hardcoded 432
+    // while the deployed wrapper moved 432 -> 496 -> 576.
+    expect(V17_WRAPPER_CONFIG_LEN).toBe(576);
+    expect(V17_WRAPPER_CONFIG_LEN).not.toBe(432);
+    expect(V17_WRAPPER_CONFIG_LEN).not.toBe(496);
+  });
+
+  it("puts the market group header 144 bytes later than the stale constant did", () => {
+    expect(V17_MARKET_GROUP_OFF).toBe(V17_HEADER_LEN + V17_WRAPPER_CONFIG_LEN);
+    expect(V17_MARKET_GROUP_OFF).toBe(592);
+    // What the keeper was using before the fix:
+    const staleMarketGroupOff = 16 + 432;
+    expect(staleMarketGroupOff).toBe(448);
+    expect(V17_MARKET_GROUP_OFF - staleMarketGroupOff).toBe(144);
+  });
+
+  it("agrees with the tripwire's expected generation", () => {
+    expect(V17_WRAPPER_CONFIG_LEN).toBe(V17_EXPECTED_WRAPPER_CONFIG_LEN);
+    expect(() => assertV17LayoutGeneration()).not.toThrow();
+  });
+});
+
+describe("v17 layout — struct sizes derived independently, then cross-checked", () => {
+  // These are the checks that actually caught the 432 bug: sum the field sizes
+  // from the engine's #[repr(C)] structs and compare against a length the SDK
+  // sourced separately. Two independent derivations agreeing is evidence; one
+  // derivation agreeing with itself is not.
+
+  it("MarketGroupV16HeaderAccount field offsets sum to the SDK's length", () => {
+    expect(MG_DERIVED_LEN).toBe(V17_MARKET_GROUP_LEN);
+    expect(MG_DERIVED_LEN).toBe(758);
+  });
+
+  it("EngineAssetSlotV16Account field offsets sum to the SDK's stride", () => {
+    expect(ENGINE_ASSET_SLOT_DERIVED_LEN).toBe(1285);
+    expect(ASSET_SLOT_DERIVED_STRIDE).toBe(V17_MARKET_ASSET_SLOT_LEN);
+    expect(ASSET_SLOT_DERIVED_STRIDE).toBe(1797);
+  });
+
+  it("V16ConfigAccount length is consistent with the vault/insurance offsets", () => {
+    // insurance sits at config_off + config_len + asset_slot_capacity(4) + vault(16).
+    expect(MG_CONFIG_OFF + V16_CFG_LEN + 4).toBe(MG_VAULT_OFF);
+    expect(MG_VAULT_OFF + 16).toBe(MG_INSURANCE_OFF);
+    expect(MG_INSURANCE_OFF + 16).toBe(MG_C_TOT_OFF);
+    expect(MG_INSURANCE_OFF).toBe(301); // matches percolator-indexer's independent reading
+    expect(MG_C_TOT_OFF).toBe(317);
+  });
+
+  it("sub-struct sizes match the engine's Pod definitions", () => {
+    expect(ASSET_STATE_LEN).toBe(499);
+    expect(SOURCE_CREDIT_LEN).toBe(11 * 16 + 8); // 11×u128 + u64
+    expect(BACKING_BUCKET_LEN).toBe(8 + 5 * 16 + 8 + 1); // market_id + 5×u128 + expiry + status
+    expect(INSURANCE_RESERVATION_LEN).toBe(4 * 16 + 8);
+    expect(SLOT_BACKING_SHORT_OFF - SLOT_BACKING_LONG_OFF).toBe(BACKING_BUCKET_LEN);
+  });
+});
+
+describe("v17 layout — domain addressing", () => {
+  it("maps domain to (asset, side) the way the engine does", () => {
+    // engine domain_asset_side: asset = domain/2, side = domain%2 (0 = long).
+    // Getting this backwards would expire the wrong bucket.
+    expect(backingBucketOff(0)).toBe(engineAssetSlotOff(0) + SLOT_BACKING_LONG_OFF);
+    expect(backingBucketOff(1)).toBe(engineAssetSlotOff(0) + SLOT_BACKING_SHORT_OFF);
+    expect(backingBucketOff(2)).toBe(engineAssetSlotOff(1) + SLOT_BACKING_LONG_OFF);
+    expect(backingBucketOff(3)).toBe(engineAssetSlotOff(1) + SLOT_BACKING_SHORT_OFF);
+  });
+
+  it("advances one full stride per asset", () => {
+    expect(engineAssetSlotOff(1) - engineAssetSlotOff(0)).toBe(V17_MARKET_ASSET_SLOT_LEN);
+    expect(backingBucketOff(2) - backingBucketOff(0)).toBe(V17_MARKET_ASSET_SLOT_LEN);
+  });
+
+  it("places asset slots immediately after the market group header", () => {
+    expect(V17_ASSET_SLOTS_BASE_OFF).toBe(V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_LEN);
+    expect(V17_ASSET_SLOTS_BASE_OFF).toBe(1350);
+  });
+
+  it("locates mode and current_slot inside the header", () => {
+    expect(MG_MODE_OFF).toBeLessThan(MG_DERIVED_LEN);
+    expect(MG_CURRENT_SLOT_OFF).toBeLessThan(MG_MODE_OFF);
+    expect(MG_CURRENT_SLOT_OFF + 8).toBeLessThanOrEqual(MG_MODE_OFF);
+    expect(V16_CFG_MAINTENANCE_MARGIN_BPS_OFF).toBe(54);
+  });
+});

--- a/tests/poc/issue-331-per-asset-price.poc.test.ts
+++ b/tests/poc/issue-331-per-asset-price.poc.test.ts
@@ -1,18 +1,29 @@
 import { describe, it, expect } from "vitest";
 
-// Constants from v17-risk.ts (mirrored here to keep test self-contained)
-const V17_MARKET_GROUP_OFF = 448;
-const V17_MARKET_GROUP_LEN = 758;
-const V17_ASSET_ORACLE_WRAPPER_LEN = 512;
-const V17_ENGINE_ASSET_SLOT_LEN = 1285;
-const V17_ASSET_SLOT_STRIDE = V17_ASSET_ORACLE_WRAPPER_LEN + V17_ENGINE_ASSET_SLOT_LEN;
-const V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT = 25;
+// Offsets come from the PRODUCTION modules, not a local copy.
+//
+// This test used to mirror the constants "to keep the test self-contained",
+// which made it a tautology: it computed an offset from its own copies and
+// asserted the result equalled the same copies re-added by hand. It could not
+// fail no matter what the keeper actually did, and it happily kept passing
+// through the entire period when production was reading v17 markets at the
+// stale 432-byte-config layout. Importing the real functions is what makes this
+// a test rather than an arithmetic identity.
+import {
+  V17_MARKET_GROUP_OFF,
+  V17_MARKET_GROUP_LEN,
+  V17_ASSET_ORACLE_WRAPPER_LEN,
+  V17_ASSET_SLOT_STRIDE,
+  V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT,
+} from "../../src/lib/v17-risk.js";
+import { engineAssetSlotOff } from "../../src/lib/v17-layout.js";
 
 function computeEffectivePriceOffset(assetIndex: number): number {
-  return V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_LEN
-    + assetIndex * V17_ASSET_SLOT_STRIDE
-    + V17_ASSET_ORACLE_WRAPPER_LEN
-    + V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT;
+  return engineAssetSlotOff(assetIndex) + V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT;
+}
+
+function off0Expected(): number {
+  return V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_LEN + V17_ASSET_ORACLE_WRAPPER_LEN + 25;
 }
 
 function readU64LE(data: Uint8Array, offset: number): bigint {
@@ -26,7 +37,10 @@ function readU64LE(data: Uint8Array, offset: number): bigint {
 describe("issue-331: per-asset effective_price byte offset", () => {
   it("reads effective_price at correct offset for asset 0", () => {
     const off0 = computeEffectivePriceOffset(0);
-    expect(off0).toBe(448 + 758 + 512 + 25); // 1743
+    // Post-fee-split: market group at 592 (was 448 under the stale 432-byte
+    // wrapper config), + header 758 + oracle wrapper prefix 512 + 25 = 1887.
+    expect(off0).toBe(V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_LEN + V17_ASSET_ORACLE_WRAPPER_LEN + 25);
+    expect(off0).toBe(1887);
 
     // Build a mock market data buffer with a known price at that offset
     const bufLen = off0 + 8;
@@ -41,7 +55,9 @@ describe("issue-331: per-asset effective_price byte offset", () => {
 
   it("reads effective_price at correct offset for asset 1", () => {
     const off1 = computeEffectivePriceOffset(1);
-    expect(off1).toBe(448 + 758 + 1797 + 512 + 25); // 1743 + 1797 = 3540
+    // One full stride (1797) past asset 0: 1887 + 1797 = 3684.
+    expect(off1).toBe(off0Expected() + V17_ASSET_SLOT_STRIDE);
+    expect(off1).toBe(3684);
 
     const bufLen = off1 + 8;
     const buf = new Uint8Array(bufLen);

--- a/tests/poc/issue-335-health-divergence.poc.test.ts
+++ b/tests/poc/issue-335-health-divergence.poc.test.ts
@@ -22,18 +22,24 @@
 import { describe, it, expect } from "vitest";
 import { evaluateV17PortfolioHealth } from "../../src/services/liquidation.js";
 
-// Per-asset slot byte offsets (must match src/lib/v17-risk.ts).
-const V17_MARKET_GROUP_OFF = 448;
-const V17_MARKET_GROUP_LEN = 758;
-const V17_ASSET_ORACLE_WRAPPER_LEN = 512;
-const V17_ASSET_SLOT_STRIDE = 1797;
-const V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT = 25;
-const V17_RAW_ORACLE_TARGET_PRICE_OFF_IN_ASSET_SLOT = 17;
+// Per-asset slot byte offsets — IMPORTED, not copied.
+//
+// These used to be duplicated here as literals ("must match src/lib/v17-risk.ts"),
+// including V17_MARKET_GROUP_OFF = 448, which was derived from the stale
+// V17_WRAPPER_CONFIG_LEN = 432. Because the fixture builder and the code under
+// test shared the same wrong number, the test passed while the evaluator was
+// misreading every real market account. When the constant was corrected to 592
+// the fixture kept writing at 448 and the reader fell off the end of the buffer,
+// silently returning 0n ("unknown") and dropping the lag penalty — which is how
+// this duplication finally surfaced.
+import {
+  V17_EFFECTIVE_PRICE_OFF_IN_ASSET_SLOT,
+  V17_RAW_ORACLE_TARGET_PRICE_OFF_IN_ASSET_SLOT,
+} from "../../src/lib/v17-risk.js";
+import { engineAssetSlotOff } from "../../src/lib/v17-layout.js";
 
 function slotBase(assetIndex: number): number {
-  return V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_LEN
-    + assetIndex * V17_ASSET_SLOT_STRIDE
-    + V17_ASSET_ORACLE_WRAPPER_LEN;
+  return engineAssetSlotOff(assetIndex);
 }
 
 /**

--- a/tests/services/crank-error-code.poc.test.ts
+++ b/tests/services/crank-error-code.poc.test.ts
@@ -19,7 +19,12 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("@solana/web3.js", async () => ({ ...(await vi.importActual("@solana/web3.js")) }));
-vi.mock("@percolatorct/sdk", () => ({
+// Partial mock: real exports fill anything this factory does not override.
+// A full-replacement mock silently breaks whenever the source under test
+// imports a new SDK export (e.g. the v17 layout constants), and the failure
+// surfaces as an unrelated "no export defined on the mock" at import time.
+vi.mock("@percolatorct/sdk", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   discoverMarkets: vi.fn(),
   encodeKeeperCrank: vi.fn(() => Buffer.from([1])),
   encodeUpdateHyperpMark: vi.fn(() => Buffer.from([7])),

--- a/tests/services/crank-hyperp-detection.poc.test.ts
+++ b/tests/services/crank-hyperp-detection.poc.test.ts
@@ -19,7 +19,12 @@ vi.mock("@solana/web3.js", async () => {
   const actual = await vi.importActual("@solana/web3.js");
   return { ...actual };
 });
-vi.mock("@percolatorct/sdk", () => ({
+// Partial mock: real exports fill anything this factory does not override.
+// A full-replacement mock silently breaks whenever the source under test
+// imports a new SDK export (e.g. the v17 layout constants), and the failure
+// surfaces as an unrelated "no export defined on the mock" at import time.
+vi.mock("@percolatorct/sdk", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   discoverMarkets: vi.fn(),
   encodeKeeperCrank: vi.fn(() => Buffer.from([1])),
   encodeUpdateHyperpMark: vi.fn(() => Buffer.from([7])),

--- a/tests/services/crank.b-fixes.test.ts
+++ b/tests/services/crank.b-fixes.test.ts
@@ -18,7 +18,12 @@ vi.mock("@solana/web3.js", async () => {
   };
 });
 
-vi.mock("@percolatorct/sdk", () => ({
+// Partial mock: real exports fill anything this factory does not override.
+// A full-replacement mock silently breaks whenever the source under test
+// imports a new SDK export (e.g. the v17 layout constants), and the failure
+// surfaces as an unrelated "no export defined on the mock" at import time.
+vi.mock("@percolatorct/sdk", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   discoverMarkets: vi.fn(),
   encodePermissionlessCrank: vi.fn(() => Buffer.from([5, 0, 0, 0, 0, 0])),
   CrankAction: { FeeSweep: 0, Liquidate: 1 },

--- a/tests/services/crank.processBatched.test.ts
+++ b/tests/services/crank.processBatched.test.ts
@@ -15,7 +15,12 @@ vi.mock("@solana/web3.js", async () => {
   };
 });
 
-vi.mock("@percolatorct/sdk", () => ({
+// Partial mock: real exports fill anything this factory does not override.
+// A full-replacement mock silently breaks whenever the source under test
+// imports a new SDK export (e.g. the v17 layout constants), and the failure
+// surfaces as an unrelated "no export defined on the mock" at import time.
+vi.mock("@percolatorct/sdk", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   discoverMarkets: vi.fn(),
   encodeKeeperCrank: vi.fn(() => Buffer.from([1])),
   encodeUpdateHyperpMark: vi.fn(() => Buffer.from([2])),

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -13,7 +13,12 @@ vi.mock('@solana/web3.js', async () => {
 });
 
 // Mock all external dependencies
-vi.mock('@percolatorct/sdk', () => ({
+// Partial mock: real exports fill anything this factory does not override.
+// A full-replacement mock silently breaks whenever the source under test
+// imports a new SDK export (e.g. the v17 layout constants), and the failure
+// surfaces as an unrelated "no export defined on the mock" at import time.
+vi.mock('@percolatorct/sdk', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   discoverMarkets: vi.fn(),
   encodePermissionlessCrank: vi.fn(() => Buffer.from([5, 0, 0, 0, 0, 0])),
   CrankAction: { FeeSweep: 0, Liquidate: 1 },

--- a/tests/services/fee-crank.test.ts
+++ b/tests/services/fee-crank.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import type { Connection, Keypair } from "@solana/web3.js";
+
+// keeperSend / the tx queue reach for RPC and budget state. Stub them so these
+// tests exercise the crank's own decision logic and nothing else.
+const sendMock = vi.fn();
+vi.mock("../../src/lib/keeper-send.js", () => ({
+  keeperSend: (...args: unknown[]) => sendMock(...args),
+  sharedBudget: {},
+}));
+vi.mock("../../src/lib/tx-queue.js", () => ({
+  sharedTxQueue: { enqueue: (_k: string, fn: () => Promise<unknown>) => fn() },
+}));
+
+// vi.mock calls above are hoisted by vitest, so a static import here still
+// receives the stubbed modules.
+import {
+  classifyRejection,
+  extractCustomErrorCode,
+  BENIGN_PROGRAM_ERRORS,
+  runLegsForMarket,
+  runFeeCrankCycle,
+  buildSnapshot,
+  loadFeeCrankThresholds,
+  describeBucketExpiryUrgency,
+  expireBackingBucketLeg,
+  ALL_LEGS,
+} from "../../src/services/fee-crank.js";
+import type {
+  CrankLeg,
+  MarketSnapshot,
+  LegContext,
+  PendingWork,
+} from "../../src/services/fee-crank.js";
+
+const MARKET = new PublicKey("11111111111111111111111111111112");
+const PROGRAM = new PublicKey("11111111111111111111111111111113");
+
+function fakeCtx(): LegContext {
+  return {
+    connection: {} as Connection,
+    keypair: { publicKey: new PublicKey("11111111111111111111111111111114") } as Keypair,
+    thresholds: loadFeeCrankThresholds(),
+  };
+}
+
+function fakeSnapshot(): MarketSnapshot {
+  return {
+    address: MARKET,
+    programId: PROGRAM,
+    data: new Uint8Array(0),
+    group: {
+      mode: 0,
+      currentSlot: 0n,
+      insurance: 0n,
+      cTot: 0n,
+      materializedPortfolioCount: 0n,
+      sourceInsuranceCreditReservedTotalAtoms: 0n,
+      insuranceDomainBudgetRemainingTotal: 0n,
+      maxMarketSlots: 1,
+      assetSlotCount: 1,
+    },
+    chainSlot: 0n,
+  };
+}
+
+const work = (reason = "test work"): PendingWork => ({
+  reason,
+  expectedAtoms: 1_000n,
+  instructions: [],
+});
+
+function legThatFinds(name: string, items: PendingWork[]): CrankLeg {
+  return {
+    name: name as CrankLeg["name"],
+    tag: 78,
+    detect: async () => items,
+  };
+}
+
+beforeEach(() => {
+  sendMock.mockReset();
+  sendMock.mockResolvedValue({ signature: "sig", estimatedCost: 0, simulatedCu: 0 });
+});
+
+describe("extractCustomErrorCode", () => {
+  it("parses the decimal Custom(N) form", () => {
+    expect(extractCustomErrorCode(new Error("Transaction failed: Custom(38)"))).toBe(38);
+    expect(extractCustomErrorCode(new Error("Error: Custom: 21"))).toBe(21);
+    expect(extractCustomErrorCode(new Error("Custom 61 raised"))).toBe(61);
+  });
+
+  it("parses the hex custom-program-error form", () => {
+    expect(extractCustomErrorCode(new Error("custom program error: 0x26"))).toBe(38);
+    expect(extractCustomErrorCode(new Error("custom program error: 0x15"))).toBe(21);
+  });
+
+  it("returns null when there is no program error code", () => {
+    expect(extractCustomErrorCode(new Error("fetch failed"))).toBeNull();
+    expect(extractCustomErrorCode(new Error("blockhash not found"))).toBeNull();
+  });
+});
+
+describe("classifyRejection — by-design rejections must not alarm", () => {
+  it("treats every documented by-design code as benign", () => {
+    // The brief's list plus the two the program actually raises for the same
+    // situations (41 = no LP shares, 61 = bucket not Fresh-and-lapsed).
+    for (const code of [19, 21, 27, 38, 41, 53, 61]) {
+      const result = classifyRejection(new Error(`Custom(${code})`));
+      expect(result.benign, `Custom(${code}) should be benign`).toBe(true);
+      expect(result.code).toBe(code);
+      expect(BENIGN_PROGRAM_ERRORS.has(code)).toBe(true);
+    }
+  });
+
+  it("does NOT swallow an unrecognised program error", () => {
+    // The old crankLpVault treated any message containing "Custom" as
+    // "no fees to crank". Unauthorized, a bad account, or a genuinely broken
+    // market would all have been invisible.
+    const result = classifyRejection(new Error("Custom(4)"));
+    expect(result.benign).toBe(false);
+    expect(result.code).toBe(4);
+    expect(result.reason).toMatch(/unexpected program error/i);
+  });
+
+  it("does NOT swallow non-program failures", () => {
+    for (const message of ["fetch failed", "blockhash not found", "429 Too Many Requests"]) {
+      const result = classifyRejection(new Error(message));
+      expect(result.benign, `${message} should not be benign`).toBe(false);
+      expect(result.code).toBeNull();
+    }
+  });
+});
+
+describe("never crank blind", () => {
+  it("sends nothing when every leg reports no pending work", async () => {
+    const idleLegs: CrankLeg[] = [
+      legThatFinds("lpVaultCrankFees", []),
+      legThatFinds("protocolFee", []),
+    ];
+    const outcomes = await runLegsForMarket(fakeSnapshot(), fakeCtx(), idleLegs);
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(outcomes.every((o) => o.status === "idle")).toBe(true);
+  });
+
+  it("sends exactly one transaction per unit of detected work", async () => {
+    const legs: CrankLeg[] = [legThatFinds("lpVaultCrankFees", [work("a"), work("b")])];
+    const outcomes = await runLegsForMarket(fakeSnapshot(), fakeCtx(), legs);
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(outcomes.filter((o) => o.status === "sent")).toHaveLength(2);
+  });
+
+  it("tag 89 detection returns nothing on a non-Live market", async () => {
+    const snapshot = fakeSnapshot();
+    snapshot.group.mode = 2; // Recovery
+    const found = await expireBackingBucketLeg.detect(snapshot, fakeCtx());
+    expect(found).toEqual([]);
+  });
+});
+
+describe("failure isolation", () => {
+  it("a leg that throws in detect does not stop later legs", async () => {
+    const legs: CrankLeg[] = [
+      { name: "expireBackingBucket", tag: 89, detect: async () => { throw new Error("boom"); } },
+      legThatFinds("lpVaultCrankFees", [work()]),
+    ];
+    const outcomes = await runLegsForMarket(fakeSnapshot(), fakeCtx(), legs);
+    expect(outcomes[0]!.status).toBe("error");
+    expect(outcomes[1]!.status).toBe("sent");
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a leg whose send fails does not stop later legs", async () => {
+    sendMock.mockRejectedValueOnce(new Error("fetch failed"));
+    const legs: CrankLeg[] = [
+      legThatFinds("lpVaultCrankFees", [work()]),
+      legThatFinds("protocolFee", [work()]),
+    ];
+    const outcomes = await runLegsForMarket(fakeSnapshot(), fakeCtx(), legs);
+    expect(outcomes[0]!.status).toBe("error");
+    expect(outcomes[1]!.status).toBe("sent");
+  });
+
+  it("one failing unit of work does not stop the rest within the same leg", async () => {
+    sendMock.mockRejectedValueOnce(new Error("fetch failed"));
+    const legs: CrankLeg[] = [legThatFinds("expireBackingBucket", [work("d0"), work("d1"), work("d2")])];
+    const outcomes = await runLegsForMarket(fakeSnapshot(), fakeCtx(), legs);
+    // A bricked domain must not be left bricked because a sibling domain's
+    // transaction happened to fail first.
+    expect(outcomes.map((o) => o.status)).toEqual(["error", "sent", "sent"]);
+  });
+
+  it("a benign rejection is reported as such, not as an error", async () => {
+    sendMock.mockRejectedValueOnce(new Error("Custom(38)"));
+    const legs: CrankLeg[] = [legThatFinds("lpVaultCrankFees", [work()])];
+    const outcomes = await runLegsForMarket(fakeSnapshot(), fakeCtx(), legs);
+    expect(outcomes[0]!.status).toBe("benign-reject");
+    expect(outcomes[0]!.reason).toMatch(/LpVaultNoFeesToCrank/);
+  });
+
+  it("one market erroring does not stop the loop for other markets", async () => {
+    const good = fakeSnapshot();
+    const bad = { ...fakeSnapshot(), address: PROGRAM };
+    const legs: CrankLeg[] = [
+      {
+        name: "lpVaultCrankFees",
+        tag: 78,
+        detect: async (s) => {
+          if (s.address.equals(PROGRAM)) throw new Error("market-specific failure");
+          return [work()];
+        },
+      },
+    ];
+    const outcomes = await runFeeCrankCycle([bad, good], fakeCtx(), legs);
+    expect(outcomes.filter((o) => o.status === "sent")).toHaveLength(1);
+    expect(outcomes.filter((o) => o.status === "error")).toHaveLength(1);
+  });
+
+  it("a budget-gate decline is idle, not an error", async () => {
+    sendMock.mockResolvedValueOnce(null);
+    const legs: CrankLeg[] = [legThatFinds("lpVaultCrankFees", [work()])];
+    const outcomes = await runLegsForMarket(fakeSnapshot(), fakeCtx(), legs);
+    expect(outcomes[0]!.status).toBe("idle");
+  });
+});
+
+describe("leg ordering and thresholds", () => {
+  it("runs the liveness-critical bucket expiry before the revenue legs", () => {
+    // If a cycle runs out of budget it should run out on revenue, not on the
+    // leg that unbricks user funds.
+    expect(ALL_LEGS[0]!.tag).toBe(89);
+    expect(ALL_LEGS.map((l) => l.tag)).toEqual([89, 78, 87, 84]);
+  });
+
+  it("documents why tag 89 has no economic threshold", () => {
+    expect(describeBucketExpiryUrgency()).toMatch(/only exit/i);
+  });
+
+  it("reads thresholds from env with sensible defaults", () => {
+    delete process.env.KEEPER_PROTOCOL_FEE_SWEEP_MIN_ATOMS;
+    expect(loadFeeCrankThresholds().protocolAtoms).toBe(1_000_000n);
+
+    process.env.KEEPER_PROTOCOL_FEE_SWEEP_MIN_ATOMS = "250000";
+    expect(loadFeeCrankThresholds().protocolAtoms).toBe(250_000n);
+
+    // A malformed threshold must fall back to the default, not become 0 (which
+    // would turn the gate off and sweep dust at a loss on every cycle).
+    process.env.KEEPER_PROTOCOL_FEE_SWEEP_MIN_ATOMS = "not-a-number";
+    expect(loadFeeCrankThresholds().protocolAtoms).toBe(1_000_000n);
+
+    process.env.KEEPER_PROTOCOL_FEE_SWEEP_MIN_ATOMS = "-5";
+    expect(loadFeeCrankThresholds().protocolAtoms).toBe(1_000_000n);
+
+    delete process.env.KEEPER_PROTOCOL_FEE_SWEEP_MIN_ATOMS;
+  });
+});
+
+describe("buildSnapshot", () => {
+  it("returns null for an account too short to be a v17 market", () => {
+    expect(buildSnapshot(MARKET, PROGRAM, new Uint8Array(512), 0n)).toBeNull();
+    expect(buildSnapshot(MARKET, PROGRAM, new Uint8Array(0), 0n)).toBeNull();
+  });
+});

--- a/tests/services/liquidation-watchdog-race.test.ts
+++ b/tests/services/liquidation-watchdog-race.test.ts
@@ -17,7 +17,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@solana/web3.js", async () => ({ ...(await vi.importActual("@solana/web3.js")) }));
-vi.mock("@percolatorct/sdk", () => ({
+// Partial mock: real exports fill anything this factory does not override.
+// A full-replacement mock silently breaks whenever the source under test
+// imports a new SDK export (e.g. the v17 layout constants), and the failure
+// surfaces as an unrelated "no export defined on the mock" at import time.
+vi.mock("@percolatorct/sdk", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   fetchSlab: vi.fn(), parseConfig: vi.fn(), parseEngine: vi.fn(), parseParams: vi.fn(),
   parseAccount: vi.fn(), parseUsedIndices: vi.fn(), detectLayout: vi.fn(),
   buildAccountMetas: vi.fn(() => []), buildIx: vi.fn(() => ({})),

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -39,7 +39,12 @@ vi.mock('@solana/web3.js', async () => {
 });
 
 // Mock external dependencies
-vi.mock('@percolatorct/sdk', () => ({
+// Partial mock: real exports fill anything this factory does not override.
+// A full-replacement mock silently breaks whenever the source under test
+// imports a new SDK export (e.g. the v17 layout constants), and the failure
+// surfaces as an unrelated "no export defined on the mock" at import time.
+vi.mock('@percolatorct/sdk', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   fetchSlab: vi.fn(),
   parseConfig: vi.fn(),
   parseEngine: vi.fn(),

--- a/tests/services/monitor.test.ts
+++ b/tests/services/monitor.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { PublicKey } from "@solana/web3.js";
 
-vi.mock("@percolatorct/sdk", () => ({
+// Partial mock: real exports fill anything this factory does not override.
+// A full-replacement mock silently breaks whenever the source under test
+// imports a new SDK export (e.g. the v17 layout constants), and the failure
+// surfaces as an unrelated "no export defined on the mock" at import time.
+vi.mock("@percolatorct/sdk", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   fetchSlab: vi.fn(),
   isV17Account: vi.fn(() => false),
   parseEngine: vi.fn(),

--- a/tests/services/monitor.test.ts
+++ b/tests/services/monitor.test.ts
@@ -54,11 +54,14 @@ describe("MonitorService", () => {
     const status = service.getStatus();
     expect(sdk.parseEngine).not.toHaveBeenCalled();
     expect(sdk.parseConfig).not.toHaveBeenCalled();
+    // #347: this previously asserted `ok: true`, codifying the bug — a v17
+    // market was reported healthy without the conservation invariant ever
+    // running. `null` means "not evaluated" and is the whole point.
     expect(status.invariants).toEqual([
       expect.objectContaining({
         slabAddress,
-        ok: true,
-        skippedReason: expect.stringContaining("v17 market account"),
+        ok: null,
+        skippedReason: expect.stringContaining("UNCHECKED"),
       }),
     ]);
     expect(status.adlStaleness).toEqual([
@@ -69,6 +72,49 @@ describe("MonitorService", () => {
         skippedReason: expect.stringContaining("v17 removed ExecuteAdl"),
       }),
     ]);
+  });
+
+  it("#347: never reports a v17 market as ok:true — an unevaluated check is not a passing one", async () => {
+    // The load-bearing assertion. Since the v17 cutover every production market
+    // takes this branch, so `ok: true` here meant the only fund-conservation
+    // tripwire in the codebase emitted green across the entire live market set
+    // without ever computing anything.
+    const service = new MonitorService();
+    const slabAddress = "11111111111111111111111111111111";
+    const markets = new Map([
+      [slabAddress, { market: { slabAddress: new PublicKey(slabAddress) } }],
+    ]);
+
+    vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array([1, 2, 3]));
+    vi.mocked(sdk.isV17Account).mockReturnValue(true);
+
+    service.setMarketSource(() => markets as any);
+    await (service as any)._runChecks();
+
+    const [invariant] = service.getStatus().invariants;
+    expect(invariant.ok).not.toBe(true);
+    expect(invariant.ok).toBeNull();
+  });
+
+  it("#347: does not fabricate zeroed balances for an unevaluated v17 market", async () => {
+    // shortfall "0" reads as "checked, nothing missing" on a dashboard, which is
+    // the same false-green in a different field. Unevaluated must be null.
+    const service = new MonitorService();
+    const slabAddress = "11111111111111111111111111111111";
+    const markets = new Map([
+      [slabAddress, { market: { slabAddress: new PublicKey(slabAddress) } }],
+    ]);
+
+    vi.mocked(sdk.fetchSlab).mockResolvedValue(new Uint8Array([1, 2, 3]));
+    vi.mocked(sdk.isV17Account).mockReturnValue(true);
+
+    service.setMarketSource(() => markets as any);
+    await (service as any)._runChecks();
+
+    const [invariant] = service.getStatus().invariants;
+    expect(invariant.shortfall).toBeNull();
+    expect(invariant.vaultTokenBalance).toBeNull();
+    expect(invariant.engineVault).toBeNull();
   });
 
   it("M-6: passes the market's programId to fetchSlab as expectedOwner", async () => {

--- a/tests/services/oracle.b-fixes.test.ts
+++ b/tests/services/oracle.b-fixes.test.ts
@@ -20,7 +20,12 @@ const hoisted = vi.hoisted(() => ({
   sendWarningAlert: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@percolatorct/sdk", () => ({
+// Partial mock: real exports fill anything this factory does not override.
+// A full-replacement mock silently breaks whenever the source under test
+// imports a new SDK export (e.g. the v17 layout constants), and the failure
+// surfaces as an unrelated "no export defined on the mock" at import time.
+vi.mock("@percolatorct/sdk", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   encodePushOraclePrice: vi.fn(() => Buffer.from([1])),
   buildAccountMetas: vi.fn(() => []),
   buildIx: vi.fn(() => ({})),

--- a/tests/services/program-id-allowlist.test.ts
+++ b/tests/services/program-id-allowlist.test.ts
@@ -17,7 +17,12 @@ const C = vi.hoisted(() => ({
   ownerToReturn: "" as string, // set per test
 }));
 
-vi.mock("@percolatorct/sdk", () => ({
+// Partial mock: real exports fill anything this factory does not override.
+// A full-replacement mock silently breaks whenever the source under test
+// imports a new SDK export (e.g. the v17 layout constants), and the failure
+// surfaces as an unrelated "no export defined on the mock" at import time.
+vi.mock("@percolatorct/sdk", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   discoverMarkets: vi.fn(async () => []),
   // v17 SDK API (replaces encodeKeeperCrank / encodeUpdateHyperpMark)
   encodePermissionlessCrank: vi.fn(() => Buffer.from([5, 0, 0, 0, 0, 0])),

--- a/tests/v17-risk-params.poc.test.ts
+++ b/tests/v17-risk-params.poc.test.ts
@@ -5,11 +5,19 @@ import {
   V17RiskParamsCorruptedError,
 } from "../src/lib/v17-risk.js";
 
-const V17_HEADER_LEN = 16;
-const V17_WRAPPER_CONFIG_LEN = 432;
-const V17_MARKET_GROUP_OFF = V17_HEADER_LEN + V17_WRAPPER_CONFIG_LEN;
-const V17_MARKET_GROUP_ID_LEN = 32;
-const V17_ENGINE_CONFIG_OFF = V17_MARKET_GROUP_OFF + V17_MARKET_GROUP_ID_LEN;
+// Layout constants come from the SDK via v17-layout.ts. This test previously
+// duplicated the stale `V17_WRAPPER_CONFIG_LEN = 432` literal, so it wrote its
+// fixture bytes at exactly the same wrong offsets the parser read them from —
+// the test passed while the parser was misreading every live account. A test
+// that shares the bug under test cannot detect it; both sides now derive from
+// one source.
+import {
+  MG_CONFIG_OFF,
+  V17_HEADER_LEN,
+  V17_MARKET_GROUP_OFF,
+} from "../src/lib/v17-layout.js";
+
+const V17_ENGINE_CONFIG_OFF = V17_MARKET_GROUP_OFF + MG_CONFIG_OFF;
 
 function writeU64LE(data: Uint8Array, offset: number, value: bigint): void {
   for (let i = 0; i < 8; i++) {


### PR DESCRIPTION
Eight commits that the running keeper does not have. Three of them are correctness fixes for v17 markets; without them a freshly launched devnet-2.0 market is not reliably cranked.

| commit | what it fixes |
|---|---|
| `f5658e6` | **The keeper misread every v17 market** — wrapper config is 576 bytes, not 432 |
| `3a14b05` | `PermissionlessCrank` wire aligned with upstream #206 (`close_q`/`fee_bps` removed) |
| `b3a969e` | Cranks the v17 fee split, and recovers lapsed backing buckets |
| `05ea37d` | Derives the market vault **per market**; stops double-requesting the heap frame |
| `da6d693` | Monitor no longer reports v17 markets as a passing conservation check (#347) |
| `6541a88`, `65bbc40` | Pin the SDK to a pushed GitHub SHA — `file:../` broke the Docker build |
| `e44722f` | Healthcheck window 120s → 300s (devnet startup provisions N portfolios and exceeds 120s) |

## Why now

The devnet-2.0 launch path is being re-tested end to end. The prior on-chain audit found that a market's health depends on the keeper cranking it correctly, and these fixes are the difference between a new market being cranked and being misread.

Note the audit's fourth blocker — *one bad market silently stops every price in its batch* — is **not** in this branch. Markets are still packed by byte size with no health filter, sent preflight-skipped, and the success counter increments on send, so the keeper reports "pushed" either way. That remains open.

## Verification

`pnpm build` clean, **1030 tests pass** (97 files, 2 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional v17 fee distribution and backing-bucket recovery processing.
  - Added configurable fee thresholds, protocol-fee destinations, and bucket lapse warnings.
  - Added operational metrics for fee activity, pending claims, errors, and bucket status.

- **Bug Fixes**
  - Prevented duplicate simulation instructions and aligned v17 crank and liquidation transactions with the current format.
  - Improved handling of benign transaction rejections and isolated failures.
  - v17 monitoring now clearly reports unevaluated invariants instead of false healthy results.

- **Reliability**
  - Added startup validation to detect incompatible account layouts before processing begins.
  - Increased service health-check timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->