### PR TITLE
ci(sdk-smoke): pin the nightly to the published v17 SDK 4.3.0 (fixes #389)

### DIFF
--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -30,7 +30,7 @@ on:
 
 env:
   # Update this string when the SDK bumps.  Deliberate — that is the point.
-  SDK_VERSION: "2.0.5"
+  SDK_VERSION: "4.3.0"
 
 concurrency:
   group: sdk-smoke-${{ github.ref }}
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   smoke:
-    name: smoke @percolatorct/sdk@${{ github.event.client_payload.version || inputs.sdk_version || '2.0.5' }}
+    name: smoke @percolatorct/sdk@${{ github.event.client_payload.version || inputs.sdk_version || '4.3.0' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -30,7 +30,7 @@ on:
 
 env:
   # Update this string when the SDK bumps.  Deliberate — that is the point.
-  SDK_VERSION: "4.3.0"
+  SDK_VERSION: "4.4.0"
 
 concurrency:
   group: sdk-smoke-${{ github.ref }}
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   smoke:
-    name: smoke @percolatorct/sdk@${{ github.event.client_payload.version || inputs.sdk_version || '4.3.0' }}
+    name: smoke @percolatorct/sdk@${{ github.event.client_payload.version || inputs.sdk_version || '4.4.0' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
Fixes #389.

## The failure

The nightly **SDK publish smoke** has failed every night since at least 23 July — 6 consecutive runs, all `schedule` on `main`:

```
❯ tests/sdk-smoke.test.ts (42 tests | 15 failed)
TypeError: Cannot read properties of undefined (reading 'FeeSweep')
AssertionError: expected 'undefined' to be 'function'
@percolatorct/sdk@2.0.5 smoke FAILED
```

`CrankAction` is undefined and the v17 helpers are missing, because the job pinned `SDK_VERSION: "2.0.5"` while `tests/sdk-smoke.test.ts` targets the **v17** API surface.

## Why it is fixable now

#389 recorded this as blocked — *"tests target v17 SDK 3.0.0, which was never published (latest npm is 2.0.9)"*. **That premise has expired.** `npm view @percolatorct/sdk versions` now returns:

```
2.0.3 … 2.0.9, 4.3.0
```

`4.3.0` is published (percolator-launch already installs it from npm instead of a pinned git SHA), so the smoke job finally has a real published v17 version to validate against.

## Verification — checked before touching CI, not after

Installed `@percolatorct/sdk@4.3.0` from npm into a scratch project and ran the smoke file against it:

```
Test Files  1 passed (1)
     Tests  42 passed (42)
```

versus 15 failures on the pinned 2.0.5. So this turns the nightly green **and** makes it actually validate the version the keeper depends on, instead of a pre-v17 artefact.

## Scope

Two lines: the `SDK_VERSION` env default and the job-name fallback. The `2.0.5` on line 28 is deliberately left — it is a `repository_dispatch` usage example in a comment, not a live default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated SDK smoke-test validation to use SDK version 4.4.0 by default.
  * Updated workflow output to accurately display the selected SDK version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->