### PR TITLE
fix(keeper-send): broadcast the budget-gated priority fee + CU (closes #396)

### DIFF
--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -119,6 +119,13 @@ function firstProgramInstruction(instructions: TransactionInstruction[]): Transa
 interface EstimateCostResult {
   estimatedCost: number;
   simulatedCu: number;
+  /**
+   * The priority fee (microLamports per CU) the budget gated on. Surfaced so the
+   * caller can broadcast this exact value instead of letting the shared sender
+   * re-derive it from getRecentPrioritizationFees — otherwise the gated cost and
+   * the on-chain bid are independent numbers (dcccrypto/percolator-keeper#396).
+   */
+  microLamports: number;
   /** H-3: true iff simulation proved this exact tx would fail on-chain. */
   provenToFail: boolean;
   simError?: unknown;
@@ -153,6 +160,7 @@ async function estimateCost(
   return {
     estimatedCost: estimateLamportCost(microLamports, cuResult.cu, jitoTip, extraLamports),
     simulatedCu: cuResult.cu,
+    microLamports,
     provenToFail: cuResult.provenToFail,
     simError: cuResult.simError,
   };
@@ -234,7 +242,7 @@ export async function keeperSend(
     ...instructions,
   ];
 
-  const { estimatedCost, simulatedCu, provenToFail, simError } = await estimateCost(
+  const { estimatedCost, simulatedCu, microLamports, provenToFail, simError } = await estimateCost(
     connection,
     simulationInstructions,
     signers,
@@ -336,6 +344,17 @@ export async function keeperSend(
 
     const opts: KeeperSendOptions = {
       ...keeperOpts,
+      // Couple the broadcast to the budget: hand the shared sender the exact
+      // priority fee and CU limit the budget gated on, so it broadcasts those
+      // instead of re-deriving the fee from getRecentPrioritizationFees (an
+      // RPC-controlled, ceiling-less source). Without this the gated cost and the
+      // on-chain bid are independent numbers, and a hostile or spiking RPC can
+      // drive spend past the budget cap while the gate approved a small estimate;
+      // with it, an inflated fee raises estimatedCost and trips the existing
+      // fail-closed budget halt instead. A caller-supplied override still wins.
+      // See dcccrypto/percolator-keeper#396.
+      priorityFeeMicroLamports: keeperOpts?.priorityFeeMicroLamports ?? microLamports,
+      computeUnitLimit: keeperOpts?.computeUnitLimit ?? simulatedCu,
       // Saves ~20-50ms on mainnet when Helius Sender runs its own preflight downstream.
       ...(isMainnetSender() ? { skipPreflight: true } : {}),
     };

--- a/tests/lib/keeper-send.priority-fee-coupling.poc.test.ts
+++ b/tests/lib/keeper-send.priority-fee-coupling.poc.test.ts
@@ -1,0 +1,165 @@
+/**
+ * PoC — CRITICAL: budget gate is decoupled from the priority fee actually broadcast.
+ *
+ * keeperSend computes a tier-aware priority-fee estimate (HeliusPriorityFeeEstimator)
+ * and a CU estimate, then gates the budget on
+ *     estimatedCost = base + microLamports * simulatedCu / 1e6
+ * ...and hands `sendWithRetryKeeper` an options object containing NEITHER
+ * `priorityFeeMicroLamports` NOR `computeUnitLimit`.
+ *
+ * Per @percolatorct/shared (#311), when those overrides are absent the shared
+ * sender derives the broadcast fee ITSELF from `getRecentPrioritizationFees` — a
+ * DIFFERENT, RPC-controlled source — with a floor-only `Math.max(fee, 1_000)` and
+ * NO ceiling, then broadcasts it via setComputeUnitPrice(microLamports).
+ *
+ * Exploit: a malicious or merely spiking RPC answers the keeper's estimator call
+ * with a small fee (budget approves ~5_200 lamports) and answers
+ * getRecentPrioritizationFees with an arbitrarily large p75. The keeper signs and
+ * broadcasts a priority bid bounded only by wallet balance, while the budget
+ * booked the small estimate. The override that prevents exactly this already
+ * exists in shared — its JSDoc says "so the budget the caller gated on is the one
+ * actually broadcast" — the keeper simply never populates it.
+ *
+ * This PoC captures the options keeperSend hands the (mocked) shared sender and
+ * asserts the broadcast fee + CU equal the budget-gated estimate. It FAILS before
+ * the fix (options undefined → shared would broadcast the RPC's fee) and PASSES
+ * after keeperSend plumbs its gated estimate through.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// What the keeper's estimator returns — the value the budget gate approves.
+const GATED_FEE_MICROLAMPORTS = 1_000;
+const GATED_CU = 200_000;
+// What a hostile/degraded RPC returns from getRecentPrioritizationFees — the
+// value the shared sender broadcasts when the keeper passes no override.
+const HOSTILE_RPC_P75_MICROLAMPORTS = 1_000_000_000;
+
+// Capture the keeperOpts (5th arg) keeperSend hands the shared sender.
+const captured: { opts: any } = { opts: undefined };
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  sendWithRetryKeeper: vi.fn(async (_conn, _ix, _signers, _maxRetries, keeperOpts) => {
+    captured.opts = keeperOpts;
+    return "mock-sig";
+  }),
+}));
+
+vi.mock("../../src/lib/priority-fee.js", () => {
+  class HeliusPriorityFeeEstimator {
+    estimate = vi.fn(async () => GATED_FEE_MICROLAMPORTS);
+  }
+  return { HeliusPriorityFeeEstimator };
+});
+
+vi.mock("../../src/lib/cu-estimator.js", () => {
+  class CuEstimator {
+    estimate = vi.fn(async () => ({ cu: GATED_CU, provenToFail: false }));
+  }
+  return { CuEstimator };
+});
+
+import { keeperSend } from "../../src/lib/keeper-send.js";
+import { KeeperBudget } from "../../src/lib/budget.js";
+import { Keypair, TransactionInstruction, PublicKey } from "@solana/web3.js";
+
+function makeDummyIx(): TransactionInstruction {
+  return new TransactionInstruction({
+    programId: PublicKey.default,
+    keys: [],
+    data: Buffer.from([]),
+  });
+}
+
+function makeConnection() {
+  return {
+    simulateTransaction: vi.fn(async () => ({
+      value: { unitsConsumed: GATED_CU, err: null, logs: [] },
+    })),
+    getTransaction: vi.fn(async () => ({ meta: { fee: 5_000, err: null } })),
+  } as any;
+}
+
+describe("PoC: budget-gated priority fee must equal the broadcast priority fee", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captured.opts = undefined;
+    process.env.NETWORK = "devnet";
+    process.env.USE_HELIUS_SENDER = "false";
+    process.env.KEEPER_REALIZED_COST_SAMPLE_PCT = "0"; // no post-send reconciliation timer
+    delete process.env.PRIORITY_FEE_MICROLAMPORTS;
+    delete process.env.DRY_RUN;
+  });
+
+  it("plumbs the gated priority fee + CU into the shared sender (no RPC-controlled bid)", async () => {
+    // Cap approves the GATED cost (~5_200) but is ~192_000x below the hostile bid
+    // (base 5_000 + 1e9 * 200_000 / 1e6 = ~200_005_000 lamports).
+    const budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000 });
+    const keypair = Keypair.generate();
+
+    const result = await keeperSend(
+      makeConnection(),
+      [makeDummyIx()],
+      [keypair],
+      "liquidation",
+      budget,
+      3,
+    );
+
+    expect(result).not.toBeNull();
+    expect(captured.opts).toBeDefined();
+
+    // Model the shared sender's selection (verified in @percolatorct/shared):
+    //   fee = keeperOpts?.priorityFeeMicroLamports ?? getRecentPrioritizationFees()
+    //   cu  = keeperOpts?.computeUnitLimit          ?? 400_000
+    const broadcastFee =
+      captured.opts.priorityFeeMicroLamports ?? HOSTILE_RPC_P75_MICROLAMPORTS;
+    const broadcastCu = captured.opts.computeUnitLimit ?? 400_000;
+
+    // The broadcast MUST equal what the budget gated on — not the RPC's fee.
+    expect(broadcastFee).toBe(GATED_FEE_MICROLAMPORTS);
+    expect(broadcastCu).toBe(GATED_CU);
+  });
+
+  it("the override fee equals the estimator output the budget approved (coupling invariant)", async () => {
+    const budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000 });
+    const keypair = Keypair.generate();
+
+    const result = await keeperSend(
+      makeConnection(),
+      [makeDummyIx()],
+      [keypair],
+      "crank",
+      budget,
+      3,
+    );
+
+    expect(result).not.toBeNull();
+    expect(captured.opts?.priorityFeeMicroLamports).toBe(GATED_FEE_MICROLAMPORTS);
+  });
+
+  it("a caller-supplied override still wins (does not clobber an explicit fee)", async () => {
+    const budget = new KeeperBudget({ maxSolPerCycle: 1_000_000_000 });
+    const keypair = Keypair.generate();
+
+    const result = await keeperSend(
+      makeConnection(),
+      [makeDummyIx()],
+      [keypair],
+      "crank",
+      budget,
+      3,
+      { priorityFeeMicroLamports: 7_777, computeUnitLimit: 123_456 },
+    );
+
+    expect(result).not.toBeNull();
+    expect(captured.opts?.priorityFeeMicroLamports).toBe(7_777);
+    expect(captured.opts?.computeUnitLimit).toBe(123_456);
+  });
+});


### PR DESCRIPTION
Closes #396.

## Problem

`keeperSend()` gates the SOL budget on a priority-fee estimate it computes locally (`estimateCost` → `HeliusPriorityFeeEstimator`, tier percentile), then builds the `KeeperSendOptions` handed to `sendWithRetryKeeper` with neither `priorityFeeMicroLamports` nor `computeUnitLimit`. On the standard (non-Sender) path, `@percolatorct/shared` therefore re-derives the priority fee from `getRecentPrioritizationFees` — a distinct, RPC-controlled call with a floor (`Math.max(fee, 1_000)`) but no ceiling — and broadcasts it via `setComputeUnitPrice`.

The fee the budget approved and the fee bid on-chain were independent numbers from different sources. A malicious or degraded RPC could return a small value to the estimator (budget approves a low `estimatedCost`) and an arbitrarily large p75 to `getRecentPrioritizationFees` (broadcast bids that large), spending past the budget cap bounded only by wallet balance.

## Fix

Surface `microLamports` from `estimateCost` and pass it — together with `simulatedCu` — as the send overrides `@percolatorct/shared` already exposes for exactly this purpose (#311, "so the budget the caller gated on is the one actually broadcast"):

```ts
priorityFeeMicroLamports: keeperOpts?.priorityFeeMicroLamports ?? microLamports,
computeUnitLimit:         keeperOpts?.computeUnitLimit ?? simulatedCu,
```

Now the gate and the broadcast use one number. An inflated fee raises `estimatedCost` and trips the existing fail-closed budget halt instead of overspending, and the CU basis the budget reserves against matches the CU requested on-chain. Any caller-supplied override still takes precedence.

**Second-order effect: this also lowers real spend on every crank.** Solana charges the priority fee on the *requested* CU limit, not the amount consumed. The crank call sites pass `simulateForCU: false`, so with no `computeUnitLimit` override the shared sender fell through to a flat `400_000` — a crank consuming ~50k CU was bidding on 400k. Passing `simulatedCu` (`Math.ceil(consumed * 1.1)`, safe headroom) cuts the priority component proportionally.

## Testing

- New PoC `tests/lib/keeper-send.priority-fee-coupling.poc.test.ts` captures the options `keeperSend` hands the sender and asserts the broadcast fee/CU equal the gated estimate (fails before this change: broadcast resolves to the RPC value / `undefined`; passes after). Includes a case proving a caller-supplied override is not clobbered.
- Full suite green (`1035 passed | 33 skipped`); `tsc --noEmit` clean.

## Residual (out of scope, mainnet-only) — this PR does not close the whole class

The Helius Sender fast path (`USE_HELIUS_SENDER=true`) forwards `computeUnitLimit` but not `priorityFeeMicroLamports` to `sendKeeperTxViaSender`, deriving the fee via `getHeliusPriorityFee` (also floor-only), so it self-derives regardless of this change. Closing it requires a `@percolatorct/shared` fix and will land as part of a separate, dedicated Sender-routing change — closing #396 here is scoped to the standard path only (which is what devnet uses; the Sender path is mainnet-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
