### PR TITLE
fix(leader): demote by lease deadline when renewal stalls (closes #398)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,13 @@ USE_HELIUS_SENDER=true
 # NETWORK=mainnet
 # KEEPER_REDIS_URL=https://your-upstash-rest-url.upstash.io
 # KEEPER_REDIS_TOKEN=                # required when KEEPER_REDIS_URL is set (no empty fallback)
+# Lease timings. All three must be finite and > 0, and RENEW_MS must be
+# strictly less than TTL_MS — otherwise the lease expires before the leader
+# renews it, a standby promotes while the old leader still believes it holds
+# the lock, and both submit on-chain transactions (split-brain). The keeper
+# refuses to boot on a violation rather than run split-brained (#377).
+# Keep RENEW_MS at or below half of TTL_MS so a slow Redis round-trip or an
+# event-loop stall cannot let the lease lapse between renewals.
 # KEEPER_LEADER_LOCK_TTL_MS=30000
 # KEEPER_LEADER_LOCK_RENEW_MS=10000
 # KEEPER_STANDBY_POLL_MS=5000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,44 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: build-and-test
-    if: github.ref == 'refs/heads/main'
+    # #384: this was gated to `refs/heads/main`, so the image was only built
+    # AFTER merge and image-build breakage passed PR review invisibly. It then
+    # failed on every push to main from 2026-06-22 to 2026-07-18 (~4 weeks) with
+    # ERR_PNPM_LOCKFILE_CONFIG_MISMATCH, and the PR that introduced it could not
+    # have caught it: build-and-test passes there, because actions/checkout
+    # supplies the whole repo while the docker build context is narrower. The
+    # two jobs disagree on exactly the thing that broke, and only the invisible
+    # one failed.
+    #
+    # The job only builds — it never pushes to a registry — so running it on
+    # pull requests needs no push-gating.
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build Docker image
         run: docker build -t percolator-keeper .
+
+      # K-NEW-1 in the Dockerfile installs production deps only, to keep vitest,
+      # tsx, @types/* and their CVEs out of the runtime image. Nothing verified
+      # that. A regression to a full install would still build green, so assert
+      # the outcome rather than the exit code.
+      - name: Assert devDependencies are absent from the runtime image
+        run: |
+          set -euo pipefail
+          for pkg in vitest tsx typescript fast-check; do
+            if docker run --rm --entrypoint sh percolator-keeper -c "test -e /app/node_modules/$pkg"; then
+              echo "::error::devDependency '$pkg' is present in the runtime image (K-NEW-1 regression)"
+              exit 1
+            fi
+          done
+          echo "OK: vitest, tsx, typescript and fast-check are absent from the runtime image"
+
+      - name: Assert production dependencies survived
+        run: |
+          set -euo pipefail
+          # Mirror check: an install that dropped real dependencies would also
+          # satisfy the assertion above, so it has to be paired with this one.
+          for pkg in @solana/web3.js @upstash/redis p-queue lru-cache; do
+            docker run --rm --entrypoint sh percolator-keeper -c "test -e /app/node_modules/$pkg" \
+              || { echo "::error::production dependency '$pkg' missing from the runtime image"; exit 1; }
+          done
+          echo "OK: production dependencies are present"

--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -30,7 +30,7 @@ on:
 
 env:
   # Update this string when the SDK bumps.  Deliberate — that is the point.
-  SDK_VERSION: "2.0.5"
+  SDK_VERSION: "4.4.0"
 
 concurrency:
   group: sdk-smoke-${{ github.ref }}
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   smoke:
-    name: smoke @percolatorct/sdk@${{ github.event.client_payload.version || inputs.sdk_version || '2.0.5' }}
+    name: smoke @percolatorct/sdk@${{ github.event.client_payload.version || inputs.sdk_version || '4.4.0' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .env
 *.tsbuildinfo
 .pnpm-store/
+.claude/

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0",
+    "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#886aa6b9eb96950c8e415df695cd3ae3614472d5",
     "@percolatorct/shared": "github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f",
     "@solana/web3.js": "^1.98.0",
     "@upstash/redis": "^1.38.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#ac68ac3f45fb3a069866308727c0fd40e8293d2e",
+    "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0",
     "@percolatorct/shared": "github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f",
     "@solana/web3.js": "^1.98.0",
     "@upstash/redis": "^1.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   vite: 8.0.8
+  '@opentelemetry/core': '>=2.8.0'
 
 importers:
 
@@ -270,14 +271,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.6.0':
-    resolution: {integrity: sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/core@2.6.1':
-    resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
+  '@opentelemetry/core@2.9.0':
+    resolution: {integrity: sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -615,7 +610,7 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
       '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
-      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': '>=2.8.0'
       '@opentelemetry/instrumentation': '>=0.57.1 <1'
       '@opentelemetry/resources': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
@@ -646,7 +641,7 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
       '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
-      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': '>=2.8.0'
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
       '@opentelemetry/semantic-conventions': ^1.39.0
 
@@ -1588,7 +1583,7 @@ snapshots:
   '@fastify/otel@0.17.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       minimatch: 10.2.4
@@ -1628,12 +1623,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.40.0
-
-  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -1641,7 +1631,7 @@ snapshots:
   '@opentelemetry/instrumentation-amqplib@0.60.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -1650,7 +1640,7 @@ snapshots:
   '@opentelemetry/instrumentation-connect@0.56.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/connect': 3.4.38
@@ -1667,7 +1657,7 @@ snapshots:
   '@opentelemetry/instrumentation-express@0.61.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -1676,7 +1666,7 @@ snapshots:
   '@opentelemetry/instrumentation-fs@0.32.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
@@ -1698,7 +1688,7 @@ snapshots:
   '@opentelemetry/instrumentation-hapi@0.59.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -1707,7 +1697,7 @@ snapshots:
   '@opentelemetry/instrumentation-http@0.213.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       forwarded-parse: 2.1.2
@@ -1742,7 +1732,7 @@ snapshots:
   '@opentelemetry/instrumentation-koa@0.61.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -1766,7 +1756,7 @@ snapshots:
   '@opentelemetry/instrumentation-mongoose@0.59.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -1793,7 +1783,7 @@ snapshots:
   '@opentelemetry/instrumentation-pg@0.65.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
@@ -1823,7 +1813,7 @@ snapshots:
   '@opentelemetry/instrumentation-undici@0.23.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -1861,13 +1851,13 @@ snapshots:
   '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
@@ -1876,7 +1866,7 @@ snapshots:
   '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
 
   '@oxc-project/types@0.124.0': {}
 
@@ -1991,15 +1981,15 @@ snapshots:
 
   '@sentry/core@10.46.0': {}
 
-  '@sentry/node-core@10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+  '@sentry/node-core@10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
       '@sentry/core': 10.46.0
-      '@sentry/opentelemetry': 10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/opentelemetry': 10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       import-in-the-middle: 3.0.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
@@ -2010,7 +2000,7 @@ snapshots:
       '@fastify/otel': 0.17.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-amqplib': 0.60.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-connect': 0.56.0(@opentelemetry/api@1.9.1)
@@ -2039,17 +2029,17 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.40.0
       '@prisma/instrumentation': 7.4.2(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.46.0
-      '@sentry/node-core': 10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      '@sentry/opentelemetry': 10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/node-core': 10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/opentelemetry': 10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       import-in-the-middle: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/opentelemetry@10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+  '@sentry/opentelemetry@10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@sentry/core': 10.46.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
   .:
     dependencies:
       '@percolatorct/sdk':
-        specifier: github:dcccrypto/percolator-sdk#ac68ac3f45fb3a069866308727c0fd40e8293d2e
-        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        specifier: github:dcccrypto/percolator-sdk#bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0
+        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@percolatorct/shared':
         specifier: github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f
-        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -461,9 +461,9 @@ packages:
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
-  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e}
-    version: 4.2.0
+  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0':
+    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0}
+    version: 4.3.0
     engines: {node: '>=20.0.0'}
 
   '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f':
@@ -1880,7 +1880,7 @@ snapshots:
 
   '@oxc-project/types@0.124.0': {}
 
-  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1891,9 +1891,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@percolatorct/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/ac68ac3f45fb3a069866308727c0fd40e8293d2e(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@percolatorct/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@sentry/node': 10.46.0
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@supabase/supabase-js': 2.100.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
   .:
     dependencies:
       '@percolatorct/sdk':
-        specifier: github:dcccrypto/percolator-sdk#bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0
-        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        specifier: github:dcccrypto/percolator-sdk#886aa6b9eb96950c8e415df695cd3ae3614472d5
+        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@percolatorct/shared':
         specifier: github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f
-        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -461,8 +461,8 @@ packages:
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
-  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0}
+  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5':
+    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5}
     version: 4.3.0
     engines: {node: '>=20.0.0'}
 
@@ -1880,7 +1880,7 @@ snapshots:
 
   '@oxc-project/types@0.124.0': {}
 
-  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1891,9 +1891,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@percolatorct/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/bbe48e445e8e6aae386d9bfb6c7ad5970f92a3f0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@percolatorct/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@sentry/node': 10.46.0
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@supabase/supabase-js': 2.100.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,11 @@
 overrides:
   vite: 8.0.8
+  # GHSA-8988-4f7v-96qf / CVE-2026-54285 (#378): W3CBaggagePropagator.extract()
+  # in @opentelemetry/core < 2.8.0 does not enforce the W3C baggage limits
+  # (8192 bytes / 180 entries) on inbound headers, so it allocates and parses
+  # every entry of an oversized `baggage` header. Reached transitively via
+  # @sentry/node, which the keeper initialises before creating its HTTP
+  # health/admin server — so on a remotely bound deployment the parser sits on
+  # an unauthenticated request path. Pulled in at 2.6.0 and 2.6.1 by different
+  # Sentry sub-dependencies, hence an override rather than a direct bump.
+  "@opentelemetry/core": ">=2.8.0"

--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -279,5 +279,27 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
           "would fire and vanish with no operator-visible signal.",
       );
     }
+
+    // BUG-101: keeper-send.ts's isMainnetSender() is a literal
+    // `USE_HELIUS_SENDER === "true"` check with no NETWORK-based default --
+    // unset or any non-"true" value silently falls back to plain
+    // sendRawTransaction broadcast (skipPreflight, no Jito bundle) to public
+    // RPCs, exposing the liquidation target pubkey and close size to any RPC
+    // operator or mempool listener before confirmation (front-running /
+    // liquidation-sniping). .env.example documents USE_HELIUS_SENDER=true as
+    // the mainnet default, but nothing enforced it -- a deployment built from
+    // a partial env (not copying that line) degraded silently with zero
+    // boot-time signal, unlike every other mainnet-critical setting in this
+    // file. Require it explicitly, mirroring the H-7 DISCORD_ALERT_WEBHOOK guard.
+    if (env.USE_HELIUS_SENDER !== "true") {
+      throw new Error(
+        "USE_HELIUS_SENDER must be set to 'true' when NETWORK=mainnet. It is " +
+          "unset or not 'true', and keeper-send.ts's isMainnetSender() would " +
+          "silently fall back to plain sendRawTransaction broadcast to public " +
+          "RPCs with no Jito-bundle protection -- exposing the liquidation " +
+          "target and size to front-running/sandwiching before confirmation. " +
+          "Set USE_HELIUS_SENDER=true (see .env.example) for mainnet.",
+      );
+    }
   }
 }

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -25,6 +25,7 @@
  * concurrent canSpend() / recordTx() callers.
  */
 
+import fs from "node:fs";
 import { createLogger } from "@percolatorct/shared";
 
 const logger = createLogger("keeper:budget");
@@ -111,6 +112,16 @@ export interface KeeperBudgetDeps {
   /** Fired when a latched halt is cleared (resume()). Lets callers reset a
    *  halted gauge without coupling this class to the metrics layer. */
   onResume?: () => void;
+  /**
+   * BUG-106: when set, a latched halt is persisted to this local file (and
+   * restored from it at construction) so a process crash/restart does not
+   * silently resume spending into whatever condition caused the halt.
+   * Unset by default -- every existing/test instance is unaffected unless it
+   * opts in explicitly. Covers process-level restarts that reuse the same
+   * filesystem (the common automatic-restart case); a full container
+   * recreate on an ephemeral filesystem is not covered.
+   */
+  haltStatePath?: string;
 }
 
 interface SpendEvent {
@@ -203,6 +214,7 @@ export class KeeperBudget {
   private _isHalted = false;
   private _haltKind: HaltKind | undefined;
   private _haltReason: string | undefined;
+  private readonly _haltStatePath: string | undefined;
 
   // M12: realized-cost reconciliation telemetry.
   private _realizedCostDriftLamports = 0;
@@ -214,6 +226,76 @@ export class KeeperBudget {
     this._now = deps.now ?? (() => Date.now());
     this._onHalt = deps.onHalt;
     this._onResume = deps.onResume;
+    this._haltStatePath = deps.haltStatePath;
+    this._restoreHaltState();
+  }
+
+  /**
+   * BUG-106: restore a latched halt persisted by a previous process, if any.
+   * A halt that was never resumed before a restart must keep the keeper
+   * halted -- silently resuming would defeat the entire point of a
+   * manual-resume-only breaker. Fires onHalt again so paging/metrics react
+   * exactly as if the halt had just occurred.
+   */
+  private _restoreHaltState(): void {
+    if (!this._haltStatePath) return;
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this._haltStatePath, "utf8");
+    } catch {
+      return; // no persisted halt — start clean
+    }
+    try {
+      const parsed = JSON.parse(raw) as { kind?: HaltKind; reason?: string };
+      if (!parsed.kind || !parsed.reason) return;
+      this._isHalted = true;
+      this._haltKind = parsed.kind;
+      this._haltReason = parsed.reason;
+      logger.error(
+        "Restored a latched budget halt from a previous run — keeper is starting " +
+          "halted. This halt was never resume()d before the process restarted; " +
+          "investigate the original cause before calling resume().",
+        { kind: parsed.kind, reason: parsed.reason, path: this._haltStatePath },
+      );
+      try {
+        this._onHalt?.(parsed.kind, parsed.reason);
+      } catch (err) {
+        logger.warn("onHalt hook threw while restoring a persisted halt — ignoring", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    } catch (err) {
+      logger.warn("Failed to parse persisted budget halt state — starting clean", {
+        path: this._haltStatePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private _persistHaltState(): void {
+    if (!this._haltStatePath) return;
+    try {
+      fs.writeFileSync(
+        this._haltStatePath,
+        JSON.stringify({ kind: this._haltKind, reason: this._haltReason, haltedAt: this._now() }),
+        "utf8",
+      );
+    } catch (err) {
+      logger.warn("Failed to persist budget halt state — a restart will not remember this halt", {
+        path: this._haltStatePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private _clearHaltStateFile(): void {
+    if (!this._haltStatePath) return;
+    try {
+      fs.unlinkSync(this._haltStatePath);
+    } catch {
+      // Nothing to remove, or removal failed — not critical; the next halt
+      // (if any) overwrites it, and a missing file is treated as no-halt.
+    }
   }
 
   /**
@@ -538,6 +620,7 @@ export class KeeperBudget {
     this._isHalted = false;
     this._haltKind = undefined;
     this._haltReason = undefined;
+    this._clearHaltStateFile();
     try {
       this._onResume?.();
     } catch (err) {
@@ -560,6 +643,7 @@ export class KeeperBudget {
     this._isHalted = true;
     this._haltKind = kind;
     this._haltReason = reason;
+    this._persistHaltState();
     logger.error("Keeper budget halted — refusing further sends until manual resume()", {
       kind,
       reason,

--- a/src/lib/keeper-send.ts
+++ b/src/lib/keeper-send.ts
@@ -80,6 +80,13 @@ function getCuEstimator(): CuEstimator {
 export const sharedBudget = new KeeperBudget(
   {},
   {
+    // BUG-106: persist a latched halt to disk so a crash/restart (the common
+    // case — same container/filesystem, e.g. an uncaught exception or an
+    // orchestrator-driven OOM restart) keeps the keeper halted instead of
+    // silently resuming spend into whatever condition tripped the breaker.
+    // A full container recreate on an ephemeral filesystem is not covered;
+    // operators wanting that can point this at a mounted persistent volume.
+    haltStatePath: process.env.KEEPER_BUDGET_HALT_STATE_PATH ?? "/tmp/keeper-budget-halt.json",
     onHalt: (kind, reason) => {
       budgetHalted.set(1);
       logger.error("KeeperBudget circuit-breaker halted — refusing all sends until resume", {

--- a/src/lib/leader.ts
+++ b/src/lib/leader.ts
@@ -20,6 +20,58 @@ end
 
 export type LeaderRole = "leader" | "standby" | "starting";
 
+/**
+ * #377: thrown when lease timings would make the single-writer guarantee
+ * unenforceable. Constructing a LeaderLock is the last point at which this is
+ * still cheap to catch — past it the misconfiguration is silent, and its only
+ * symptom is two nodes writing on-chain at once.
+ */
+export class LeaderLockTimingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LeaderLockTimingError";
+  }
+}
+
+/**
+ * #377: the lock's correctness rests on timings nothing previously checked.
+ * `Number(process.env.X ?? default)` in index.ts yields NaN for any malformed
+ * value, and NaN fails every comparison silently: `setTimeout(fn, NaN)` fires
+ * on the next tick, turning renewal into a hot loop, while `ex: NaN` produces a
+ * lease Redis will not honour.
+ *
+ * The ordering invariant matters more than the individual bounds. If
+ * renewMs >= ttlMs the lease expires BEFORE the leader ever tries to renew, so
+ * a standby acquires the freed key and promotes itself while the original node
+ * still reports role() === "leader" — it does not learn otherwise until its
+ * renewal finally runs and the fencing script rejects it. keeperSend gates
+ * writes on that local role alone, so both nodes submit transactions in the
+ * interval. Split-brain is then deterministic, not a race.
+ */
+function validateTiming(ttlMs: number, renewMs: number, pollMs: number): void {
+  for (const [name, value] of [
+    ["ttlMs", ttlMs],
+    ["renewMs", renewMs],
+    ["pollMs", pollMs],
+  ] as const) {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new LeaderLockTimingError(
+        `LeaderLock ${name} must be a finite positive number of milliseconds, got ${String(value)}. ` +
+          `Check KEEPER_LEADER_LOCK_TTL_MS / KEEPER_LEADER_LOCK_RENEW_MS / KEEPER_STANDBY_POLL_MS.`,
+      );
+    }
+  }
+
+  if (renewMs >= ttlMs) {
+    throw new LeaderLockTimingError(
+      `LeaderLock renewMs (${renewMs}) must be strictly less than ttlMs (${ttlMs}) — otherwise the ` +
+        `lease expires before the leader renews it and a standby can promote while this node still ` +
+        `reports itself leader, allowing both to submit on-chain transactions (split-brain). ` +
+        `Set KEEPER_LEADER_LOCK_RENEW_MS below KEEPER_LEADER_LOCK_TTL_MS (recommended: at most half).`,
+    );
+  }
+}
+
 export interface LeaderLockOptions {
   ttlMs?: number;
   renewMs?: number;
@@ -56,11 +108,32 @@ export class LeaderLock {
   private _stopped = false;
 
   constructor(redis: RedisLike, identity: string, opts: LeaderLockOptions = {}) {
+    const ttlMs = opts.ttlMs ?? 30_000;
+    const renewMs = opts.renewMs ?? 10_000;
+    const pollMs = opts.pollMs ?? 5_000;
+
+    // #377: fail fast at construction. A lock built on unsafe timings cannot
+    // provide the guarantee its callers assume, so refusing to boot is the only
+    // safe outcome — the alternative is a silently split-brained keeper.
+    validateTiming(ttlMs, renewMs, pollMs);
+
+    // Renewal must also survive being LATE. A renewal firing at renewMs still
+    // has to complete a Redis round-trip before ttlMs, so a margin thinner than
+    // half the TTL leaves little room for a slow round-trip or event-loop stall.
+    // This is a judgement call, not an invariant, so it warns rather than throws.
+    if (renewMs > ttlMs / 2) {
+      logger.warn("LeaderLock renew margin is thin — a slow Redis round-trip or event-loop stall could let the lease lapse", {
+        ttlMs,
+        renewMs,
+        recommendedMaxRenewMs: ttlMs / 2,
+      });
+    }
+
     this.redis = redis;
     this.identity = identity;
-    this.ttlMs = opts.ttlMs ?? 30_000;
-    this.renewMs = opts.renewMs ?? 10_000;
-    this.pollMs = opts.pollMs ?? 5_000;
+    this.ttlMs = ttlMs;
+    this.renewMs = renewMs;
+    this.pollMs = pollMs;
   }
 
   role(): LeaderRole {

--- a/src/lib/leader.ts
+++ b/src/lib/leader.ts
@@ -24,6 +24,7 @@ export interface LeaderLockOptions {
   ttlMs?: number;
   renewMs?: number;
   pollMs?: number;
+  renewTimeoutMs?: number;
 }
 
 export interface StartOptions {
@@ -38,10 +39,12 @@ export class LeaderLock {
   private readonly ttlMs: number;
   private readonly renewMs: number;
   private readonly pollMs: number;
+  private readonly renewTimeoutMs: number;
 
   private _role: LeaderRole = "starting";
   private _renewTimer: NodeJS.Timeout | null = null;
   private _pollTimer: NodeJS.Timeout | null = null;
+  private _leaseTimer: NodeJS.Timeout | null = null;
   private _renewFailures = 0;
   private _lockKey = "";
   private _onDemote: ((reason: string) => void) | null = null;
@@ -61,6 +64,10 @@ export class LeaderLock {
     this.ttlMs = opts.ttlMs ?? 30_000;
     this.renewMs = opts.renewMs ?? 10_000;
     this.pollMs = opts.pollMs ?? 5_000;
+    // Bound each renew RPC so a hung Redis fetch cannot stall the renew loop
+    // forever. Kept at/below renewMs so a timed-out renew still leaves room to
+    // retry (and strike-demote) before the lease-expiry watchdog fires.
+    this.renewTimeoutMs = opts.renewTimeoutMs ?? Math.min(this.renewMs, 5_000);
   }
 
   role(): LeaderRole {
@@ -130,6 +137,9 @@ export class LeaderLock {
     this._role = "leader";
     this._renewFailures = 0;
     logger.info("LeaderLock promoted to leader", { identity: this.identity });
+    // Arm the lease watchdog before firing onPromote so the split-brain guard is
+    // live even if the handler throws (mirrors _demote arming the poll first).
+    this._armLeaseWatchdog();
     opts.onPromote();
     this._scheduleRenew(opts);
   }
@@ -139,6 +149,49 @@ export class LeaderLock {
       await this._renew(opts);
     }, this.renewMs);
     this._renewTimer.unref?.();
+  }
+
+  // Lease-expiry watchdog. The Redis lock we hold expires ttlMs after our last
+  // successful acquire/renew; if we cannot confirm a renewal before then — the
+  // eval hangs, times out repeatedly, or errors — we MUST relinquish leadership
+  // so a standby that acquires the now-free lock is the only writer. This is the
+  // hard guarantee behind the 2-strike renew counter: regardless of how renewal
+  // fails, a node stops believing it is leader by its own lease deadline. Armed
+  // on promotion and re-armed on every successful renewal.
+  private _armLeaseWatchdog(): void {
+    if (this._leaseTimer) clearTimeout(this._leaseTimer);
+    this._leaseTimer = setTimeout(() => {
+      if (this._stopped || this._role !== "leader") return;
+      logger.error(
+        "LeaderLock lease watchdog fired — no successful renewal within ttlMs; demoting to prevent split-brain",
+        { identity: this.identity, ttlMs: this.ttlMs },
+      );
+      this._demote("lease-expired");
+    }, this.ttlMs);
+    this._leaseTimer.unref?.();
+  }
+
+  // Bound the renew eval so a hung Redis request cannot stall the renew loop
+  // indefinitely (which would leave _role === "leader" forever). A timeout is
+  // surfaced as a thrown error, taking the same strike/demote path as any other
+  // transient transport failure.
+  private async _evalRenewWithTimeout(): Promise<number | null> {
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`Redis renew timed out after ${this.renewTimeoutMs}ms`)),
+        this.renewTimeoutMs,
+      );
+      timer.unref?.();
+    });
+    try {
+      return await Promise.race([
+        this.redis.eval<number | null>(RENEW_SCRIPT, [this._lockKey], [this.identity, this.ttlMs]),
+        timeout,
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   private async _renew(opts: StartOptions): Promise<void> {
@@ -151,14 +204,18 @@ export class LeaderLock {
       // or key gone). Identity mismatch is a definitive loss of lease and
       // demotes IMMEDIATELY — it is NOT a transient error and must bypass the
       // 2-strike counter (which is reserved for thrown transport errors).
-      const result = await this.redis.eval<number | null>(
-        RENEW_SCRIPT,
-        [this._lockKey],
-        [this.identity, this.ttlMs],
-      );
+      // Bounded by a timeout so a hung Redis cannot stall this await forever.
+      const result = await this._evalRenewWithTimeout();
+
+      // A hung/slow eval may resolve after a concurrent stop() or after the
+      // lease watchdog already demoted us — never act on a stale result or
+      // re-arm timers on a node that is no longer leader.
+      if (this._stopped || this._role !== "leader") return;
 
       if (result === 1) {
         this._renewFailures = 0;
+        // Fresh lease confirmed — push the split-brain watchdog out by ttlMs.
+        this._armLeaseWatchdog();
         this._scheduleRenew(opts);
         return;
       }
@@ -189,9 +246,15 @@ export class LeaderLock {
         this._scheduleRenew(opts);
       }
     } catch (err) {
-      // Transient transport error (network blip, 5xx, rate-limit). Preserve
-      // the existing 2-strike tolerance — this is the path the M15 finding
-      // discusses; tightening it is a separate PR.
+      // A concurrent stop() or lease-watchdog demotion may have already moved us
+      // out of leader while the eval/timeout was in flight — do not strike or
+      // re-arm a renew on a non-leader.
+      if (this._stopped || this._role !== "leader") return;
+
+      // Transient transport error (network blip, 5xx, rate-limit) or a renew
+      // timeout. The 2-strike tolerance still applies for a responsive fast
+      // demote; the lease watchdog is the backstop that guarantees demotion by
+      // the lease deadline even if strikes accrue more slowly than the TTL.
       this._renewFailures++;
       logger.warn("LeaderLock renew error", {
         identity: this.identity,
@@ -276,6 +339,10 @@ export class LeaderLock {
     if (this._pollTimer) {
       clearTimeout(this._pollTimer);
       this._pollTimer = null;
+    }
+    if (this._leaseTimer) {
+      clearTimeout(this._leaseTimer);
+      this._leaseTimer = null;
     }
   }
 }

--- a/src/lib/leader.ts
+++ b/src/lib/leader.ts
@@ -116,10 +116,13 @@ export class LeaderLock {
     const ttlSec = Math.ceil(this.ttlMs / 1000);
 
     try {
+      // Stamp before the SET so the watchdog deadline is measured from when the
+      // lease request was issued (see _armLeaseWatchdog).
+      const acquiredAt = Date.now();
       const result = await this.redis.set(this._lockKey, this.identity, { ex: ttlSec, nx: true } as { ex: number; nx: true });
 
       if (result === "OK") {
-        this._promote(opts);
+        this._promote(opts, acquiredAt);
       } else {
         this._enterStandby(opts);
       }
@@ -132,14 +135,15 @@ export class LeaderLock {
     }
   }
 
-  private _promote(opts: StartOptions): void {
+  private _promote(opts: StartOptions, leaseIssuedAt: number): void {
     if (this._stopped) return;
     this._role = "leader";
     this._renewFailures = 0;
     logger.info("LeaderLock promoted to leader", { identity: this.identity });
     // Arm the lease watchdog before firing onPromote so the split-brain guard is
     // live even if the handler throws (mirrors _demote arming the poll first).
-    this._armLeaseWatchdog();
+    // leaseIssuedAt is when the acquiring SET NX was issued, not when _promote runs.
+    this._armLeaseWatchdog(leaseIssuedAt);
     opts.onPromote();
     this._scheduleRenew(opts);
   }
@@ -151,15 +155,21 @@ export class LeaderLock {
     this._renewTimer.unref?.();
   }
 
-  // Lease-expiry watchdog. The Redis lock we hold expires ttlMs after our last
-  // successful acquire/renew; if we cannot confirm a renewal before then — the
-  // eval hangs, times out repeatedly, or errors — we MUST relinquish leadership
-  // so a standby that acquires the now-free lock is the only writer. This is the
-  // hard guarantee behind the 2-strike renew counter: regardless of how renewal
-  // fails, a node stops believing it is leader by its own lease deadline. Armed
-  // on promotion and re-armed on every successful renewal.
-  private _armLeaseWatchdog(): void {
+  // Lease-expiry watchdog. The Redis lock expires ttlMs after Redis EXECUTES our
+  // acquire/renew, which happens between our request and its response. We measure
+  // the deadline from when the request was ISSUED (`leaseIssuedAt`), not when it
+  // resolved: measuring from issue time is conservative (arms slightly early,
+  // never late), so a slow-but-not-hung Redis — a renewal that succeeds just
+  // under renewTimeoutMs — cannot leave us believing we still hold a lease that
+  // has, on Redis's clock, already expired (which would open a dual-leader window
+  // up to renewTimeoutMs wide). If we cannot confirm a renewal before the
+  // deadline — the eval hangs, times out repeatedly, or errors — we MUST
+  // relinquish leadership so a standby that acquires the now-free lock is the
+  // only writer. This is the hard guarantee behind the 2-strike renew counter.
+  // Armed on promotion and re-armed on every successful renewal.
+  private _armLeaseWatchdog(leaseIssuedAt: number): void {
     if (this._leaseTimer) clearTimeout(this._leaseTimer);
+    const remainingMs = Math.max(0, this.ttlMs - (Date.now() - leaseIssuedAt));
     this._leaseTimer = setTimeout(() => {
       if (this._stopped || this._role !== "leader") return;
       logger.error(
@@ -167,7 +177,7 @@ export class LeaderLock {
         { identity: this.identity, ttlMs: this.ttlMs },
       );
       this._demote("lease-expired");
-    }, this.ttlMs);
+    }, remainingMs);
     this._leaseTimer.unref?.();
   }
 
@@ -205,6 +215,9 @@ export class LeaderLock {
       // demotes IMMEDIATELY — it is NOT a transient error and must bypass the
       // 2-strike counter (which is reserved for thrown transport errors).
       // Bounded by a timeout so a hung Redis cannot stall this await forever.
+      // Stamp before the eval so the watchdog deadline is measured from when the
+      // renew request was issued, not when Redis replied (see _armLeaseWatchdog).
+      const issuedAt = Date.now();
       const result = await this._evalRenewWithTimeout();
 
       // A hung/slow eval may resolve after a concurrent stop() or after the
@@ -214,8 +227,9 @@ export class LeaderLock {
 
       if (result === 1) {
         this._renewFailures = 0;
-        // Fresh lease confirmed — push the split-brain watchdog out by ttlMs.
-        this._armLeaseWatchdog();
+        // Fresh lease confirmed — push the split-brain watchdog out, dated from
+        // when Redis received the renew (issuedAt), not from now.
+        this._armLeaseWatchdog(issuedAt);
         this._scheduleRenew(opts);
         return;
       }
@@ -296,10 +310,11 @@ export class LeaderLock {
 
       if (current === null) {
         const ttlSec = Math.ceil(this.ttlMs / 1000);
+        const acquiredAt = Date.now();
         const result = await this.redis.set(this._lockKey, this.identity, { ex: ttlSec, nx: true } as { ex: number; nx: true });
         if (this._stopped || this._role !== "standby") return;
         if (result === "OK") {
-          this._promote(opts);
+          this._promote(opts, acquiredAt);
           return;
         }
       }

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -606,13 +606,25 @@ async function crankLpVault(
     domainIdx = 0;
   }
 
+  // v17 dual-domain: tag 78 names the pot the fees land in and needs BOTH
+  // ledgers. We credit the registry's own domain; a rebalance (tag 91) can move
+  // the resulting backing if the house is drawing on the other pot. The target
+  // ledger is created on first use, so the cranker must be writable (it pays the
+  // rent) and the system program is required.
   const [ledgerPda] = deriveLpBackingLedger(programId, market.slabAddress, domainIdx);
-  const data = encodeLpVaultCrankFees();
+  const [siblingLedgerPda] = deriveLpBackingLedger(
+    programId,
+    market.slabAddress,
+    domainIdx ^ 1,
+  );
+  const data = encodeLpVaultCrankFees({ domain: domainIdx });
   const keys = [
-    { pubkey: keypair.publicKey, isSigner: true,  isWritable: false },
+    { pubkey: keypair.publicKey, isSigner: true,  isWritable: true  },
     { pubkey: market.slabAddress, isSigner: false, isWritable: true  },
     { pubkey: registryPda,        isSigner: false, isWritable: true  },
     { pubkey: ledgerPda,          isSigner: false, isWritable: true  },
+    { pubkey: siblingLedgerPda,   isSigner: false, isWritable: true  },
+    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
   ];
   const ix = buildIx({ programId, keys, data });
 

--- a/src/services/fee-crank.ts
+++ b/src/services/fee-crank.ts
@@ -48,7 +48,7 @@
  * abort the cycle for any other market or any other leg.
  */
 
-import { PublicKey } from "@solana/web3.js";
+import { PublicKey, SystemProgram } from "@solana/web3.js";
 import type { Connection, Keypair, TransactionInstruction } from "@solana/web3.js";
 import {
   buildIx,
@@ -424,16 +424,26 @@ export const lpVaultCrankFeesLeg: CrankLeg = {
       return [];
     }
 
+    // v17 dual-domain: the vault can hold backing in EITHER pot of its asset,
+    // so tag 78 now names the pot the fees land in and needs both ledgers. We
+    // credit the registry's own domain — fees become backing there, and a
+    // rebalance (tag 91) can move them if the house needs the other pot.
+    // The sibling ledger may not exist yet; the program creates the target
+    // ledger on first use, which is why the cranker must be writable (it pays
+    // the rent) and the system program is required.
     const [ledgerPda] = deriveLpBackingLedger(programId, address, domainIdx);
+    const [siblingLedgerPda] = deriveLpBackingLedger(programId, address, domainIdx ^ 1);
     const ix = buildIx({
       programId,
       keys: [
-        { pubkey: ctx.keypair.publicKey, isSigner: true, isWritable: false },
+        { pubkey: ctx.keypair.publicKey, isSigner: true, isWritable: true },
         { pubkey: address, isSigner: false, isWritable: true },
         { pubkey: registryPda, isSigner: false, isWritable: true },
         { pubkey: ledgerPda, isSigner: false, isWritable: true },
+        { pubkey: siblingLedgerPda, isSigner: false, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
       ],
-      data: encodeLpVaultCrankFees(),
+      data: encodeLpVaultCrankFees({ domain: domainIdx }),
     });
 
     return [

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -168,6 +168,7 @@ describe("validateKeeperEnvGuards", () => {
         KEEPER_REDIS_URL: "https://fake-host.upstash.io",
         KEEPER_REDIS_TOKEN: "fake-token",
         DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+        USE_HELIUS_SENDER: "true",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -357,6 +358,7 @@ describe("validateKeeperEnvGuards", () => {
         FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
         RPC_URL: "https://mainnet.helius-rpc.com/?api-key=xxx",
         DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+        USE_HELIUS_SENDER: "true",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -514,6 +516,7 @@ describe("validateKeeperEnvGuards", () => {
         FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
         RPC_URL: MAINNET,
         DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+        USE_HELIUS_SENDER: "true",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -527,6 +530,7 @@ describe("validateKeeperEnvGuards", () => {
         RPC_URL: "https://my-devnet-migration.example.com",
         FALLBACK_RPC_URL: "https://my-devnet-migration.example.com",
         DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+        USE_HELIUS_SENDER: "true",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
@@ -613,11 +617,59 @@ describe("validateKeeperEnvGuards", () => {
         RPC_URL: MAINNET,
         FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
         DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+        USE_HELIUS_SENDER: "true",
       } as NodeJS.ProcessEnv;
       expect(() => validateKeeperEnvGuards(env)).not.toThrow();
     });
 
     it("does NOT require DISCORD_ALERT_WEBHOOK off mainnet (devnet/unset)", () => {
+      expect(() =>
+        validateKeeperEnvGuards({ NETWORK: "devnet" } as NodeJS.ProcessEnv),
+      ).not.toThrow();
+      expect(() => validateKeeperEnvGuards({} as NodeJS.ProcessEnv)).not.toThrow();
+    });
+  });
+
+  // BUG-101: keeper-send.ts's isMainnetSender() is a literal `=== "true"` check
+  // with no NETWORK-based default -- unset silently degrades to a public,
+  // unprotected sendRawTransaction broadcast on mainnet.
+  describe("BUG-101: USE_HELIUS_SENDER required on mainnet", () => {
+    const MAINNET = "https://mainnet.helius-rpc.com/?api-key=test";
+    const baseMainnetEnv = {
+      NETWORK: "mainnet",
+      SOLANA_RPC_URL: MAINNET,
+      RPC_URL: MAINNET,
+      FALLBACK_RPC_URL: "https://api.mainnet-beta.solana.com",
+      DISCORD_ALERT_WEBHOOK: "https://discord.com/api/webhooks/123/abc",
+    };
+
+    it("throws when USE_HELIUS_SENDER is unset on mainnet", () => {
+      const env = { ...baseMainnetEnv } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /USE_HELIUS_SENDER must be set to 'true'.*NETWORK=mainnet/i,
+      );
+    });
+
+    it("throws when USE_HELIUS_SENDER=false on mainnet", () => {
+      const env = { ...baseMainnetEnv, USE_HELIUS_SENDER: "false" } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /USE_HELIUS_SENDER must be set to 'true'/i,
+      );
+    });
+
+    it("throws when USE_HELIUS_SENDER is an arbitrary non-'true' string on mainnet", () => {
+      const env = { ...baseMainnetEnv, USE_HELIUS_SENDER: "1" } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).toThrow(
+        /USE_HELIUS_SENDER must be set to 'true'/i,
+      );
+    });
+
+    it("accepts USE_HELIUS_SENDER=true on mainnet", () => {
+      const env = { ...baseMainnetEnv, USE_HELIUS_SENDER: "true" } as NodeJS.ProcessEnv;
+      expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+    });
+
+    it("does NOT require USE_HELIUS_SENDER off mainnet (devnet/unset)", () => {
       expect(() =>
         validateKeeperEnvGuards({ NETWORK: "devnet" } as NodeJS.ProcessEnv),
       ).not.toThrow();

--- a/tests/lib/budget.test.ts
+++ b/tests/lib/budget.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { KeeperBudget, type TxResult } from "../../src/lib/budget.js";
 
 function makeClock(start = 1_700_000_000_000) {
@@ -746,5 +749,84 @@ describe("KeeperBudget — M12 adjustForRealizedCost", () => {
       expect(s.realizedCostDriftLamports).toBe(75);
       expect(s.realizedCostSamples).toBe(1);
     });
+  });
+});
+
+// BUG-106: a latched halt was purely in-memory -- a process crash/restart
+// silently resumed spending into whatever condition tripped the breaker,
+// with no record that it was ever halted. haltStatePath is opt-in (undefined
+// by default) so every test above, and every consumer that doesn't pass it,
+// is completely unaffected.
+describe("KeeperBudget — BUG-106: halt-state persistence", () => {
+  function tempHaltPath(): string {
+    return path.join(os.tmpdir(), `keeper-budget-halt-test-${Math.random().toString(36).slice(2)}.json`);
+  }
+
+  it("does not touch the filesystem when haltStatePath is not set", () => {
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now });
+    b.haltManually("cordon");
+    expect(b.isHalted()).toBe(true);
+    // No haltStatePath was given — nothing to assert on disk, just confirms
+    // the existing in-memory-only behavior is unchanged when opted out.
+  });
+
+  it("persists a halt to disk and restores it in a fresh instance constructed with the same path", () => {
+    const haltStatePath = tempHaltPath();
+    try {
+      const clock = makeClock();
+      const b1 = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, haltStatePath });
+      b1.haltManually("cordoning for deploy");
+      expect(fs.existsSync(haltStatePath)).toBe(true);
+
+      // Simulates a process restart: a brand-new instance, same path.
+      const onHalt = vi.fn();
+      const b2 = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, haltStatePath, onHalt });
+      expect(b2.isHalted()).toBe(true);
+      expect(b2.haltKind).toBe("operator");
+      expect(b2.canSpend(1, "crank")).toBe(false);
+      // The restore re-fires onHalt so paging/metrics react as if it just happened.
+      expect(onHalt).toHaveBeenCalledWith("operator", "cordoning for deploy");
+    } finally {
+      fs.rmSync(haltStatePath, { force: true });
+    }
+  });
+
+  it("clears the persisted file on resume — a later restart starts clean", () => {
+    const haltStatePath = tempHaltPath();
+    try {
+      const clock = makeClock();
+      const b1 = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, haltStatePath });
+      b1.haltManually("cordon");
+      expect(fs.existsSync(haltStatePath)).toBe(true);
+      b1.resume("op");
+      expect(fs.existsSync(haltStatePath)).toBe(false);
+
+      const b2 = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, haltStatePath });
+      expect(b2.isHalted()).toBe(false);
+      expect(b2.canSpend(1, "crank")).toBe(true);
+    } finally {
+      fs.rmSync(haltStatePath, { force: true });
+    }
+  });
+
+  it("starts clean when the configured path has no file yet", () => {
+    const haltStatePath = tempHaltPath(); // never written
+    const clock = makeClock();
+    const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, haltStatePath });
+    expect(b.isHalted()).toBe(false);
+  });
+
+  it("starts clean and logs rather than throwing when the persisted file is malformed", () => {
+    const haltStatePath = tempHaltPath();
+    try {
+      fs.writeFileSync(haltStatePath, "{not valid json", "utf8");
+      const clock = makeClock();
+      expect(() => new KeeperBudget(TIGHT_CONFIG, { now: clock.now, haltStatePath })).not.toThrow();
+      const b = new KeeperBudget(TIGHT_CONFIG, { now: clock.now, haltStatePath });
+      expect(b.isHalted()).toBe(false);
+    } finally {
+      fs.rmSync(haltStatePath, { force: true });
+    }
   });
 });

--- a/tests/lib/leader-hung-renew.poc.test.ts
+++ b/tests/lib/leader-hung-renew.poc.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { LeaderLock } from "../../src/lib/leader.js";
+import type { RedisLike } from "../../src/lib/redis-client.js";
+
+/**
+ * PoC — leader renewal has no deadline, so a hung Redis keeps a node believing
+ * it is leader past its lease expiry (split-brain double-send).
+ *
+ * `_renew()` awaits `redis.eval(RENEW_SCRIPT, ...)` with no timeout, and the
+ * Upstash client is constructed with no request signal. Demotion is purely
+ * event-driven — it happens only when the eval THROWS (2-strike counter) or
+ * RETURNS a lease-lost result. A hung/partitioned Redis (fetch that neither
+ * resolves nor rejects) produces neither, so `_renew` stalls forever, no new
+ * renew timer is scheduled, and `_role` stays "leader" indefinitely. Meanwhile
+ * the Redis lock TTL lapses and a standby acquires it — now two nodes act as
+ * leader against a permissionless program (duplicate liquidations / sends).
+ *
+ * A correct leader must relinquish leadership by the time the lease it last set
+ * would expire (ttlMs since the last successful renewal), regardless of why
+ * renewal stopped succeeding. This PoC hangs every renewal and asserts the node
+ * has demoted itself by the lease deadline. It FAILS before the fix (stuck
+ * "leader") and passes after.
+ */
+
+const KEY = "keeper:leader:devnet";
+type SetOpts = { ex: number; nx?: true } | { ex: number; xx?: true };
+
+describe("LeaderLock hung-renewal lease expiry (PoC)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("demotes by the lease deadline when Redis renewal hangs", async () => {
+    const store = new Map<string, string>();
+    const redis: RedisLike = {
+      async set(key: string, value: string, opts: SetOpts): Promise<"OK" | null> {
+        const hasNx = "nx" in opts && opts.nx === true;
+        if (hasNx && store.has(key)) return null;
+        store.set(key, value);
+        return "OK";
+      },
+      async get(key: string): Promise<string | null> {
+        return store.get(key) ?? null;
+      },
+      async del(...keys: string[]): Promise<number> {
+        let n = 0;
+        for (const k of keys) if (store.delete(k)) n++;
+        return n;
+      },
+      // Renewal hangs forever — Redis partitioned/unresponsive mid-request, the
+      // fetch neither resolves nor rejects.
+      eval<T>(): Promise<T> {
+        return new Promise<T>(() => {});
+      },
+    };
+
+    const lock = new LeaderLock(redis, "node-a", {
+      ttlMs: 30_000,
+      renewMs: 10_000,
+      pollMs: 5_000,
+    });
+    const onDemote = vi.fn();
+    lock.start({ network: "devnet", onPromote: vi.fn(), onDemote });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(lock.role()).toBe("leader");
+    expect(store.has(KEY)).toBe(true);
+
+    // Renewal fires at 10s and hangs. By the 30s lease deadline the node must
+    // relinquish leadership — otherwise a standby that acquires the expired lock
+    // and this node both act (split-brain). Advance just past the deadline.
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    expect(lock.role()).toBe("standby");
+    expect(onDemote).toHaveBeenCalled();
+
+    await lock.stop();
+  });
+});

--- a/tests/lib/leader-timing-validation.test.ts
+++ b/tests/lib/leader-timing-validation.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression tests for #377 — invalid HA lease timings create a deterministic
+ * split-brain leader window.
+ *
+ * LeaderLock accepted any timing values. With renewMs >= ttlMs the Redis lease
+ * expires before the leader attempts renewal, so a standby acquires the freed
+ * key and promotes itself while the original node still reports
+ * role() === "leader". keeperSend gates on-chain writes on that local role
+ * alone, so both nodes submit transactions in the interval.
+ *
+ * The first test is the issue's proof-of-concept, inverted: it drives the exact
+ * timing that produced two concurrent leaders and asserts the lock now refuses
+ * to be constructed at all, so the unsafe state is unreachable.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { LeaderLock, LeaderLockTimingError } from "../../src/lib/leader.js";
+import type { RedisLike } from "../../src/lib/redis-client.js";
+
+vi.mock("@percolatorct/shared", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+/** Redis-compatible in-memory lease WITH expiry semantics (the PoC's harness). */
+function makeExpiringRedis(): RedisLike {
+  let value: string | null = null;
+  let expiresAt = 0;
+  const live = () => {
+    if (value !== null && Date.now() >= expiresAt) value = null;
+    return value;
+  };
+  return {
+    async set(_key: string, next: string, opts: { ex: number; nx?: true }) {
+      if ("nx" in opts && opts.nx === true && live() !== null) return null;
+      value = next;
+      expiresAt = Date.now() + opts.ex * 1000;
+      return "OK" as const;
+    },
+    async get() {
+      return live();
+    },
+    async del() {
+      value = null;
+      return 1;
+    },
+    async eval<T>(_script: string, _keys: string[], args: (string | number)[]): Promise<T> {
+      if (live() !== args[0]) return 0 as T;
+      expiresAt = Date.now() + Number(args[1]);
+      return 1 as T;
+    },
+  };
+}
+
+const VALID = { ttlMs: 30_000, renewMs: 10_000, pollMs: 5_000 };
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("#377 LeaderLock lease-timing validation", () => {
+  it("refuses the exact configuration from the issue PoC (renewMs > ttlMs)", async () => {
+    vi.useFakeTimers();
+    const redis = makeExpiringRedis();
+    const bad = { ttlMs: 1_000, renewMs: 5_000, pollMs: 100 };
+
+    // Previously both nodes could be constructed and started, and after the
+    // 1s lease lapsed BOTH reported "leader". Construction now fails first.
+    expect(() => new LeaderLock(redis, "node-a", bad)).toThrow(LeaderLockTimingError);
+    expect(() => new LeaderLock(redis, "node-b", bad)).toThrow(/split-brain/);
+  });
+
+  it("still elects exactly one leader under a valid configuration", async () => {
+    vi.useFakeTimers();
+    const redis = makeExpiringRedis();
+    const a = new LeaderLock(redis, "node-a", VALID);
+    const b = new LeaderLock(redis, "node-b", VALID);
+    const noop = { network: "devnet", onPromote() {}, onDemote() {} };
+
+    a.start(noop);
+    b.start(noop);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(a.role()).toBe("leader");
+    expect(b.role()).toBe("standby");
+
+    // Past the point where the bad config split-brained, and past a renewal.
+    await vi.advanceTimersByTimeAsync(11_000);
+    expect(a.role()).toBe("leader");
+    expect(b.role()).toBe("standby");
+
+    await a.stop();
+    await b.stop();
+  });
+
+  it("rejects renewMs exactly equal to ttlMs (the boundary)", () => {
+    const redis = makeExpiringRedis();
+    expect(() => new LeaderLock(redis, "n", { ...VALID, ttlMs: 10_000, renewMs: 10_000 })).toThrow(
+      LeaderLockTimingError,
+    );
+  });
+
+  it("accepts renewMs just below ttlMs", () => {
+    const redis = makeExpiringRedis();
+    expect(() => new LeaderLock(redis, "n", { ttlMs: 10_000, renewMs: 9_999, pollMs: 1_000 })).not.toThrow();
+  });
+
+  // index.ts builds these with Number(process.env.X ?? default), so any
+  // malformed env value arrives here as NaN rather than being rejected upstream.
+  it.each([
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+    ["zero", 0],
+    ["negative", -1],
+  ])("rejects %s for each timing field", (_label, bad) => {
+    const redis = makeExpiringRedis();
+    expect(() => new LeaderLock(redis, "n", { ...VALID, ttlMs: bad })).toThrow(LeaderLockTimingError);
+    expect(() => new LeaderLock(redis, "n", { ...VALID, renewMs: bad })).toThrow(LeaderLockTimingError);
+    expect(() => new LeaderLock(redis, "n", { ...VALID, pollMs: bad })).toThrow(LeaderLockTimingError);
+  });
+
+  it("names the offending field so an operator can fix the right env var", () => {
+    const redis = makeExpiringRedis();
+    expect(() => new LeaderLock(redis, "n", { ...VALID, pollMs: NaN })).toThrow(/pollMs/);
+    expect(() => new LeaderLock(redis, "n", { ...VALID, ttlMs: NaN })).toThrow(/ttlMs/);
+  });
+
+  it("still applies its defaults when no options are supplied", () => {
+    const redis = makeExpiringRedis();
+    expect(() => new LeaderLock(redis, "n")).not.toThrow();
+    expect(() => new LeaderLock(redis, "n", {})).not.toThrow();
+  });
+
+  it("accepts a thin renew margin but does not silently endorse it", () => {
+    const redis = makeExpiringRedis();
+    // 0.6 * ttl — legal (renew < ttl) but leaves little room for a slow
+    // round-trip, so it is warned about rather than rejected.
+    expect(() => new LeaderLock(redis, "n", { ttlMs: 10_000, renewMs: 6_000, pollMs: 1_000 })).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #398.

## Problem

`LeaderLock._renew()` awaited `redis.eval(RENEW_SCRIPT, ...)` with no timeout, and the Upstash client is constructed with no request signal. Demotion was purely event-driven — only when the eval **threw** (2-strike counter) or **returned** a lease-lost result. A hung or partitioned Redis whose request neither resolves nor rejects produced neither, so `_renew` stalled forever, no new renew timer was scheduled, and `_role` stayed `"leader"` indefinitely while the lock TTL lapsed and a standby acquired it — split-brain double-send against a permissionless program.

## Fix

Keeper-side, in `leader.ts`:

1. **Lease-expiry watchdog** — armed for `ttlMs` on promotion and re-armed on every successful renewal. If it fires while still leader, demote (`"lease-expired"`). This guarantees a node relinquishes leadership by the deadline of the lease it last set, regardless of why renewal stopped succeeding — the hard split-brain guarantee behind the existing 2-strike counter.
2. **Bounded renew eval** — `Promise.race` against `renewTimeoutMs` (default `min(renewMs, 5s)`), surfaced as a thrown error onto the existing strike/demote path, so a hung request can no longer stall the loop.
3. **Post-await role re-check** — after the eval and in the catch, bail if a concurrent `stop()`/watchdog demotion already moved us out of leader, so a late-resolving eval cannot re-arm timers on a non-leader.

## Testing

- New PoC `tests/lib/leader-hung-renew.poc.test.ts` hangs every renewal and asserts the node has demoted by the lease deadline (fails before: stuck `"leader"` at 31s; passes after).
- All existing leader/C2 tests unchanged and green (`leader.test.ts`, `leader-demote-recovery.poc.test.ts`, `keeper-send-leader-gate.test.ts`, `c2.poc.test.ts`); full suite `1033 passed`; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable renewal timeouts and lease monitoring for leader locks.
  * Added optional persistence and restoration of keeper budget halt states.
  * Updated LP crank operations to support dual-domain backing ledgers and lazy ledger creation.

* **Bug Fixes**
  * Prevented stalled or delayed renewals from incorrectly restoring leadership.
  * Mainnet startup now requires the approved transaction sender configuration.

* **Documentation**
  * Documented recommended lease timing requirements and safety margins.

* **Tests**
  * Added coverage for renewal hangs, lease validation, halt persistence, and startup safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->