### PR TITLE
fix(keeper): match custom program error 0x4 exactly, not as a substring (closes #401)

### DIFF
--- a/src/lib/program-error.ts
+++ b/src/lib/program-error.ts
@@ -1,0 +1,15 @@
+/**
+ * Match a Solana custom program error code exactly.
+ *
+ * Solana formats a custom program error as unpadded lowercase hex:
+ * "custom program error: 0x4" for code 4, "0x40" for 64, "0x4c" for 76, "0x400"
+ * for 1024, etc. A substring check for "custom program error: 0x4" therefore
+ * also matches 0x40–0x4f and 0x400+, misreading a transient engine error in
+ * those ranges as code 4. Anchoring the code with a trailing word boundary
+ * (\b, since all hex digits are word characters) means only the exact code
+ * matches — "0x4" hits, "0x40"/"0x4c"/"0x400" do not.
+ */
+export function isCustomProgramError(errMsg: string, code: number): boolean {
+  const hex = code.toString(16);
+  return new RegExp(`custom program error: 0x${hex}\\b`).test(errMsg);
+}

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -25,6 +25,7 @@ import {
 import { config, getConnection, getFallbackConnection, loadKeypair, eventBus, createLogger, sendCriticalAlert, getSupabase } from "@percolatorct/shared";
 import { OracleService } from "./oracle.js";
 import { resolveExternalOracleAccount } from "../lib/oracle-account.js";
+import { isCustomProgramError } from "../lib/program-error.js";
 import { recordAttempt, recordLanded, recordFailed } from "../lib/sender-metrics.js";
 import {
   txSentTotal,
@@ -1626,9 +1627,11 @@ export class CrankService {
         });
       }
 
-      // Detect NotInitialized (error 0x4) — permanently skip these markets
-      // PERC-381: Track skip count and timestamp for exponential cooldown on rediscovery
-      if (errMsg.includes("custom program error: 0x4")) {
+      // Detect InvalidSlabLen (error 0x4) — permanently skip these markets.
+      // PERC-381: Track skip count and timestamp for exponential cooldown on rediscovery.
+      // Exact-code match: a substring check would also catch 0x40–0x4f / 0x400+
+      // and permanently skip a healthy market on an unrelated engine error.
+      if (isCustomProgramError(errMsg, 0x4)) {
         state.permanentlySkipped = true;
         state.permanentlySkippedAt = Date.now();
         state.skipCount = (state.skipCount ?? 0) + 1;

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -512,7 +512,9 @@ async function provisionKeeperPortfolio(
   } catch (provisionErr) {
     const errMsg = provisionErr instanceof Error ? provisionErr.message : String(provisionErr);
     // AlreadyInitialized: a concurrent provision beat us; re-query for the existing portfolio.
-    if (errMsg.includes("AlreadyInitialized") || errMsg.includes("custom program error: 0x0")) {
+    // Exact-code match on 0x0 — a substring check also caught 0x00–0x0f (codes 1–15),
+    // misrouting an unrelated failure into this re-query path.
+    if (errMsg.includes("AlreadyInitialized") || isCustomProgramError(errMsg, 0x0)) {
       logger.info("provisionKeeperPortfolio: AlreadyInitialized — re-querying for existing portfolio", {
         market: marketKeyBase58.slice(0, 8),
       });

--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -19,6 +19,7 @@ import {
 import { config, getConnection, loadKeypair, sendWithRetry, pollSignatureStatus, getRecentPriorityFees, checkTransactionSize, eventBus, createLogger, sendWarningAlert, sendCriticalAlert, acquireToken, getFallbackConnection, backoffMs, getErrorMessage } from "@percolatorct/shared";
 import { OracleService } from "./oracle.js";
 import { resolveExternalOracleAccount } from "../lib/oracle-account.js";
+import { isCustomProgramError } from "../lib/program-error.js";
 import { recordAttempt, recordLanded, recordFailed } from "../lib/sender-metrics.js";
 import {
   txSentTotal,
@@ -1383,8 +1384,10 @@ export class LiquidationService {
 
       // PERC-484: InvalidSlabLen (0x4) means the slab has wrong size for the program.
       // These are test/corrupt markets that will never succeed — permanently skip them
-      // so the liquidation service stops retrying every 60 seconds.
-      if (errMsg.includes("custom program error: 0x4")) {
+      // so the liquidation service stops retrying every 60 seconds. Exact-code match:
+      // a substring check would also catch 0x40–0x4f / 0x400+ and permanently drop a
+      // healthy market from liquidation on an unrelated engine error.
+      if (isCustomProgramError(errMsg, 0x4)) {
         this.permanentlySkipped.add(slabAddress.toBase58());
         logger.warn(
           "Market slab size mismatch (0x4 InvalidSlabLen) — permanently skipping for liquidation. " +

--- a/tests/lib/program-error.poc.test.ts
+++ b/tests/lib/program-error.poc.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { isCustomProgramError } from "../../src/lib/program-error.js";
+
+/**
+ * PoC — the permanent-skip guards in crank.ts and liquidation.ts used
+ * `errMsg.includes("custom program error: 0x4")`, which also matches 0x40–0x4f
+ * and 0x400+. A transient engine error numbered in those ranges was misread as
+ * InvalidSlabLen (code 4) and the healthy market was permanently skipped from
+ * cranking / liquidation. The "does NOT match higher codes" case below fails
+ * against the old substring check and passes against the exact helper.
+ */
+describe("isCustomProgramError — exact custom-error-code matching", () => {
+  it("matches the exact code 0x4", () => {
+    expect(isCustomProgramError("custom program error: 0x4", 4)).toBe(true);
+    expect(
+      isCustomProgramError(
+        "Transaction simulation failed: Error processing Instruction 0: custom program error: 0x4",
+        4,
+      ),
+    ).toBe(true);
+    expect(isCustomProgramError("custom program error: 0x4 (InvalidSlabLen)", 4)).toBe(true);
+  });
+
+  it("does NOT match higher codes that share the 0x4 prefix", () => {
+    for (const higher of ["0x40", "0x41", "0x4c", "0x4f", "0x400", "0x4a2"]) {
+      expect(isCustomProgramError(`custom program error: ${higher}`, 4)).toBe(false);
+    }
+  });
+
+  it("documents the defect this replaces: the old substring check misfired", () => {
+    // The removed check classified code 0x40 (64) as code 4 ...
+    expect("custom program error: 0x40".includes("custom program error: 0x4")).toBe(true);
+    // ... whereas the helper correctly rejects it.
+    expect(isCustomProgramError("custom program error: 0x40", 4)).toBe(false);
+  });
+
+  it("works for multi-digit / hex-letter codes too", () => {
+    expect(isCustomProgramError("custom program error: 0x33", 0x33)).toBe(true);
+    expect(isCustomProgramError("custom program error: 0x330", 0x33)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #401.

## Problem

The permanent-skip guards in `crank.ts` and `liquidation.ts` classified a failure as InvalidSlabLen (custom program error code 4) with `errMsg.includes("custom program error: 0x4")`. Solana formats custom errors as unpadded lowercase hex, so that substring also matches `0x40`–`0x4f` (codes 64–79) and `0x400+`. A transient engine error in those ranges was misread as code 4 and the healthy market was **permanently removed** from cranking / liquidation until keeper restart (the crank path additionally escalates the skip cooldown toward 24h on repeats).

## Fix

Extract one tested helper and route both guards through it:

```ts
// src/lib/program-error.ts
export function isCustomProgramError(errMsg: string, code: number): boolean {
  const hex = code.toString(16);
  return new RegExp(`custom program error: 0x${hex}\\b`).test(errMsg);
}
```

`crank.ts` and `liquidation.ts` now call `isCustomProgramError(errMsg, 0x4)`. The trailing `\b` (all hex digits are word characters) means `0x4` matches but `0x40` / `0x4c` / `0x400` do not. This also removes the duplicated inline check.

## Testing

- New `tests/lib/program-error.poc.test.ts` pins exact-code matching and documents the old misfire (fails against the substring check, passes against the helper).
- The pinned exact-`0x4` permanent-skip behavior in `crank.test.ts` / `liquidation.test.ts` is preserved and green; full suite `1036 passed`; `tsc --noEmit` clean.

## Related (not in this change)

`crank.ts` uses the same substring shape for a `0x33` InsufficientDexLiquidity **log line** (code 51). Same collision class (`0x330+`) but log-only, no skip-state impact — a tidy follow-up would route it through the same helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of program errors during automated market maintenance.
  - Prevented unrelated error codes from being mistaken for known errors.
  - Reduced the risk of markets being incorrectly skipped during crank and liquidation operations.

- **Tests**
  - Added coverage for exact error-code matching, embedded messages, named errors, and multi-digit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->