### PR TITLE
docs(env): clarify USE_HELIUS_SENDER is mainnet-only (companion to percolator-shared#30)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,10 +48,13 @@ KEEPER_HEALTH_PORT=8081
 # Helius Sender (Phase 1 performance upgrade)
 # Default: USE_HELIUS_SENDER=true on mainnet (NETWORK=mainnet). Set false to opt out.
 # Requires RPC_URL to be a Helius mainnet endpoint with an api-key query param.
-# When true, sendWithRetryKeeper routes via https://sender.helius-rpc.com/fast
-# with skipPreflight + Jito tip + program-specific priority fee estimate.
-# On mainnet (NETWORK=mainnet), USE_HELIUS_SENDER should always be true for
-# competitive landing rates — devnet uses standard RPC regardless of this flag.
+# When true AND NETWORK=mainnet, sendWithRetryKeeper routes via
+# https://sender.helius-rpc.com/fast with skipPreflight + Jito tip + program-
+# specific priority fee estimate. The Sender is mainnet-only infrastructure, so
+# the keeper IGNORES this flag on every other network (enforced in
+# sendWithRetryKeeper) — a devnet/testnet keeper always uses standard RPC, and
+# leaving this true here is harmless off mainnet.
+# On mainnet, USE_HELIUS_SENDER should always be true for competitive landing.
 USE_HELIUS_SENDER=true
 # HELIUS_PRIORITY_LEVEL=High       # Min | Low | Medium | High | VeryHigh
 # JITO_TIP_LAMPORTS=200000         # 0.0002 SOL minimum for dual-routing


### PR DESCRIPTION
Companion to dcccrypto/percolator-shared#30 (issue) / dcccrypto/percolator-shared#31 (fix).

## Problem

`.env.example` shipped `USE_HELIUS_SENDER=true` with the comment "devnet uses standard RPC regardless of this flag." That was **false**: the shared `sendWithRetryKeeper` took the Helius Sender fast path on the flag alone, so a devnet keeper POSTed devnet-blockhash transactions to the mainnet Sender and never landed anything.

## Change

percolator-shared#31 network-gates the Sender path (`USE_HELIUS_SENDER === "true" && isMainnet(...)`), so the flag is now genuinely ignored off mainnet. This updates `.env.example` to state that enforcement explicitly — the Sender is mainnet-only, the keeper ignores the flag on every other network, and leaving it true here is harmless off mainnet. Docs only.

## Follow-up (not in this PR)

`keeper-send.ts` still adds the Jito tip to the budget *estimate* (`estimateCost`, and the realized-cost reconciliation) on the bare `USE_HELIUS_SENDER` flag rather than `isMainnetSender()`, so off mainnet it over-reserves by the tip (fail-safe — over-estimate only). Small fix, but it sits in `estimateCost`, which #397 already edits; I'll fold it in there or as a follow-up to avoid a conflicting change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
