### PR TITLE
fix(test): add createServiceMonitors to the oracle-quote-token shared mock

### DIFF
--- a/tests/services/oracle-quote-token.test.ts
+++ b/tests/services/oracle-quote-token.test.ts
@@ -50,6 +50,25 @@ vi.mock("@percolatorct/shared", () => ({
   getErrorMessage: (err: unknown) => String(err),
   sendWarningAlert: hoisted.sendWarningAlert,
   sendCriticalAlert: hoisted.sendCriticalAlert,
+  // #369: src/lib/service-monitors.ts calls this at import time, and oracle.ts
+  // imports it — so every test file that mocks this module must supply it or
+  // the suite fails at collection. Intermittent without this: it only throws
+  // when this file is the first in its worker to load service-monitors.ts.
+  createServiceMonitors: vi.fn(() => {
+    const m = () => ({
+      recordSuccess: vi.fn(async () => {}),
+      recordFailure: vi.fn(async () => {}),
+      getErrorRate: vi.fn(() => 0),
+      getStatus: vi.fn(() => ({
+        healthy: true,
+        consecutiveFailures: 0,
+        errorRate: 0,
+        timeSinceSuccessMs: 0,
+        alertActive: false,
+      })),
+    });
+    return { rpc: m(), scan: m(), oracle: m(), db: m() };
+  }),
 }));
 
 import { OracleService } from "../../src/services/oracle.js";


### PR DESCRIPTION
#369 and #382 are each green on their own and break `main` together.

#369 made `src/services/oracle.ts` import `src/lib/service-monitors.ts`, which calls `createServiceMonitors()` at module load, and patched the eight test files that mocked `@percolatorct/shared` at the time. #382 added a ninth — `tests/services/oracle-quote-token.test.ts` — after that sweep, so its mock is missing the export.

```
Error: [vitest] No "createServiceMonitors" export is defined on the "@percolatorct/shared" mock.
  ❯ src/lib/service-monitors.ts:11   export const monitors = createServiceMonitors("Keeper");
  ❯ src/services/oracle.ts:8
```

The failure is **intermittent**, which is why it is worth the explanatory comment: it only throws when this file happens to be the first in its vitest worker to load `service-monitors.ts`. Otherwise the module is already cached from a file whose mock does supply the export. Observed in 2 of 5 full runs before this fix, 0 of 3 after.

Verified on the merged `main`: `pnpm build` clean, and three consecutive full runs at **102 files / 1078 passed / 33 skipped** (the 6 previously-uncollected tests are back).

Worth noting as a standing hazard: any *future* test file that mocks `@percolatorct/shared` and transitively imports `oracle.ts` or `crank.ts` needs this same entry, and will fail only intermittently without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D