### PR TITLE
fix(deps): override ws to ^8.21.0 (re-cut of #371 against current main)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   vite: 8.0.8
   '@opentelemetry/core': '>=2.8.0'
+  ws: ^8.21.0
 
 importers:
 
@@ -1067,7 +1068,7 @@ packages:
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
     peerDependencies:
-      ws: '*'
+      ws: ^8.21.0
 
   jayson@4.3.0:
     resolution: {integrity: sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==}
@@ -1451,20 +1452,8 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1890,7 +1879,7 @@ snapshots:
       bs58: 6.0.0
       dotenv: 16.6.1
       tweetnacl: 1.0.3
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - bufferutil
@@ -2206,7 +2195,7 @@ snapshots:
       '@supabase/phoenix': 0.4.0
       '@types/ws': 8.18.1
       tslib: 2.8.1
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -2539,9 +2528,9 @@ snapshots:
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
-  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isomorphic-ws@4.0.1(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -2552,11 +2541,11 @@ snapshots:
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isomorphic-ws: 4.0.1(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
       uuid: 8.3.2
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -2746,7 +2735,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.4
       uuid: 11.1.0
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
@@ -2872,12 +2861,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-
-  ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,10 @@ overrides:
   # an unauthenticated request path. Pulled in at 2.6.0 and 2.6.1 by different
   # Sentry sub-dependencies, hence an override rather than a direct bump.
   "@opentelemetry/core": ">=2.8.0"
+  # GHSA-3h5v-q93c-6h6q (CVE-2024-37890) / GHSA-5v72-xg48-5rpm (#372-adjacent):
+  # ws < 8.17.1 allocates one object per HTTP header, so a request carrying many
+  # headers exhausts memory. The keeper reaches ws two ways: @supabase/realtime-js
+  # and helius-laserstream both pull ws@8.20.0, and @solana/web3.js pulls ws@7.5.10
+  # transitively through jayson/isomorphic-ws. An override is required rather than
+  # a direct bump because the keeper has no direct ws dependency of its own.
+  ws: ^8.21.0


### PR DESCRIPTION
Re-cut of #371. That PR's lockfile predates the SDK re-pin to `886aa6b` and #386's `@opentelemetry/core` override, so it conflicts on both `pnpm-lock.yaml` and `pnpm-workspace.yaml` and cannot be rebased mechanically.

`ws < 8.17.1` allocates one object per HTTP header, so a request with many headers exhausts memory (CVE-2024-37890). The keeper reaches `ws` two ways:

- `@supabase/realtime-js` and `helius-laserstream` → `ws@8.20.0`
- `@solana/web3.js` → `jayson` → `isomorphic-ws` → `ws@7.5.10`

The keeper has no direct `ws` dependency, so an override is the only lever. After it the tree collapses to a single `ws@8.21.3`; the only remaining `ws@7` entries are `@types/ws@7.4.7`, which is types-only.

**Residual risk for a reviewer:** this bumps `jayson`'s `ws` from 7 to 8, a major version. Its runtime use through web3.js is the basic client surface (connect/send/close/on), the build is clean and the full suite passes — but nothing in the suite exercises the web3.js WebSocket RPC path, so that route is untested here rather than proven.

Verified: `pnpm install --frozen-lockfile` clean, `tsc` clean, **102 files / 1078 passed / 33 skipped**.

Closes #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D