### PR TITLE
fix(liquidation): bound the portfolio scan response to prevent a silent blackout (closes #408)

### DIFF
--- a/src/services/liquidation.ts
+++ b/src/services/liquidation.ts
@@ -272,10 +272,19 @@ async function scanV17Portfolios(
   cursors: Map<string, number>,
 ): Promise<Array<{ portfolioPubkey: PublicKey; owner: string; assetIndex: number; closeQ: bigint; deficit: bigint }>> {
   const marketKey = market.slabAddress.toBase58();
+  // #334-followup: fetch only the matching portfolio PUBKEYS here (dataSlice
+  // length 0). The full portfolio account is ~9.3 KB, so fetching every match's
+  // data up front lets an attacker who floods a market with portfolios push the
+  // getProgramAccounts response into the tens of MB — past RPC response limits —
+  // so the query fails, the catch returns [], and (previously logged at debug)
+  // liquidation scanning for that market goes dark SILENTLY. Fetching keys only
+  // bounds the response; full data for the capped window is fetched below via
+  // getMultipleAccountsInfo.
   let rawPortfolios: ReadonlyArray<{ pubkey: PublicKey; account: { data: Buffer | Uint8Array } }>;
   try {
     rawPortfolios = await withTimeout(
       connection.getProgramAccounts(programId, {
+        dataSlice: { offset: 0, length: 0 },
         filters: [
           { dataSize: V17_PORTFOLIO_ACCOUNT_LEN },
           {
@@ -290,7 +299,9 @@ async function scanV17Portfolios(
       `scanV17Portfolios:getProgramAccounts(${marketKey.slice(0, 8)})`,
     );
   } catch (err) {
-    logger.debug("scanV17Portfolios: getProgramAccounts failed", {
+    // Visible, not debug: a persistent failure here silently disables
+    // liquidation for this market, which is exactly the case ops must see.
+    logger.warn("scanV17Portfolios: portfolio key scan failed — liquidation scanning DEGRADED for this market this cycle", {
       market: marketKey.slice(0, 8),
       error: err instanceof Error ? err.message : String(err),
     });
@@ -340,6 +351,37 @@ async function scanV17Portfolios(
     // Market shrank back under the cap — reset the cursor so we don't carry a
     // stale offset that would skip the front of a now-small set.
     cursors.delete(marketKey);
+  }
+
+  // Hydrate the capped window: the getProgramAccounts above fetched pubkeys only
+  // (to bound the response under a flood), so fetch full account data for just
+  // the ≤MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE window via getMultipleAccountsInfo,
+  // chunked at the 100-pubkey RPC limit. This is bounded work regardless of how
+  // many portfolios the market has.
+  try {
+    const GMA_CHUNK = 100;
+    const winKeys = window.map((w) => w.pubkey);
+    const hydrated: RawPortfolio[] = [];
+    for (let i = 0; i < winKeys.length; i += GMA_CHUNK) {
+      const chunk = winKeys.slice(i, i + GMA_CHUNK);
+      const infos = await withTimeout(
+        connection.getMultipleAccountsInfo(chunk),
+        RPC_TIMEOUT_MS,
+        `scanV17Portfolios:getMultipleAccountsInfo(${marketKey.slice(0, 8)})`,
+      );
+      for (let j = 0; j < chunk.length; j++) {
+        const info = infos[j];
+        // Skip accounts that vanished between the key scan and this fetch.
+        if (info?.data) hydrated.push({ pubkey: chunk[j]!, account: { data: info.data } });
+      }
+    }
+    window = hydrated;
+  } catch (err) {
+    logger.warn("scanV17Portfolios: portfolio hydration failed — liquidation scanning DEGRADED for this market this cycle", {
+      market: marketKey.slice(0, 8),
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
   }
 
   // #334: collect all qualifying candidates with their deficit so we can

--- a/tests/services/liquidation.test.ts
+++ b/tests/services/liquidation.test.ts
@@ -589,6 +589,7 @@ describe('LiquidationService', () => {
         vi.mocked(shared.getConnection).mockReturnValue({
           getAccountInfo: vi.fn(async () => null),
           getProgramAccounts: vi.fn(async () => [makeRawPortfolio('Mismatched')]),
+          getMultipleAccountsInfo: vi.fn(async (keys: any[]) => keys.map(() => ({ data: new Uint8Array(16) }))),
         } as any);
         vi.mocked(core.parseWrapperConfigV17).mockReturnValueOnce({
           oracleMode: 2, // EWMA_MARK
@@ -621,6 +622,7 @@ describe('LiquidationService', () => {
         vi.mocked(shared.getConnection).mockReturnValue({
           getAccountInfo: vi.fn(async () => null),
           getProgramAccounts: vi.fn(async () => [makeRawPortfolio('Matching')]),
+          getMultipleAccountsInfo: vi.fn(async (keys: any[]) => keys.map(() => ({ data: new Uint8Array(16) }))),
         } as any);
         vi.mocked(core.parseWrapperConfigV17).mockReturnValueOnce({
           oracleMode: 2, // EWMA_MARK
@@ -655,6 +657,7 @@ describe('LiquidationService', () => {
             makeRawPortfolio('Mismatched'),
             makeRawPortfolio('Matching'),
           ]),
+          getMultipleAccountsInfo: vi.fn(async (keys: any[]) => keys.map(() => ({ data: new Uint8Array(16) }))),
         } as any);
         vi.mocked(core.parseWrapperConfigV17).mockReturnValueOnce({
           oracleMode: 2, // EWMA_MARK
@@ -685,6 +688,50 @@ describe('LiquidationService', () => {
 
         expect(candidates).toHaveLength(1);
         expect(candidates[0].owner).toBe('OwnerMatching11111111111111111111111');
+      });
+
+      // PoC: a portfolio flood must not make the scan fetch full account data for
+      // every match. getProgramAccounts fetches PUBKEYS ONLY (dataSlice length 0),
+      // and full data is fetched for at most the per-cycle cap via chunked
+      // getMultipleAccountsInfo. Pre-fix (full-data getProgramAccounts, no cap on
+      // the fetch) there is no dataSlice and no getMultipleAccountsInfo call.
+      it('bounds the full-data fetch under a portfolio flood', async () => {
+        const MAX_PER_CYCLE = 512; // MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE
+        const FLOOD = 1000;
+        vi.mocked(core.isV17Account).mockReturnValueOnce(true);
+        vi.mocked(core.fetchSlab).mockResolvedValue(new Uint8Array(9_347));
+        const floodKeys = Array.from({ length: FLOOD }, (_, i) => makeRawPortfolio(`Flood${i}`));
+        const gpaSpy = vi.fn(async () => floodKeys);
+        const gmaSpy = vi.fn(async (keys: any[]) => keys.map(() => ({ data: new Uint8Array(16) })));
+        vi.mocked(shared.getConnection).mockReturnValue({
+          getAccountInfo: vi.fn(async () => null),
+          getProgramAccounts: gpaSpy,
+          getMultipleAccountsInfo: gmaSpy,
+        } as any);
+        vi.mocked(core.parseWrapperConfigV17).mockReturnValueOnce({
+          oracleMode: 2,
+          maxStalenessSecs: 60n,
+          oracleTargetPriceE6: 0n,
+          oracleTargetPublishTime: BigInt(Math.floor(Date.now() / 1000)) - 10n,
+          markEwmaE6: 1_000_000n,
+        } as any);
+        // Every parsed portfolio is healthy — we only assert on the fetch shape.
+        vi.mocked(core.parsePortfolioV17).mockReturnValue({
+          marketGroupId: mockMarket.slabAddress,
+          owner: mockNonZeroKey('Owner11111111111111111111111111111111'),
+          capital: 10_000_000_000n,
+          pnl: 0n,
+          feeCredits: 0n,
+          legs: [{ active: true, basisPosQ: 1n, assetIndex: 0 }],
+        } as any);
+
+        await liquidationService.scanMarket(mockMarket as any);
+
+        // Response bounded to pubkeys.
+        expect(gpaSpy.mock.calls[0]?.[1]?.dataSlice).toEqual({ offset: 0, length: 0 });
+        // Full data fetched for at most the per-cycle cap — NOT all 1000.
+        const totalHydrated = gmaSpy.mock.calls.reduce((s, c) => s + (c[0] as any[]).length, 0);
+        expect(totalHydrated).toBe(MAX_PER_CYCLE);
       });
     });
   });


### PR DESCRIPTION
Closes #408.

## Problem

`scanV17Portfolios` fetched full account data (~9.3 KB each) for **every** portfolio matching a market via one unpaginated `getProgramAccounts`, applying the #334 cap only to *parsing* — after the whole response was buffered client-side. A portfolio flood (rent only; trivial on devnet) pushes the response into the tens of MB, past RPC limits / the timeout, so the query throws. The catch returned `[]` and logged at **debug**, so liquidation scanning for that market went dark **silently** — genuinely underwater positions there are never liquidated.

## Fix

- **Bound the response:** `getProgramAccounts` now fetches pubkeys only (`dataSlice: { offset: 0, length: 0 }`), so the response size is independent of portfolio count.
- **Bound the data fetch:** the existing rotating cursor/cap runs on the pubkey list, then full data is hydrated for only the ≤`MAX_PORTFOLIOS_PER_MARKET_PER_CYCLE` window via chunked `getMultipleAccountsInfo` (100/call, the RPC limit).
- **Make it visible:** the scan-failure log is escalated from `debug` to `warn`, so a persistent blackout is surfaced to ops instead of being silent.

Downstream parsing / the M-9 market-group re-check / health evaluation are unchanged — they just read the hydrated window.

## Testing

- New PoC asserts that under a 1000-portfolio flood the scan fetches pubkeys-only and hydrates at most the 512 cap (fails before: no `dataSlice`, `getMultipleAccountsInfo` never called).
- The three existing v17-scan tests were given a `getMultipleAccountsInfo` companion mock (the fetch pattern changed); liquidation suite green (40 tests). Full suite green apart from a known machine-specific timeout flake in an unrelated file (passes in isolation); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved v17 portfolio scanning by reducing initial data retrieved from the network.
  * Limited account hydration to a rotating window of up to 512 accounts per scan cycle.
  * Added batched account retrieval to improve handling of large portfolios.

* **Bug Fixes**
  * Skips accounts that are no longer available during scanning.
  * Displays visible warnings when portfolio scanning or account loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->