### PR TITLE
fix(env-guards): stop echoing CRANK_KEYPAIR secret bytes in the boot error (closes #410)

### DIFF
--- a/src/env-guards.ts
+++ b/src/env-guards.ts
@@ -81,10 +81,15 @@ export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): v
   if (crankKp) {
     try {
       loadKeypair(crankKp);
-    } catch (err) {
+    } catch {
+      // Do NOT append the underlying parse error. For the JSON-array form,
+      // JSON.parse quotes an excerpt of the input — i.e. raw secret-key bytes —
+      // into its SyntaxError message, which would then land in stderr / Railway
+      // logs / Sentry. A truncated or typo'd keypair is exactly this case.
       throw new Error(
-        `CRANK_KEYPAIR is not a valid keypair (expected a 64-byte JSON array or ` +
-          `base58-encoded secret key): ${err instanceof Error ? err.message : String(err)}`,
+        "CRANK_KEYPAIR is not a valid keypair (expected a 64-byte JSON array " +
+          "from `solana-keygen new`, or a base58-encoded secret key). The " +
+          "underlying parse error is omitted because it can contain secret-key bytes.",
       );
     }
   }

--- a/tests/env-guards.test.ts
+++ b/tests/env-guards.test.ts
@@ -436,6 +436,23 @@ describe("validateKeeperEnvGuards", () => {
         /CRANK_KEYPAIR is not a valid keypair/,
       );
     });
+    it("M1: does not echo CRANK_KEYPAIR secret bytes into the boot error", () => {
+      // A malformed JSON secret-key array. JSON.parse throws a SyntaxError that
+      // quotes an excerpt of the input — real secret-key bytes — pre-fix. The
+      // boot error must not carry them into stderr / Railway logs / Sentry.
+      const env = { CRANK_KEYPAIR: "[201,163,88,7,x]" } as NodeJS.ProcessEnv;
+      let caught: Error | undefined;
+      try {
+        validateKeeperEnvGuards(env);
+      } catch (e) {
+        caught = e as Error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught!.message).toMatch(/CRANK_KEYPAIR is not a valid keypair/);
+      // The raw key bytes must not appear anywhere in the message.
+      expect(caught!.message).not.toContain("201,163,88");
+      expect(caught!.message).not.toContain("[201");
+    });
 
     it("M1: accepts a well-formed 64-byte JSON array keypair", () => {
       const env = { CRANK_KEYPAIR: VALID_KEYPAIR_JSON } as NodeJS.ProcessEnv;


### PR DESCRIPTION
Closes #410.

## Problem

The boot-time `CRANK_KEYPAIR` format check re-threw with the underlying parse error appended. For the JSON-array keypair form, `loadKeypair` calls `JSON.parse`, whose `SyntaxError` quotes an excerpt of the input — **raw secret-key bytes** — so a truncated or typo'd keypair leaked part of the private key into the boot error, and thus into stderr, Railway logs, and Sentry.

## Fix

Drop the appended parse error and throw a static, actionable message. The static `CRANK_KEYPAIR is not a valid keypair …` prefix that the existing M1 tests pin is preserved, so no pinned behavior changes.

## Testing

- New PoC asserts a malformed keypair (`[201,163,88,7,x]`) throws an error whose message does **not** contain the byte excerpt (fails before: the message carried `"[201,163,88,7,x]"` from the `SyntaxError`).
- `tests/env-guards.test.ts` green (77); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
