### PR TITLE
fix(health): mask the RPC api-key in /health failureReason (closes #412)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import http from "node:http";
 import { timingSafeEqual } from "node:crypto";
-import { config, createLogger, initSentry, captureException, sendInfoAlert, sendCriticalAlert, sendWarningAlert, getConnection, loadKeypair } from "@percolatorct/shared";
+import { config, createLogger, initSentry, captureException, sendInfoAlert, sendCriticalAlert, sendWarningAlert, getConnection, loadKeypair, maskApiKeys } from "@percolatorct/shared";
 import { monitors } from "./lib/service-monitors.js";
 import { OracleService } from "./services/oracle.js";
 import { CrankService } from "./services/crank.js";
@@ -765,7 +765,10 @@ async function start() {
       });
     }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    // Mask any embedded api-key: a node-fetch failure quotes the full RPC URL
+    // ("request to https://…?api-key=XXX failed"), and this msg flows to the log,
+    // the thrown error (→ Sentry via captureAndExit), and /health's failureReason.
+    const msg = maskApiKeys(err instanceof Error ? err.message : String(err));
     logger.error("Primary RPC unreachable at startup — check SOLANA_RPC_URL", { error: msg });
     throw new Error(`Primary RPC connectivity check failed: ${msg}`);
   }

--- a/src/lib/startup-tracker.ts
+++ b/src/lib/startup-tracker.ts
@@ -1,3 +1,5 @@
+import { maskApiKeys } from "@percolatorct/shared";
+
 /**
  * Tracks whether the asynchronous keeper boot (RPC connectivity probe,
  * market discovery, service start) has completed.
@@ -19,7 +21,11 @@ export class StartupTracker {
 
   markFailed(reason: string): void {
     this._state = "failed";
-    this._failureReason = reason;
+    // failureReason is served on /health (503 body), so mask any embedded
+    // api-key before storing it. A boot RPC failure surfaces as a node-fetch
+    // error quoting the full URL ("request to https://…?api-key=XXX failed"),
+    // which would otherwise leak the RPC key to any prober and to Sentry.
+    this._failureReason = maskApiKeys(reason);
   }
 
   get state(): StartupState {

--- a/tests/lib/startup-tracker.test.ts
+++ b/tests/lib/startup-tracker.test.ts
@@ -50,4 +50,16 @@ describe("StartupTracker", () => {
     t.markReady();
     expect(t.state).toBe("ready");
   });
+
+  it("masks an embedded api-key in the failure reason (served on /health)", () => {
+    const t = new StartupTracker();
+    // A boot RPC failure surfaces as a node-fetch error quoting the full URL.
+    t.markFailed(
+      "Primary RPC connectivity check failed: request to " +
+        "https://mainnet.helius-rpc.com/?api-key=SECRET123 failed, reason: ECONNREFUSED",
+    );
+    // failureReason is returned in the /health 503 body — it must not leak the key.
+    expect(t.failureReason).not.toContain("SECRET123");
+    expect(t.failureReason).toContain("api-key=***");
+  });
 });


### PR DESCRIPTION
Closes #412.

## Problem

When the boot-time primary-RPC connectivity probe fails, the node-fetch error quotes the full RPC URL including `?api-key=…`. That message was stored as `startupTracker.failureReason` and served verbatim in the `/health` 503 body (and sent to Sentry), so any prober during a boot RPC failure — or on each crash-loop restart — received the RPC api-key. The exposure is worse under the Railway remote-bind posture where `/health` is reachable without a secret.

## Fix

Reuse `maskApiKeys` from `@percolatorct/shared` (already in the installed dist — replaces `api[_-]?key=…` with `api-key=***`):
- `StartupTracker.markFailed` masks the reason before storing, so anything served as `failureReason` on `/health` is clean — for this and any future failure path.
- The RPC-probe catch in `index.ts` masks at the source, so the log line and the thrown error (→ Sentry via `captureAndExit`) are masked too.

No new code, no repin.

## Testing

- New PoC asserts `markFailed(<error with ?api-key=SECRET123>)` yields a `failureReason` that masks the key (`api-key=***`, no `SECRET123`) — fails before the fix.
- `tests/lib/startup-tracker.test.ts` green (7); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
