### PR TITLE
fix(slot-tracker): gate the drift alert on a live stream + add a cooldown (closes #414)

### DIFF
--- a/src/lib/slot-tracker.ts
+++ b/src/lib/slot-tracker.ts
@@ -4,17 +4,23 @@ const logger = createLogger("keeper:slot-tracker");
 
 const POLL_INTERVAL_MS = 10_000;
 const DEFAULT_DRIFT_ALERT_SLOTS = 50;
+const DEFAULT_DRIFT_ALERT_COOLDOWN_MS = 5 * 60_000;
 
 export class SlotTracker {
   private streamSlot = 0;
   private timer: ReturnType<typeof setInterval> | null = null;
+  private _lastDriftAlertMs = 0;
   private readonly driftAlertSlots: number;
+  private readonly driftAlertCooldownMs: number;
   private readonly onDriftAlert: ((drift: number) => void) | undefined;
 
   constructor(onDriftAlert?: (drift: number) => void) {
     this.driftAlertSlots =
       parseInt(process.env.KEEPER_STREAM_SLOT_DRIFT_ALERT ?? "", 10) ||
       DEFAULT_DRIFT_ALERT_SLOTS;
+    this.driftAlertCooldownMs =
+      parseInt(process.env.KEEPER_STREAM_DRIFT_ALERT_COOLDOWN_MS ?? "", 10) ||
+      DEFAULT_DRIFT_ALERT_COOLDOWN_MS;
     this.onDriftAlert = onDriftAlert;
   }
 
@@ -43,14 +49,24 @@ export class SlotTracker {
       try {
         const rpcSlot = await getRpcSlot();
         const drift = this.getDriftEstimate(rpcSlot);
-        if (drift > this.driftAlertSlots) {
-          logger.warn("Stream slot drift exceeds threshold", {
-            streamSlot: this.streamSlot,
-            rpcSlot,
-            drift,
-            threshold: this.driftAlertSlots,
-          });
-          this.onDriftAlert?.(drift);
+        // streamSlot === 0 means the stream has not delivered a slot yet (still
+        // connecting): drift = rpcSlot, a meaninglessly huge value that would
+        // otherwise fire on the very first poll and every 10s after. Only alert
+        // once the stream is live, and rate-limit to the cooldown so a sustained
+        // real lag does not spam Discord every poll (every other alert path in
+        // the keeper has a cooldown; this one did not).
+        if (this.streamSlot > 0 && drift > this.driftAlertSlots) {
+          const now = Date.now();
+          if (now - this._lastDriftAlertMs >= this.driftAlertCooldownMs) {
+            this._lastDriftAlertMs = now;
+            logger.warn("Stream slot drift exceeds threshold", {
+              streamSlot: this.streamSlot,
+              rpcSlot,
+              drift,
+              threshold: this.driftAlertSlots,
+            });
+            this.onDriftAlert?.(drift);
+          }
         }
       } catch (err) {
         logger.warn("SlotTracker: failed to poll RPC slot", {

--- a/tests/lib/slot-tracker.test.ts
+++ b/tests/lib/slot-tracker.test.ts
@@ -112,6 +112,35 @@ describe("SlotTracker", () => {
 
       expect(alertFn).toHaveBeenCalledWith(6);
     });
+
+    it("does not alert on boot before the stream has delivered a slot (streamSlot=0)", async () => {
+      vi.useFakeTimers();
+      const alertFn = vi.fn();
+      const t = new SlotTracker(alertFn);
+      // No onStreamSlot() — streamSlot stays 0, so drift = rpcSlot (huge), but the
+      // stream simply hasn't started yet; this must not fire an alert.
+      t.start(async () => 100_000);
+
+      await vi.advanceTimersByTimeAsync(30_100); // three polls
+      t.stop();
+      vi.useRealTimers();
+
+      expect(alertFn).not.toHaveBeenCalled();
+    });
+
+    it("rate-limits repeated drift alerts to the cooldown window", async () => {
+      vi.useFakeTimers();
+      const alertFn = vi.fn();
+      const t = new SlotTracker(alertFn);
+      t.onStreamSlot(10);
+      t.start(async () => 100); // sustained drift = 90 > 50 every poll
+
+      await vi.advanceTimersByTimeAsync(60_100); // six polls within the 5-min cooldown
+      t.stop();
+      vi.useRealTimers();
+
+      expect(alertFn).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("start / stop", () => {


### PR DESCRIPTION
Closes #414.

## Problem

`SlotTracker` fired the LaserStream slot-drift alert on every 10s poll with no cooldown, and — because `streamSlot` starts at 0 — fired immediately on boot before the stream had delivered a single slot (`drift = rpcSlot`, a meaninglessly huge value). Result: a Discord warning every 10s on boot and during any stream outage, which trains operators to ignore the channel and buries real alerts. Every other alert path in the keeper has a cooldown; this one did not.

## Fix

- Gate the alert on `streamSlot > 0` — no alerting until the stream is actually live.
- Rate-limit alerts to a cooldown (default 5 min; env `KEEPER_STREAM_DRIFT_ALERT_COOLDOWN_MS`).

## Testing

- New PoCs cover the boot false-positive (`streamSlot=0` → no alert) and the per-poll spam (sustained drift over six polls → one alert). Both fail before the fix.
- `tests/lib/slot-tracker.test.ts` green (15); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream drift alerts to avoid notifications before the first slot arrives.
  * Added cooldown-based rate limiting to prevent repeated drift alerts.

* **Configuration**
  * Added support for configuring the drift-alert cooldown, with a five-minute default.

* **Tests**
  * Added coverage for initial slot handling and repeated-alert suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->