### PR TITLE
fix(account-loader): stream program + additional accounts via separate filters (closes #416)

### DIFF
--- a/src/lib/account-loader.ts
+++ b/src/lib/account-loader.ts
@@ -65,6 +65,33 @@ export interface StreamAdapter {
   stop(): void;
 }
 
+type AccountsSubscription = Record<string, { account: string[]; owner: string[]; filters: [] }>;
+
+/**
+ * Build the Yellowstone `accounts` subscription filter.
+ *
+ * Yellowstone AND-combines the non-empty fields WITHIN one filter entry and
+ * OR-combines separate named entries. Program-owned accounts (matched by `owner`)
+ * and the caller's extra accounts (e.g. dex-pool accounts owned by OTHER programs,
+ * matched by `account`) must therefore live in SEPARATE entries. Putting both
+ * `account:[extras]` and `owner:[programId]` in one entry matches NOTHING — an
+ * extra account is not program-owned, and a program-owned slab is not in the
+ * extras list — which silently kills the entire account stream the moment
+ * additionalAccounts is set.
+ */
+export function buildAccountsSubscription(
+  programId: string,
+  additionalAccounts: string[],
+): AccountsSubscription {
+  const accounts: AccountsSubscription = {
+    "keeper-program": { account: [], owner: [programId], filters: [] },
+  };
+  if (additionalAccounts.length > 0) {
+    accounts["additional-accounts"] = { account: additionalAccounts, owner: [], filters: [] };
+  }
+  return accounts;
+}
+
 /**
  * Production adapter: wraps the helius-laserstream subscribe() function.
  * Lazy-imports the native module so this file can be loaded in test environments
@@ -85,13 +112,7 @@ export class LaserStreamAdapter implements StreamAdapter {
     const programId = opts.programId ?? MAINNET_PROGRAM_ID;
 
     const request = {
-      accounts: {
-        "keeper-program": {
-          account: opts.additionalAccounts ?? [],
-          owner: [programId],
-          filters: [],
-        },
-      },
+      accounts: buildAccountsSubscription(programId, opts.additionalAccounts ?? []),
       slots: {
         "keeper-slots": { filterByCommitment: true },
       },

--- a/tests/lib/account-loader-subscription.poc.test.ts
+++ b/tests/lib/account-loader-subscription.poc.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { buildAccountsSubscription } from "../../src/lib/account-loader.js";
+
+/**
+ * PoC — the LaserStream accounts subscription must not AND-away the program
+ * stream when KEEPER_LASERSTREAM_ADDITIONAL_ACCOUNTS is set.
+ *
+ * Yellowstone AND-combines the non-empty fields WITHIN one filter entry and
+ * OR-combines separate named entries. The old request put both `account:[extras]`
+ * and `owner:[programId]` in ONE entry, so a program-owned slab (not in the extras
+ * list) and an extra dex-pool account (not program-owned) each matched NOTHING —
+ * silently killing the entire account stream. Modeled below: against the old
+ * single-entry shape both assertions fail; with the separate-entry fix both pass.
+ */
+
+function entryMatches(
+  entry: { account: string[]; owner: string[] },
+  acct: { pubkey: string; owner: string },
+): boolean {
+  const byAccount = entry.account.length === 0 || entry.account.includes(acct.pubkey);
+  const byOwner = entry.owner.length === 0 || entry.owner.includes(acct.owner);
+  return byAccount && byOwner; // AND within an entry
+}
+function requestMatches(
+  filter: Record<string, { account: string[]; owner: string[] }>,
+  acct: { pubkey: string; owner: string },
+): boolean {
+  return Object.values(filter).some((e) => entryMatches(e, acct)); // OR across entries
+}
+
+const PROGRAM = "Prog1111111111111111111111111111111111111111";
+const DEX_PROGRAM = "Dex11111111111111111111111111111111111111111";
+const SLAB = "Slab1111111111111111111111111111111111111111"; // program-owned
+const DEX_POOL = "Pool1111111111111111111111111111111111111111"; // owned by DEX_PROGRAM
+
+describe("PoC: LaserStream accounts subscription", () => {
+  it("streams program-owned accounts by owner when no additionalAccounts", () => {
+    const f = buildAccountsSubscription(PROGRAM, []);
+    expect(requestMatches(f, { pubkey: SLAB, owner: PROGRAM })).toBe(true);
+  });
+
+  it("with additionalAccounts set, BOTH program slabs and the extra accounts still stream", () => {
+    const f = buildAccountsSubscription(PROGRAM, [DEX_POOL]);
+    // Program-owned slab (not in the extras list) must still stream — pre-fix it
+    // was AND'd against account:[DEX_POOL] and matched nothing.
+    expect(requestMatches(f, { pubkey: SLAB, owner: PROGRAM })).toBe(true);
+    // The extra dex-pool account (owned by another program) must also stream.
+    expect(requestMatches(f, { pubkey: DEX_POOL, owner: DEX_PROGRAM })).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #416.

## Problem

The LaserStream account subscription put the caller's extra accounts and the program-owner filter in one Yellowstone entry: `account:[additionalAccounts] AND owner:[programId]`. Yellowstone AND-combines the non-empty fields within a single entry, so the moment `KEEPER_LASERSTREAM_ADDITIONAL_ACCOUNTS` is set (documented for dex-pool accounts, which are owned by DEX programs), the filter matches **nothing** — a dex pool is not program-owned, and a program-owned slab is not in the extras list. Result: silent total loss of the event-driven crank/liquidation path. The stream stays `connected: true` with slots flowing, so no alert fires; account updates just stop until the 30-min full rediscover.

## Fix

Yellowstone OR-combines separate named entries, so emit them separately. Extracted into a testable `buildAccountsSubscription(programId, additionalAccounts)`:

```ts
const accounts = { "keeper-program": { account: [], owner: [programId], filters: [] } };
if (additionalAccounts.length > 0) {
  accounts["additional-accounts"] = { account: additionalAccounts, owner: [], filters: [] };
}
```

Program accounts match by `owner`; extras match by `account`; both stream. With `additionalAccounts` empty, the output is identical to before (owner-only).

## Testing

- New PoC models Yellowstone matching (AND within an entry, OR across entries) and asserts both a program slab and an extra dex-pool account stream — both fail against the old single-entry shape.
- Existing `account-loader.test.ts` green (30); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
