### PR TITLE
chore(deps): bump @percolatorct/shared to 57b1de8

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#886aa6b9eb96950c8e415df695cd3ae3614472d5",
-    "@percolatorct/shared": "github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f",
+    "@percolatorct/shared": "github:dcccrypto/percolator-shared#57b1de87c3c156e46f085612e3a73866934903bb",
     "@solana/web3.js": "^1.98.0",
     "@upstash/redis": "^1.38.0",
     "dotenv": "^16.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: github:dcccrypto/percolator-sdk#886aa6b9eb96950c8e415df695cd3ae3614472d5
         version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@percolatorct/shared':
-        specifier: github:dcccrypto/percolator-shared#052edb592023de7c097f46edf8fba9a1cb20423f
-        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        specifier: github:dcccrypto/percolator-shared#57b1de87c3c156e46f085612e3a73866934903bb
+        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/57b1de87c3c156e46f085612e3a73866934903bb(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -463,8 +463,8 @@ packages:
     version: 4.3.0
     engines: {node: '>=20.0.0'}
 
-  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f}
+  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/57b1de87c3c156e46f085612e3a73866934903bb':
+    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/57b1de87c3c156e46f085612e3a73866934903bb}
     version: 1.0.0-beta.8
     peerDependencies:
       '@percolatorct/sdk': '>=2.0.5'
@@ -1871,7 +1871,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/052edb592023de7c097f46edf8fba9a1cb20423f(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/57b1de87c3c156e46f085612e3a73866934903bb(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@percolatorct/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@sentry/node': 10.46.0


### PR DESCRIPTION
Picks up three fixes in the keeper's send path. Two open keeper PRs depend on this.

| shared PR | what it fixes |
|---|---|
| **#29** | Retries re-signed with a fresh blockhash → a **second distinct signature** the chain could also land. A liquidation could execute twice and pay twice while being booked once against the budget. |
| **#31** | Helius Sender is mainnet-only infrastructure. A devnet keeper with the shipped `USE_HELIUS_SENDER=true` was POSTing devnet transactions to it, where nothing lands. |
| **#32** | Forwards the caller's `priorityFeeMicroLamports` into the Sender path and caps `getHeliusPriorityFee`. **Unblocks #397** — without it that PR is inert on mainnet. |

Also drops shared's orphaned `dist/v17Layout.js`, which had drifted to `WRAPPER_CONFIG_LEN=432` / `V17_EXPECTED_VERSION=16`, two generations stale. The keeper never imported it (it uses the SDK's constants via `src/lib/v17-layout.ts`), so that is hazard removal, not a behaviour change.

### Operator-visible behaviour change

#29 means a send whose blockhash expires mid-retry now **fails** instead of re-signing. Under 429 backoff (up to 30s per attempt) three attempts can outlive the ~60s blockhash validity window, so expect more "send failed, caller re-issues" and fewer silent duplicates. That is the intended trade — failing is recoverable, double-liquidating is not.

### Verified
- Linked build confirmed to contain all four changes (checked `node_modules/@percolatorct/shared/dist`, not the store glob — there are now two store entries and the stale one is still on disk).
- `tsc` clean.
- Full suite **106 files / 1129 passed / 33 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal shared component dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->