### PR TITLE
fix(crank): treat a silently stalled stream as stale cache, not fresh (#426 5.2)

### DIFF
--- a/src/lib/account-loader.ts
+++ b/src/lib/account-loader.ts
@@ -23,6 +23,21 @@ export type UnsubscribeFn = () => void;
 export interface LoaderStats {
   connected: boolean;
   lastSlot: number;
+  /**
+   * `Date.now()` when `lastSlot` last moved FORWARD, or 0 if it never has.
+   *
+   * #426 (5.2): consumers use `lastSlot` as the yardstick for cache freshness,
+   * which is only meaningful while the stream is actually delivering. A silent
+   * stall — gRPC connection up, no messages — freezes `lastSlot`, and because
+   * cached entries' slots freeze with it, a slot-age TTL can never expire. The
+   * cache would serve frozen bytes as fresh indefinitely. `onStreamError` does
+   * not help: it fires on an error event, and a silent stall raises none.
+   *
+   * Exposing the wall-clock stamp lets a consumer notice that slot-based
+   * freshness has stopped meaning anything, without this class having to guess
+   * what "too stale" is for any particular caller.
+   */
+  lastSlotAdvanceAt: number;
   eventsReceived: number;
   eventsDropped: number;
   reconnectCount: number;
@@ -193,6 +208,8 @@ export class AccountLoader {
   private running = false;
   private connected = false;
   private lastSlot = 0;
+  /** See LoaderStats.lastSlotAdvanceAt (#426). */
+  private lastSlotAdvanceAt = 0;
   private eventsReceived = 0;
   private eventsDropped = 0;
   private reconnectCount = 0;
@@ -264,6 +281,7 @@ export class AccountLoader {
     return {
       connected: this.connected,
       lastSlot: this.lastSlot,
+      lastSlotAdvanceAt: this.lastSlotAdvanceAt,
       eventsReceived: this.eventsReceived,
       eventsDropped: this.eventsDropped,
       reconnectCount: this.reconnectCount,
@@ -291,6 +309,15 @@ export class AccountLoader {
         this.opts,
         (update) => this.enqueue(update),
         (slot) => {
+          // Stamp only on FORWARD movement: a stream stuck re-announcing the
+          // same slot is not making progress and must not look healthy (#426).
+          //
+          // `lastSlot` itself is still assigned unconditionally. It must stay
+          // able to move BACKWARD — the cache's reorg invalidation (A.2,
+          // account-cache.ts: `currentSlot < entry.slot` is a miss) depends on
+          // exactly that. Clamping it forward here would silently disable that
+          // check, trading one staleness bug for a worse one.
+          if (slot > this.lastSlot) this.lastSlotAdvanceAt = Date.now();
           this.lastSlot = slot;
           this.slotTracker.onStreamSlot(slot);
         },

--- a/src/lib/stream-staleness.ts
+++ b/src/lib/stream-staleness.ts
@@ -1,0 +1,54 @@
+import type { LoaderStats } from "./account-loader.js";
+
+/**
+ * #426 (5.2): wall-clock staleness floor for the LaserStream account stream.
+ *
+ * The account cache expires entries by SLOT age, measured against the stream's
+ * own `lastSlot`. That is a sound freshness signal only while the stream is
+ * delivering. If the gRPC connection stays up but stops producing — a silent
+ * stall — `lastSlot` freezes, the slots stamped on cached entries freeze with
+ * it, and `currentSlot - entry.slot` stops growing. The TTL can then never
+ * expire, and the cache serves frozen bytes as fresh for as long as the stall
+ * lasts.
+ *
+ * `AccountLoader.onStreamError -> cache.invalidateAll()` does not cover this,
+ * because a silent stall raises no error event. The gap is specifically the
+ * case where nothing goes wrong loudly.
+ *
+ * The floor is wall-clock rather than slot-based on purpose: slot time is the
+ * quantity that has stopped being trustworthy, so it cannot be used to measure
+ * its own staleness.
+ */
+
+/**
+ * 30s. Mainnet slots are ~400ms, so this is ~75 slots of silence — far outside
+ * normal jitter, and comfortably above the 32-slot (~13s) cache TTL it guards,
+ * while still an order of magnitude below the 30-minute full re-discover that
+ * would eventually correct the state anyway.
+ */
+export const DEFAULT_STREAM_STALL_MS = 30_000;
+
+/** Env override, `KEEPER_STREAM_STALL_MS`. Non-numeric or <= 0 falls back. */
+export function streamStallThresholdMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = parseInt(env.KEEPER_STREAM_STALL_MS ?? "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_STREAM_STALL_MS;
+}
+
+/**
+ * True when the stream's slot has not moved forward within the threshold, and
+ * its cache-freshness signal should therefore not be trusted.
+ *
+ * A loader that has never seen a slot (`lastSlotAdvanceAt === 0`) counts as
+ * stalled. That covers boot before the first slot arrives, where the cache is
+ * empty in any case, so the conservative answer costs nothing.
+ */
+export function isStreamStalled(
+  stats: Pick<LoaderStats, "lastSlotAdvanceAt">,
+  now: number = Date.now(),
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!stats.lastSlotAdvanceAt) return true;
+  return now - stats.lastSlotAdvanceAt > streamStallThresholdMs(env);
+}

--- a/src/services/crank.ts
+++ b/src/services/crank.ts
@@ -38,6 +38,7 @@ import {
 } from "../lib/metrics.js";
 import type { AccountLoader } from "../lib/account-loader.js";
 import { monitors } from "../lib/service-monitors.js";
+import { isStreamStalled, streamStallThresholdMs } from "../lib/stream-staleness.js";
 import { keeperSend, sharedBudget } from "../lib/keeper-send.js";
 import { sharedTxQueue } from "../lib/tx-queue.js";
 import { parseV17RiskParams, V17_RISK_PARAMS_MIN_DATA_LEN } from "../lib/v17-risk.js";
@@ -1015,6 +1016,33 @@ export class CrankService {
         const cache = this._accountLoader.getCache();
         const stats = this._accountLoader.getStats();
         const currentSlot = stats.lastSlot;
+        // #426 (5.2): the cache TTL is measured in SLOTS, against the stream's
+        // own `lastSlot`. That is only a freshness signal while the stream is
+        // delivering. If the gRPC connection stays up but stops producing (a
+        // silent stall) `lastSlot` freezes, cached entries' slots freeze with
+        // it, `currentSlot - entry.slot` stops growing, and the TTL can never
+        // expire — frozen bytes are served as fresh indefinitely.
+        // `onStreamError -> invalidateAll()` does not cover this: a silent
+        // stall raises no error event.
+        //
+        // So gate the fast path on wall-clock progress as well. A stalled
+        // stream simply skips the cache refresh; each market keeps the state it
+        // already had until the next full re-discover, which reads fresh RPC.
+        // That is the same outcome as a cache miss, which this loop already
+        // handles — no new failure mode, just no false freshness.
+        const streamStalled = isStreamStalled(stats);
+        if (streamStalled) {
+          logger.warn(
+            "LaserStream slot has not advanced — skipping the cache fast path",
+            {
+              lastSlot: stats.lastSlot,
+              stalledForMs: stats.lastSlotAdvanceAt
+                ? Date.now() - stats.lastSlotAdvanceAt
+                : null,
+              thresholdMs: streamStallThresholdMs(),
+            },
+          );
+        }
         // A.1: owner-verify every cache read against the loader's program ID
         // so a corrupted stream message at a slab pubkey can't inject bytes
         // into market state via the SDK parsers.
@@ -1022,7 +1050,9 @@ export class CrankService {
         let cacheHits = 0;
         for (const [, state] of this.markets) {
           const key = state.market.slabAddress.toBase58();
-          const entry = cache.getOwnerVerified(key, currentSlot, expectedOwner);
+          const entry = streamStalled
+            ? null
+            : cache.getOwnerVerified(key, currentSlot, expectedOwner);
           if (entry) {
             // Re-parse the slab from cached bytes so the market state reflects
             // the latest on-chain data without an RPC call.

--- a/tests/lib/account-loader.test.ts
+++ b/tests/lib/account-loader.test.ts
@@ -644,3 +644,55 @@ describe("AccountLoader — H-5: connect()/stop() race", () => {
     expect(l.getStats().reconnectCount).toBe(0);
   });
 });
+
+/**
+ * #426 (5.2): the loader must expose when its slot last moved FORWARD, so a
+ * consumer can tell a live stream from a silently stalled one — and it must do
+ * so without clamping `lastSlot`, which has to stay able to move backward for
+ * the cache's reorg invalidation (A.2) to work.
+ */
+describe("#426: lastSlotAdvanceAt", () => {
+  it("stamps on a forward slot, and leaves lastSlot free to move backward", async () => {
+    // Fake timers are load-bearing here, not decoration. Without them all three
+    // pushes land in the same millisecond, so the stamps compare equal whether
+    // or not the forward-only guard exists — the assertions below would pass
+    // against a mutation that stamps on every slot. Verified by running that
+    // mutation: it only fails once time actually advances between pushes.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1_800_000_000_000));
+
+    const a = new FakeAdapter();
+    const l = new AccountLoader(BASE_OPTS, a);
+
+    expect(l.getStats().lastSlotAdvanceAt).toBe(0);
+
+    await l.start();
+    a.pushSlot(100);
+    const first = l.getStats();
+    expect(first.lastSlot).toBe(100);
+    expect(first.lastSlotAdvanceAt).toBeGreaterThan(0);
+
+    // A repeated slot is not progress — the stamp must not move, or a stream
+    // stuck re-announcing one slot would look healthy forever.
+    vi.advanceTimersByTime(5_000);
+    a.pushSlot(100);
+    expect(l.getStats().lastSlotAdvanceAt).toBe(first.lastSlotAdvanceAt);
+
+    // A BACKWARD slot must still land in lastSlot, because the cache's reorg
+    // invalidation (A.2) keys off `currentSlot < entry.slot`. Clamping it
+    // forward here would trade this staleness bug for a worse one.
+    vi.advanceTimersByTime(5_000);
+    a.pushSlot(90);
+    const after = l.getStats();
+    expect(after.lastSlot).toBe(90);
+    expect(after.lastSlotAdvanceAt).toBe(first.lastSlotAdvanceAt);
+
+    // And a genuine forward move does stamp again.
+    vi.advanceTimersByTime(5_000);
+    a.pushSlot(101);
+    expect(l.getStats().lastSlotAdvanceAt).toBeGreaterThan(first.lastSlotAdvanceAt);
+
+    await l.stop();
+    vi.useRealTimers();
+  });
+});

--- a/tests/lib/stream-staleness.test.ts
+++ b/tests/lib/stream-staleness.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_STREAM_STALL_MS,
+  isStreamStalled,
+  streamStallThresholdMs,
+} from "../../src/lib/stream-staleness.js";
+
+/**
+ * #426 (5.2). The account cache expires entries by SLOT age against the
+ * stream's own `lastSlot`. When the gRPC connection stays up but stops
+ * delivering, `lastSlot` freezes, the slots on cached entries freeze with it,
+ * and `currentSlot - entry.slot` stops growing — so the TTL can never expire
+ * and frozen bytes are served as fresh. `onStreamError -> invalidateAll()`
+ * misses this case entirely, because a silent stall raises no error.
+ */
+
+describe("isStreamStalled", () => {
+  const NOW = 1_800_000_000_000;
+
+  it("is not stalled while the slot advanced within the threshold", () => {
+    expect(
+      isStreamStalled({ lastSlotAdvanceAt: NOW - (DEFAULT_STREAM_STALL_MS - 1) }, NOW, {}),
+    ).toBe(false);
+  });
+
+  it("is stalled once the threshold is exceeded", () => {
+    expect(
+      isStreamStalled({ lastSlotAdvanceAt: NOW - (DEFAULT_STREAM_STALL_MS + 1) }, NOW, {}),
+    ).toBe(true);
+  });
+
+  it("treats exactly-at-the-threshold as still live", () => {
+    // Boundary pinned deliberately: `>` not `>=`, so a stream that advanced
+    // exactly on the threshold is not punished for arriving on time.
+    expect(
+      isStreamStalled({ lastSlotAdvanceAt: NOW - DEFAULT_STREAM_STALL_MS }, NOW, {}),
+    ).toBe(false);
+  });
+
+  it("treats a loader that has never advanced as stalled", () => {
+    // Boot, before the first slot. The cache is empty then, so the
+    // conservative answer costs nothing.
+    expect(isStreamStalled({ lastSlotAdvanceAt: 0 }, NOW, {})).toBe(true);
+  });
+
+  it("honours KEEPER_STREAM_STALL_MS", () => {
+    const env = { KEEPER_STREAM_STALL_MS: "1000" } as NodeJS.ProcessEnv;
+    expect(isStreamStalled({ lastSlotAdvanceAt: NOW - 1_500 }, NOW, env)).toBe(true);
+    expect(isStreamStalled({ lastSlotAdvanceAt: NOW - 500 }, NOW, env)).toBe(false);
+  });
+});
+
+describe("streamStallThresholdMs", () => {
+  it("defaults when unset", () => {
+    expect(streamStallThresholdMs({})).toBe(DEFAULT_STREAM_STALL_MS);
+  });
+
+  it("rejects non-numeric, zero and negative overrides rather than disabling the guard", () => {
+    // A guard that silently switches off on a typo'd env var is worse than no
+    // guard, because the dashboard still says it is configured.
+    for (const raw of ["abc", "", "0", "-1"]) {
+      expect(
+        streamStallThresholdMs({ KEEPER_STREAM_STALL_MS: raw } as NodeJS.ProcessEnv),
+      ).toBe(DEFAULT_STREAM_STALL_MS);
+    }
+  });
+
+  it("accepts a positive override", () => {
+    expect(
+      streamStallThresholdMs({ KEEPER_STREAM_STALL_MS: "5000" } as NodeJS.ProcessEnv),
+    ).toBe(5_000);
+  });
+
+  it("keeps the default above the cache TTL it guards", () => {
+    // The cache TTL is 32 slots (~13s at ~400ms). A stall floor below that
+    // would fire during normal operation; one far above it would let the TTL
+    // stay unexpirable for longer than it is meant to hold anything.
+    expect(DEFAULT_STREAM_STALL_MS).toBeGreaterThan(32 * 400);
+    expect(DEFAULT_STREAM_STALL_MS).toBeLessThan(30 * 60 * 1_000);
+  });
+});

--- a/tests/services/crank.test.ts
+++ b/tests/services/crank.test.ts
@@ -298,7 +298,7 @@ describe('CrankService', () => {
 
         const mockAccountLoader = {
           getCache: vi.fn(() => mockCache),
-          getStats: vi.fn(() => ({ lastSlot: 123 })),
+          getStats: vi.fn(() => ({ lastSlot: 123, lastSlotAdvanceAt: Date.now() })),
           getProgramId: vi.fn(() => new PublicKey('11111111111111111111111111111111')),
         };
 
@@ -1728,6 +1728,11 @@ describe('CrankService', () => {
         getStats: () => ({
           connected: true,
           lastSlot: 110,
+          // #426: the fast path is gated on the stream having advanced
+          // recently, so a live stream must say so. Previously this was
+          // implicit — a frozen stream was indistinguishable from a healthy
+          // one here, which is the bug that gating closes.
+          lastSlotAdvanceAt: Date.now(),
           eventsReceived: 0,
           eventsDropped: 0,
           reconnectCount: 0,
@@ -1769,6 +1774,58 @@ describe('CrankService', () => {
       service.stop();
     });
 
+    it('#426: does NOT read the cache when the stream slot has stalled', async () => {
+      // A silent stall freezes `lastSlot`, which freezes the slot-age TTL with
+      // it — the cache would keep serving frozen bytes as fresh forever, and
+      // `onStreamError -> invalidateAll()` never fires because no error occurs.
+      // The fast path must therefore not consult the cache at all here.
+      const { AccountCache } = await import('../../src/lib/account-cache.js');
+      const realCache = new AccountCache();
+      realCache.set(GOOD_SLAB, new Uint8Array([1]), EXPECTED_PROGRAM_ID, 100);
+
+      const getOwnerVerifiedSpy = vi.spyOn(realCache, 'getOwnerVerified');
+
+      const fakeLoader = {
+        getCache: () => realCache,
+        getProgramId: () => EXPECTED_PROGRAM_ID,
+        getStats: () => ({
+          connected: true,
+          // Slot is well within the 32-slot TTL of the cached entry, so a
+          // slot-only freshness check would happily serve it. Only the
+          // wall-clock stamp reveals that the stream stopped moving.
+          lastSlot: 110,
+          lastSlotAdvanceAt: Date.now() - 120_000,
+          eventsReceived: 0,
+          eventsDropped: 0,
+          reconnectCount: 0,
+        }),
+      } as any;
+
+      const service = new CrankService(mockOracleService, undefined, fakeLoader);
+
+      const mkMarket = (slab: string) => ({
+        slabAddress: { toBase58: () => slab, equals: () => false },
+        programId: { toBase58: () => EXPECTED_PROGRAM_ID },
+        config: {
+          collateralMint: { toBase58: () => 'Mint' + slab.slice(0, 4) },
+          oracleAuthority: { toBase58: () => 'Auth' + slab.slice(0, 4), equals: () => false },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'Admin' + slab.slice(0, 4) } },
+      });
+      const internal: any = service;
+      internal.markets.set(GOOD_SLAB, { market: mkMarket(GOOD_SLAB), missedDiscoveryCount: 0 });
+      internal._lastFullRediscoverTime = Date.now();
+
+      await service.discover();
+
+      expect(getOwnerVerifiedSpy).not.toHaveBeenCalled();
+      expect(realCache.stats().hits).toBe(0);
+
+      service.stop();
+    });
+
     it('re-parses cached v17 account data with the v17 parser, not legacy slab parsers', async () => {
       const { AccountCache } = await import('../../src/lib/account-cache.js');
       const realCache = new AccountCache();
@@ -1781,6 +1838,11 @@ describe('CrankService', () => {
         getStats: () => ({
           connected: true,
           lastSlot: 110,
+          // #426: the fast path is gated on the stream having advanced
+          // recently, so a live stream must say so. Previously this was
+          // implicit — a frozen stream was indistinguishable from a healthy
+          // one here, which is the bug that gating closes.
+          lastSlotAdvanceAt: Date.now(),
           eventsReceived: 0,
           eventsDropped: 0,
           reconnectCount: 0,
@@ -1871,6 +1933,11 @@ describe('CrankService', () => {
         getStats: () => ({
           connected: true,
           lastSlot: 110,
+          // #426: the fast path is gated on the stream having advanced
+          // recently, so a live stream must say so. Previously this was
+          // implicit — a frozen stream was indistinguishable from a healthy
+          // one here, which is the bug that gating closes.
+          lastSlotAdvanceAt: Date.now(),
           eventsReceived: 0,
           eventsDropped: 0,
           reconnectCount: 0,


### PR DESCRIPTION
Implements §5.2 of #426. Leaving §5.1 (priority-fee ceiling / tier-aware fallback) alone for now — see the note at the bottom.

## The gap

The account cache expires entries by **slot** age, measured against the stream's own `lastSlot`. That is a sound freshness signal only while the stream is delivering.

If the gRPC connection stays up but stops producing — a silent stall — `lastSlot` freezes. The slots stamped on cached entries freeze with it, so `currentSlot - entry.slot` stops growing and the TTL **can never expire**. `getOwnerVerified()` keeps returning frozen bytes as fresh for as long as the stall lasts.

`onStreamError -> cache.invalidateAll()` doesn't help: it fires on an error event, and a silent stall raises none. The gap is exactly the case where nothing goes wrong loudly.

Verified against `052b0c5` before writing anything — `crank.ts:1016-1017` takes `currentSlot` from `getStats().lastSlot`, and `invalidateAll()` appears only inside `onStreamError` (`account-loader.ts:379/388`).

## The fix

`AccountLoader` records `lastSlotAdvanceAt` — wall-clock time its slot last moved **forward** — and exposes it on `LoaderStats`. The crank discover fast path skips cache reads entirely while that stamp is older than `KEEPER_STREAM_STALL_MS` (default **30s**: ~75 slots, far outside normal jitter, comfortably above the 32-slot/~13s TTL it guards, far below the 30-minute full re-discover).

A stalled stream then behaves exactly like a cache miss, which the loop already handles — each market keeps the state it had until the next full re-discover, which reads fresh RPC. No new failure mode, just no false freshness.

The floor is wall-clock rather than slot-based deliberately: slot time is the quantity that has stopped being trustworthy, so it can't measure its own staleness.

## One thing worth a reviewer's eye

**`lastSlot` is still assigned unconditionally, and there's a test pinning that.**

My first draft clamped it to forward-only movement. That reads as harmless tidying and is not: the cache's reorg invalidation (**A.2** — `currentSlot < entry.slot` is a miss, `account-cache.ts:58-62`) *depends* on `lastSlot` being able to move **backward**. Clamping it would have silently disabled that check, trading this staleness bug for a worse one.

Only the *stamp* is gated on forward movement — a stream stuck re-announcing one slot must not look healthy. There is now a test that fails on the clamp, so the next person tempted by the same tidy-up gets told.

## Scope

Per the audit, and re-confirmed: only the crank **discover fast path** reads this cache. The 30-minute re-discover uses fresh RPC, the crank *submit* re-reads `getSlot("processed")`, and **the liquidation path never touches this cache** — so there was no wrong-or-missed-liquidation consequence, and there is none introduced here. This is defence-in-depth, rated Low in the audit, and I agree with that rating.

## Existing tests changed

Three A.1 fast-path tests now set `lastSlotAdvanceAt` in their mocked stats. That is the point rather than an inconvenience: a live stream now has to *say* it is live, where previously a frozen stream was indistinguishable from a healthy one at that call site.

## Mutation-tested

| mutation | result |
|---|---|
| control | all pass |
| stamp on every slot (not just forward) | **FAIL** `account-loader` |
| clamp `lastSlot` forward (breaks A.2 reorg) | **FAIL** `account-loader` |
| `isStreamStalled` always false | **FAIL** `stream-staleness` |
| loose env parse (`0`/negative disables the guard) | **FAIL** `stream-staleness` |
| crank reads cache despite the stall | **FAIL** `crank` |
| control | all pass |

The `account-loader` test needs **fake timers** to bind, and says so in a comment. Without them all three `pushSlot` calls land in the same millisecond, the stamps compare equal, and the assertions pass against the stamp-always mutation. I only found that by running the mutation — the test looked fine.

## Verification

```
pnpm test                       108 files, 1143 passed, 33 skipped
pnpm exec tsc --noEmit          exit 0
pnpm build                      exit 0
pnpm audit --audit-level=high   exit 0
```

## On §5.1

Not touched here. Its suggested hardening — "make the fallback tier-aware (liquidation / ADL should fall back higher than crank / oracle)" — means choosing fee values per lane, which is an operator economics call rather than a code detail, and the audit itself notes the budget gate already prevents overspend so the residual is availability-only. Happy to implement once someone says what the per-lane fallbacks should be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Detects stalled data streams when slot updates stop advancing.
  * Prevents indefinitely serving cached account data during silent stream interruptions.
  * Automatically falls back to full data refresh to obtain current information.
  * Supports configurable stall detection thresholds, with safe defaults for invalid settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->