### PR TITLE
chore(deps): repin @percolatorct/sdk to reconciled main (828b43e)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#886aa6b9eb96950c8e415df695cd3ae3614472d5",
+    "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#828b43e4ac51914210d2594c25f2206a29b377db",
     "@percolatorct/shared": "github:dcccrypto/percolator-shared#57b1de87c3c156e46f085612e3a73866934903bb",
     "@solana/web3.js": "^1.98.0",
     "@upstash/redis": "^1.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
   .:
     dependencies:
       '@percolatorct/sdk':
-        specifier: github:dcccrypto/percolator-sdk#886aa6b9eb96950c8e415df695cd3ae3614472d5
-        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        specifier: github:dcccrypto/percolator-sdk#828b43e4ac51914210d2594c25f2206a29b377db
+        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/828b43e4ac51914210d2594c25f2206a29b377db(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@percolatorct/shared':
         specifier: github:dcccrypto/percolator-shared#57b1de87c3c156e46f085612e3a73866934903bb
-        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/57b1de87c3c156e46f085612e3a73866934903bb(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/57b1de87c3c156e46f085612e3a73866934903bb(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/828b43e4ac51914210d2594c25f2206a29b377db(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -458,8 +458,8 @@ packages:
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
-  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5}
+  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/828b43e4ac51914210d2594c25f2206a29b377db':
+    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/828b43e4ac51914210d2594c25f2206a29b377db}
     version: 4.3.0
     engines: {node: '>=20.0.0'}
 
@@ -1860,7 +1860,7 @@ snapshots:
 
   '@oxc-project/types@0.133.0': {}
 
-  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/828b43e4ac51914210d2594c25f2206a29b377db(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1871,9 +1871,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/57b1de87c3c156e46f085612e3a73866934903bb(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/57b1de87c3c156e46f085612e3a73866934903bb(@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/828b43e4ac51914210d2594c25f2206a29b377db(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@percolatorct/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/886aa6b9eb96950c8e415df695cd3ae3614472d5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@percolatorct/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/828b43e4ac51914210d2594c25f2206a29b377db(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@sentry/node': 10.46.0
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@supabase/supabase-js': 2.100.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)


### PR DESCRIPTION
Repins the keeper to the reconciled SDK `main` (`828b43e`) after the fork reconciliation.

The keeper was pinned to `#886aa6b9`, which **lacked** the CRITICAL PROGRAM_ID allowlist (#309), NFT allowlist (#317), the v12 shim bankruptcy-recovery fix (#322), encoder input/length validation, the ADL forged-log guard, and the oracle-tolerance tightening. The reconciled `main` = the same feature base + all those fixes.

## Verified
- `tsc` clean; `vitest run` → **1102 pass / 0 fail** against the new SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Percolator SDK dependency to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->